### PR TITLE
Make right pane resizable + full CRUD for the People list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ qt_add_qml_module(todocpp
         qml/PeopleList.qml
         qml/TaskEditor.qml
         qml/EventEditor.qml
+        qml/PersonEditor.qml
         qml/TweaksPanel.qml
         qml/Toast.qml
         qml/PillButton.qml

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Window
 import QtQuick.Layouts
+import QtQuick.Controls
 import QtQuick.Controls.Basic
 import TodoCpp
 
@@ -121,18 +122,44 @@ ApplicationWindow {
                 anchors.fill: parent
                 spacing: 0
                 MiniWeek { Layout.fillWidth: true }
-                DayCalendar {
+                SplitView {
+                    id: rightSplit
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    onEventClicked: (id) => eventEditor.showForId(id)
+                    orientation: Qt.Vertical
+
+                    handle: Rectangle {
+                        implicitHeight: 6
+                        color: SplitHandle.pressed ? Theme.accent
+                             : SplitHandle.hovered ? Theme.borderStrong
+                             : Theme.border
+                        Rectangle {
+                            anchors.centerIn: parent
+                            width: 32; height: 2; radius: 1
+                            color: SplitHandle.hovered ? Theme.text : Theme.textDim
+                            opacity: 0.6
+                        }
+                    }
+
+                    DayCalendar {
+                        SplitView.fillHeight: true
+                        SplitView.minimumHeight: 120
+                        onEventClicked: (id) => eventEditor.showForId(id)
+                    }
+                    PeopleList {
+                        SplitView.preferredHeight: 220
+                        SplitView.minimumHeight: 64
+                        onPersonRequested: (id) => personEditor.showFor(AppController.personById(id))
+                        onNewPersonRequested: personEditor.showFor(AppController.newPersonDraft())
+                    }
                 }
-                PeopleList { Layout.fillWidth: true }
             }
         }
     }
 
