### PR TITLE
ci: release triggering manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release Portable
 
 on:
-  push:
-    branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

<!-- One or two sentences: what changes, why now. Link tickets / issues. -->

## Test plan

- [ ] `cmake --build build --target heap` succeeds locally
- [ ] `ctest --test-dir build --output-on-failure` is green
- [ ] Manual UI smoke if QML / interaction was touched
- [ ] New behaviour covered by a unit test (or explicit reason why not)

## Notes for reviewer

<!--
Anything that needs context: trade-offs, follow-ups, intentionally skipped
checks, screenshots of UI changes, etc. Delete if empty.
-->