-    TaskEditor  { id: taskEditor }
-    EventEditor { id: eventEditor }
+    TaskEditor   { id: taskEditor }
+    EventEditor  { id: eventEditor }
+    PersonEditor { id: personEditor }
 
     // Floating tweaks panel
     TweaksPanel {

--- a/qml/PeopleList.qml
+++ b/qml/PeopleList.qml
@@ -6,7 +6,9 @@ import TodoCpp
 Rectangle {
     id: root
     color: Theme.panel2
-    implicitHeight: Math.min(220, col.implicitHeight + 24)
+
+    signal personRequested(string id)
+    signal newPersonRequested()
 
     Rectangle {
         anchors.left: parent.left; anchors.right: parent.right; anchors.top: parent.top
@@ -20,6 +22,7 @@ Rectangle {
         spacing: 8
 
         RowLayout {
+            Layout.fillWidth: true
             spacing: 6
             Text {
                 text: "КОМУ НАПИСАТЬ"
@@ -43,10 +46,32 @@ Rectangle {
                 }
                 Connections {
                     target: AppController.people
-                    function onDataChanged() { badge.text = AppController.pendingPeopleCount() + " pending · " + AppController.people.rowCount() }
+                    function onDataChanged()    { badge.text = AppController.pendingPeopleCount() + " pending · " + AppController.people.rowCount() }
+                    function onRowsInserted()   { badge.text = AppController.pendingPeopleCount() + " pending · " + AppController.people.rowCount() }
+                    function onRowsRemoved()    { badge.text = AppController.pendingPeopleCount() + " pending · " + AppController.people.rowCount() }
                 }
             }
             Item { Layout.fillWidth: true }
+            Rectangle {
+                width: 22; height: 22; radius: 5
+                color: addMA.containsMouse ? Theme.panel3 : "transparent"
+                Text {
+                    anchors.centerIn: parent
+                    text: "+"
+                    color: addMA.containsMouse ? Theme.text : Theme.textDim
+                    font.pixelSize: 14
+                }
+                MouseArea {
+                    id: addMA
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root.newPersonRequested()
+                    ToolTip.visible: containsMouse
+                    ToolTip.delay: 400
+                    ToolTip.text: "Добавить контакт"
+                }
+            }
         }
 
         ListView {
@@ -55,6 +80,7 @@ Rectangle {
             clip: true
             spacing: 6
             model: AppController.people
+            boundsBehavior: Flickable.StopAtBounds
 
             delegate: Rectangle {
                 id: prow
@@ -67,8 +93,8 @@ Rectangle {
                 width: ListView.view.width
                 height: layout.implicitHeight + 12
                 radius: 7
-                color: stateMA.containsMouse ? Theme.panel : "transparent"
-                border.color: stateMA.containsMouse ? Theme.border : "transparent"
+                color: rowMA.containsMouse ? Theme.panel : "transparent"
+                border.color: rowMA.containsMouse ? Theme.border : "transparent"
                 border.width: 1
 
                 RowLayout {
@@ -99,7 +125,7 @@ Rectangle {
                         spacing: 1
                         Text {
                             width: parent.width
-                            text: prow.name + "  · " + prow.role
+                            text: prow.name + (prow.role.length ? "  · " + prow.role : "")
                             color: (prow.state === "todo") ? Theme.text : Theme.textMuted
                             font.pixelSize: 12
                             font.weight: Font.Medium
@@ -117,6 +143,31 @@ Rectangle {
                             opacity: prow.state === "replied" ? 0.6 : 1.0
                         }
                     }
+
+                    // Edit pencil (only on hover)
+                    Rectangle {
+                        visible: rowMA.containsMouse
+                        width: 22; height: 22; radius: 5
+                        color: editMA.containsMouse ? Theme.panel3 : "transparent"
+                        Text {
+                            anchors.centerIn: parent
+                            text: "✎"
+                            color: Theme.textMuted
+                            font.pixelSize: 12
+                        }
+                        MouseArea {
+                            id: editMA
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: root.personRequested(prow.id)
+                            ToolTip.visible: containsMouse
+                            ToolTip.delay: 400
+                            ToolTip.text: "Редактировать"
+                        }
+                    }
+
+                    // Clickable state badge — cycles
                     Rectangle {
                         radius: 999
                         color: prow.state === "pinged" ? Theme.withAlpha(Theme.p1, 0.10)
@@ -127,7 +178,7 @@ Rectangle {
                                     : Theme.border
                         border.width: 1
                         implicitWidth: stT.implicitWidth + 14
-                        implicitHeight: 20
+                        implicitHeight: 22
                         Text {
                             id: stT
                             anchors.centerIn: parent
@@ -140,16 +191,30 @@ Rectangle {
                             font.family: Theme.fontMono
                             font.pixelSize: 10
                             font.letterSpacing: 1
+                            font.weight: Font.DemiBold
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: AppController.cyclePerson(prow.id)
+                            ToolTip.visible: containsMouse
+                            ToolTip.delay: 400
+                            ToolTip.text: "написать → написал → ответил"
                         }
                     }
                 }
 
                 MouseArea {
-                    id: stateMA
+                    id: rowMA
                     anchors.fill: parent
                     hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: AppController.cyclePerson(prow.id)
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton
+                    onDoubleClicked: root.personRequested(prow.id)
+                    onClicked: (mouse) => {
+                        if (mouse.button === Qt.RightButton) root.personRequested(prow.id);
+                    }
+                    z: -1
                 }
             }
         }

--- a/qml/PersonEditor.qml
+++ b/qml/PersonEditor.qml
@@ -1,0 +1,171 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import TodoCpp
+
+Popup {
+    id: root
+    modal: true
+    focus: true
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+    padding: 0
+    width: 460
+    anchors.centerIn: Overlay.overlay
+
+    property var draft: ({})
+    property bool isNew: false
+
+    readonly property var palette: [
+        "#d97a6c", "#c87fc7", "#6cc4b8", "#7da8d9",
+        "#dcc06a", "#7cc492", "#e69854", "#a4a4d6"
+    ]
+    readonly property var states: ["todo", "pinged", "replied"]
+    readonly property var stateLabels: ({ todo: "написать", pinged: "написал", replied: "ответил" })
+
+    function showFor(initialDraft) {
+        draft = initialDraft || {};
+        isNew = !!draft._isNew;
+        nameField.text     = draft.name || "";
+        roleField.text     = draft.role || "";
+        questionField.text = draft.question || "";
+        stateBox.currentIndex = Math.max(0, states.indexOf(draft.state || "todo"));
+        const cur = String(draft.color || palette[0]).toLowerCase();
+        let i = 0;
+        for (let k = 0; k < palette.length; k++)
+            if (palette[k].toLowerCase() === cur) { i = k; break; }
+        colorSwatch.selectedIndex = i;
+        open();
+    }
+
+    background: Rectangle {
+        radius: 12
+        color: Theme.panel
+        border.color: Theme.borderStrong
+        border.width: 1
+    }
+
+    contentItem: ColumnLayout {
+        spacing: 12
+        Item { Layout.preferredHeight: 4 }
+
+        Text {
+            Layout.leftMargin: 18; Layout.rightMargin: 18
+            text: root.isNew ? "Новый контакт" : "Редактировать контакт"
+            color: Theme.text
+            font.pixelSize: 14
+            font.weight: Font.DemiBold
+        }
+
+        Text { Layout.leftMargin: 18; Layout.rightMargin: 18; text: "ИМЯ"
+               color: Theme.textMuted; font.pixelSize: 10; font.weight: Font.DemiBold; font.letterSpacing: 1 }
+        TextField {
+            id: nameField
+            Layout.leftMargin: 18; Layout.rightMargin: 18; Layout.fillWidth: true
+            placeholderText: "Иван Иванов"
+            background: Rectangle { radius: 6; color: Theme.panel2; border.color: Theme.border; border.width: 1 }
+            color: Theme.text
+            placeholderTextColor: Theme.textDim
+        }
+
+        Text { Layout.leftMargin: 18; Layout.rightMargin: 18; text: "РОЛЬ"
+               color: Theme.textMuted; font.pixelSize: 10; font.weight: Font.DemiBold; font.letterSpacing: 1 }
+        TextField {
+            id: roleField
+            Layout.leftMargin: 18; Layout.rightMargin: 18; Layout.fillWidth: true
+            placeholderText: "Tech Lead / QA / PHY team…"
+            background: Rectangle { radius: 6; color: Theme.panel2; border.color: Theme.border; border.width: 1 }
+            color: Theme.text
+            placeholderTextColor: Theme.textDim
+        }
+
+        Text { Layout.leftMargin: 18; Layout.rightMargin: 18; text: "ВОПРОС / ЗАДАЧА"
+               color: Theme.textMuted; font.pixelSize: 10; font.weight: Font.DemiBold; font.letterSpacing: 1 }
+        ScrollView {
+            Layout.leftMargin: 18; Layout.rightMargin: 18; Layout.fillWidth: true
+            Layout.preferredHeight: 64
+            TextArea {
+                id: questionField
+                placeholderText: "О чём написать…"
+                wrapMode: TextEdit.Wrap
+                background: Rectangle { radius: 6; color: Theme.panel2; border.color: Theme.border; border.width: 1 }
+                color: Theme.text
+                placeholderTextColor: Theme.textDim
+            }
+        }
+
+        RowLayout {
+            Layout.leftMargin: 18; Layout.rightMargin: 18; Layout.fillWidth: true
+            spacing: 12
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 4
+                Text { text: "СТАТУС"; color: Theme.textMuted; font.pixelSize: 10; font.weight: Font.DemiBold; font.letterSpacing: 1 }
+                ComboBox {
+                    id: stateBox
+                    Layout.fillWidth: true
+                    model: ["написать", "написал", "ответил"]
+                    background: Rectangle { radius: 6; color: Theme.panel2; border.color: Theme.border; border.width: 1 }
+                    contentItem: Text { text: stateBox.displayText; color: Theme.text; leftPadding: 10; verticalAlignment: Text.AlignVCenter }
+                }
+            }
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 4
+                Text { text: "ЦВЕТ АВАТАРА"; color: Theme.textMuted; font.pixelSize: 10; font.weight: Font.DemiBold; font.letterSpacing: 1 }
+                Row {
+                    id: colorSwatch
+                    property int selectedIndex: 0
+                    spacing: 4
+                    Repeater {
+                        model: root.palette
+                        delegate: Rectangle {
+                            required property string modelData
+                            required property int index
+                            width: 22; height: 22; radius: 11
+                            color: modelData
+                            border.color: colorSwatch.selectedIndex === index ? Theme.text : "transparent"
+                            border.width: 2
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: colorSwatch.selectedIndex = index
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        RowLayout {
+            Layout.leftMargin: 18; Layout.rightMargin: 18; Layout.topMargin: 8; Layout.bottomMargin: 16
+            spacing: 8
+            PillButton {
+                visible: !root.isNew
+                text: "Удалить"; danger: true
+                onClicked: {
+                    AppController.deletePerson(root.draft.id);
+                    root.close();
+                }
+            }
+            Item { Layout.fillWidth: true }
+            PillButton { text: "Отмена"; onClicked: root.close() }
+            PillButton {
+                text: root.isNew ? "Добавить" : "Сохранить"
+                primary: true
+                onClicked: {
+                    const d = {
+                        _isNew: root.isNew,
+                        id: root.draft.id,
+                        name: nameField.text,
+                        role: roleField.text,
+                        question: questionField.text,
+                        state: root.states[stateBox.currentIndex],
+                        color: root.palette[colorSwatch.selectedIndex]
+                    };
+                    AppController.savePerson(d);
+                    root.close();
+                }
+            }
+        }
+    }
+}

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -143,6 +143,69 @@ void AppController::cyclePerson(const QString &id) {
     m_people.cycleState(id);
 }
 
+void AppController::setPersonState(const QString &id, const QString &state) {
+    m_people.setState(id, state);
+}
+
+QVariantMap AppController::newPersonDraft() const {
+    static const QColor palette[] = {
+        QColor("#d97a6c"), QColor("#c87fc7"), QColor("#6cc4b8"),
+        QColor("#7da8d9"), QColor("#dcc06a"), QColor("#7cc492"),
+        QColor("#e69854"), QColor("#a4a4d6"),
+    };
+    const int n = static_cast<int>(sizeof(palette) / sizeof(palette[0]));
+    const QColor c = palette[m_people.rowCount() % n];
+    QVariantMap m;
+    m["_isNew"] = true;
+    m["id"]       = QString("p-") + QUuid::createUuid().toString(QUuid::WithoutBraces).left(8);
+    m["name"]     = QString();
+    m["role"]     = QString();
+    m["question"] = QString();
+    m["state"]    = "todo";
+    m["color"]    = c;
+    return m;
+}
+
+QVariantMap AppController::personById(const QString &id) const {
+    const int row = m_people.indexOfId(id);
+    if (row < 0) return {};
+    const QModelIndex mi = m_people.index(row, 0);
+    QVariantMap m;
+    m["_isNew"]   = false;
+    m["id"]       = m_people.data(mi, PersonModel::IdRole);
+    m["name"]     = m_people.data(mi, PersonModel::NameRole);
+    m["role"]     = m_people.data(mi, PersonModel::RoleRole);
+    m["question"] = m_people.data(mi, PersonModel::QuestionRole);
+    m["state"]    = m_people.data(mi, PersonModel::StateRole);
+    m["color"]    = m_people.data(mi, PersonModel::ColorRole);
+    return m;
+}
+
+void AppController::savePerson(const QVariantMap &draft) {
+    Person p;
+    p.id       = draft.value("id").toString();
+    p.name     = draft.value("name").toString();
+    p.role     = draft.value("role").toString();
+    p.question = draft.value("question").toString();
+    p.state    = draft.value("state").toString();
+    p.color    = draft.value("color").value<QColor>();
+    if (!p.color.isValid()) p.color = QColor("#7da8d9");
+    if (p.state.isEmpty()) p.state = "todo";
+    if (p.id.isEmpty()) p.id = QString("p-") + QUuid::createUuid().toString(QUuid::WithoutBraces).left(8);
+    const bool isNew = draft.value("_isNew").toBool();
+    if (isNew && p.name.trimmed().isEmpty()) return;
+    m_people.upsert(p);
+    if (isNew) emit toast(QString("Добавлен: %1").arg(p.name));
+}
+
+void AppController::deletePerson(const QString &id) {
+    const int row = m_people.indexOfId(id);
+    if (row < 0) return;
+    const QString name = m_people.data(m_people.index(row,0), PersonModel::NameRole).toString();
+    m_people.removeById(id);
+    emit toast(QString("Удалён: %1").arg(name));
+}
+
 int AppController::countByStatus(const QString &statusId) const {
     int n = 0;
     for (const auto &t : m_tasks.items()) if (t.status == statusId) ++n;

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -54,6 +54,11 @@ public:
 
     // ---- People ops ----
     Q_INVOKABLE void cyclePerson(const QString &id);
+    Q_INVOKABLE void setPersonState(const QString &id, const QString &state);
+    Q_INVOKABLE QVariantMap newPersonDraft() const;
+    Q_INVOKABLE QVariantMap personById(const QString &id) const;
+    Q_INVOKABLE void savePerson(const QVariantMap &draft);
+    Q_INVOKABLE void deletePerson(const QString &id);
     Q_INVOKABLE int  pendingPeopleCount() const { return m_people.todoCount(); }
 
     // ---- Status counts ----

--- a/src/Models.cpp
+++ b/src/Models.cpp
@@ -194,6 +194,35 @@ void PersonModel::cycleState(const QString &id) {
     emit dataChanged(mi, mi, { StateRole });
 }
 
+void PersonModel::setState(const QString &id, const QString &state) {
+    const int row = indexOfId(id);
+    if (row < 0 || m_items[row].state == state) return;
+    m_items[row].state = state;
+    const QModelIndex mi = index(row, 0);
+    emit dataChanged(mi, mi, { StateRole });
+}
+
+void PersonModel::upsert(const Person &p) {
+    const int row = indexOfId(p.id);
+    if (row >= 0) {
+        m_items[row] = p;
+        const QModelIndex mi = index(row, 0);
+        emit dataChanged(mi, mi);
+    } else {
+        beginInsertRows({}, m_items.size(), m_items.size());
+        m_items.push_back(p);
+        endInsertRows();
+    }
+}
+
+void PersonModel::removeById(const QString &id) {
+    const int row = indexOfId(id);
+    if (row < 0) return;
+    beginRemoveRows({}, row, row);
+    m_items.removeAt(row);
+    endRemoveRows();
+}
+
 int PersonModel::todoCount() const {
     int n = 0;
     for (const auto &p : m_items) if (p.state == "todo") ++n;

--- a/src/Models.h
+++ b/src/Models.h
@@ -112,6 +112,9 @@ public:
 
     int indexOfId(const QString &id) const;
     void cycleState(const QString &id);
+    void setState(const QString &id, const QString &state);
+    void upsert(const Person &p);
+    void removeById(const QString &id);
     int todoCount() const;
 
 private:


### PR DESCRIPTION
- Wrap DayCalendar and PeopleList in a vertical SplitView so the divider can be dragged to give either pane more room
- People CRUD: + button in the panel header opens a blank editor; hover over a row reveals a pencil icon; double-click or right-click also opens the editor; the state badge is now its own click target that cycles todo → pinged → replied
- New PersonEditor.qml popup with name / role / question / state / avatar-color picker
- PersonModel: upsert, removeById, setState
- AppController: newPersonDraft, personById, savePerson, deletePerson, setPersonState