### PR TITLE
ui: selecting multiple tickets and archive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,8 @@ qt_add_qml_module(heap
         qml/FilterBar.qml
         qml/KanbanBoard.qml
         qml/TaskCard.qml
+        qml/SelectionBar.qml
+        qml/ArchiveView.qml
         qml/TimelineView.qml
         qml/WeekView.qml
         qml/DocsView.qml

--- a/qml/ArchiveView.qml
+++ b/qml/ArchiveView.qml
@@ -1,0 +1,273 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import QtQuick.Controls.Basic
+import QtQuick.Controls as QQC
+import TodoCpp
+
+Item {
+    id: root
+
+    property string searchText: ""
+    property var prioritiesFilter: ({})
+
+    signal taskClicked(string id)
+
+    // Shift-click range select within the archive feed (flat order).
+    property string shiftAnchorId: ""
+    Connections {
+        target: AppController
+
+        function onSelectedTaskIdsChanged() {
+            if (AppController.selectionCount === 0) root.shiftAnchorId = "";
+        }
+    }
+
+    function passesFilter(t) {
+        const q = (root.searchText || "").toLowerCase();
+        if (q && q.length > 0) {
+            const hay = ((t.title || "") + " " + (t.id || "") + " " + (t.desc || "")).toLowerCase();
+            if (hay.indexOf(q) < 0) return false;
+        }
+        let any = false;
+        for (const k in root.prioritiesFilter) if (root.prioritiesFilter[k]) {
+            any = true;
+            break;
+        }
+        if (any && !root.prioritiesFilter[t.priority]) return false;
+        return true;
+    }
+
+    function statusInfo(id) {
+        const list = AppController.statuses;
+        for (let i = 0; i < list.length; i++) if (list[i].id === id) return list[i];
+        return {id: id, name: id, color: Theme.textDim};
+    }
+
+    // Snapshot of archived tasks. Rebuild on task-model mutations.
+    property int modelRev: 0
+    Connections {
+        target: AppController.tasks
+
+        function onDataChanged() {
+            root.modelRev++
+        }
+
+        function onRowsInserted() {
+            root.modelRev++
+        }
+
+        function onRowsRemoved() {
+            root.modelRev++
+        }
+
+        function onModelReset() {
+            root.modelRev++
+        }
+    }
+
+    function buildItems() {
+        const _rev = root.modelRev;
+        const m = AppController.tasks;
+        const out = [];
+        for (let i = 0; i < m.rowCount(); i++) {
+            const idx = m.index(i, 0);
+            const archived = m.data(idx, Qt.UserRole + 9);
+            if (!archived) continue;
+            const t = {
+                id: m.data(idx, Qt.UserRole + 1),
+                title: m.data(idx, Qt.UserRole + 2),
+                desc: m.data(idx, Qt.UserRole + 3),
+                priority: m.data(idx, Qt.UserRole + 4),
+                status: m.data(idx, Qt.UserRole + 5),
+                deadline: m.data(idx, Qt.UserRole + 6),
+                branch: m.data(idx, Qt.UserRole + 7),
+                archived: true,
+                blockedStuck: m.data(idx, Qt.UserRole + 10),
+                prState: m.data(idx, Qt.UserRole + 11),
+                prNumber: m.data(idx, Qt.UserRole + 12),
+                prUrl: m.data(idx, Qt.UserRole + 13),
+                gitAhead: m.data(idx, Qt.UserRole + 14),
+                gitBehind: m.data(idx, Qt.UserRole + 15),
+            };
+            if (!root.passesFilter(t)) continue;
+            out.push(t);
+        }
+        const priRank = {P0: 0, P1: 1, P2: 2, P3: 3};
+        out.sort((a, b) => (priRank[a.priority] || 9) - (priRank[b.priority] || 9));
+        return out;
+    }
+
+    readonly property var items: buildItems()
+    onSearchTextChanged: modelRev++   // re-evaluate buildItems via binding
+    onPrioritiesFilterChanged: modelRev++
+
+    function _flatVisibleIds() {
+        const ids = [];
+        for (let i = 0; i < items.length; i++) ids.push(items[i].id);
+        return ids;
+    }
+
+    function selectAllVisible() {
+        AppController.setSelectedTaskIds(_flatVisibleIds());
+    }
+
+    function _rangeSelect(targetId) {
+        const ordered = _flatVisibleIds();
+        if (ordered.length === 0) return;
+        const haveAnchor = root.shiftAnchorId && ordered.indexOf(root.shiftAnchorId) >= 0;
+        if (!haveAnchor) {
+            root.shiftAnchorId = targetId;
+            AppController.toggleTaskSelection(targetId);
+            return;
+        }
+        const ai = ordered.indexOf(root.shiftAnchorId);
+        const ti = ordered.indexOf(targetId);
+        const lo = Math.min(ai, ti);
+        const hi = Math.max(ai, ti);
+        const merged = AppController.selectedTaskIds.slice();
+        for (let i = lo; i <= hi; i++) {
+            if (merged.indexOf(ordered[i]) < 0) merged.push(ordered[i]);
+        }
+        AppController.setSelectedTaskIds(merged);
+    }
+
+    Rectangle {
+        anchors.fill: parent; color: Theme.bg
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        // Header strip
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 50
+            color: Theme.panel
+            Rectangle {
+                anchors.left: parent.left; anchors.right: parent.right; anchors.bottom: parent.bottom
+                height: 1; color: Theme.border
+            }
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 18; anchors.rightMargin: 18
+                spacing: 12
+                Column {
+                    spacing: 1
+                    Text {
+                        text: I18n.t("archive.title")
+                        color: Theme.text
+                        font.pixelSize: 14
+                        font.weight: Font.DemiBold
+                    }
+                    Text {
+                        text: root.items.length + " " + I18n.t("archive.count")
+                        color: Theme.textDim
+                        font.family: Theme.fontMono
+                        font.pixelSize: 11
+                    }
+                }
+                Item {
+                    Layout.fillWidth: true
+                }
+                PillButton {
+                    visible: root.items.length > 0
+                    text: I18n.t("archive.selectAll")
+                    onClicked: root.selectAllVisible()
+                }
+                PillButton {
+                    visible: AppController.selectionCount > 0
+                    text: I18n.t("archive.restoreSelected")
+                    primary: true
+                    onClicked: AppController.setSelectedTasksArchived(false)
+                }
+            }
+        }
+
+        // Body
+        ScrollView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+            ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+
+            ColumnLayout {
+                width: root.width
+                spacing: 0
+
+                Item {
+                    visible: root.items.length === 0
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 220
+                    Column {
+                        anchors.centerIn: parent
+                        spacing: 8
+                        Text {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            text: "▤"
+                            color: Theme.textDim
+                            font.pixelSize: 32
+                        }
+                        Text {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            text: I18n.t("archive.empty.title")
+                            color: Theme.text
+                            font.pixelSize: 13
+                        }
+                        Text {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            text: I18n.t("archive.empty.hint")
+                            color: Theme.textDim
+                            font.pixelSize: 12
+                        }
+                    }
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 18
+                    Layout.rightMargin: 18
+                    Layout.topMargin: 12
+                    Layout.bottomMargin: 18
+                    spacing: 8
+
+                    Repeater {
+                        model: root.items
+                        delegate: RowLayout {
+                            id: row
+                            required property var modelData
+                            readonly property var st: root.statusInfo(modelData.status)
+                            Layout.fillWidth: true
+                            spacing: 10
+
+                            // Status pill — gives context for "from which column".
+                            Rectangle {
+                                Layout.preferredWidth: 86
+                                Layout.preferredHeight: 24
+                                radius: 999
+                                color: "transparent"
+                                border.color: Theme.withAlpha(row.st.color, 0.45)
+                                border.width: 1
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: row.st.name
+                                    color: row.st.color
+                                    font.pixelSize: 10
+                                    font.weight: Font.DemiBold
+                                }
+                            }
+
+                            TaskCard {
+                                Layout.fillWidth: true
+                                task: row.modelData
+                                onClicked: root.taskClicked(row.modelData.id)
+                                onRangeSelectRequested: (anchorId) => root._rangeSelect(anchorId)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qml/I18n.qml
+++ b/qml/I18n.qml
@@ -82,6 +82,15 @@ QtObject {
             "siderail.tip.hotkeys": "Hotkeys · keys and bindings",
             "siderail.tip.tweaks": "Tweaks · theme, density, workday",
             "siderail.tip.settings": "Settings",
+            "siderail.tip.archive": "Archive · restore or purge old tickets",
+
+            // ── ArchiveView ──
+            "archive.title": "Archive",
+            "archive.count": "archived tickets",
+            "archive.selectAll": "Select all",
+            "archive.restoreSelected": "Restore selected",
+            "archive.empty.title": "Archive is empty",
+            "archive.empty.hint": "Tickets you archive show up here. Multi-select + restore to bring them back.",
 
             // ── FilterBar ──
             "filter.all": "All",
@@ -477,7 +486,15 @@ QtObject {
             "settings.about.version": "Version",
             "settings.about.channel": "Channel",
             "settings.about.storage": "Storage",
-            "settings.about.engine": "Engine"
+            "settings.about.engine": "Engine",
+
+            // ── Selection action bar ──
+            "selection.bar.count": "%1 selected",
+            "selection.bar.move": "Move to…",
+            "selection.bar.archive": "Archive",
+            "selection.bar.unarchive": "Unarchive",
+            "selection.bar.delete": "Delete",
+            "selection.bar.clear": "Clear"
         },
         ru: {
             // ── Common ──
@@ -545,6 +562,15 @@ QtObject {
             "siderail.tip.hotkeys": "Hotkeys · клавиши и биндинги",
             "siderail.tip.tweaks": "Tweaks · тема, плотность, рабочий день",
             "siderail.tip.settings": "Settings",
+            "siderail.tip.archive": "Архив · вернуть или удалить старые тикеты",
+
+            // ── ArchiveView ──
+            "archive.title": "Архив",
+            "archive.count": "архивных тикетов",
+            "archive.selectAll": "Выделить все",
+            "archive.restoreSelected": "Вернуть выделенные",
+            "archive.empty.title": "Архив пуст",
+            "archive.empty.hint": "Тикеты, отправленные в архив, появятся здесь. Множественный выбор + «Вернуть».",
 
             "filter.all": "Все",
             "filter.mine": "Мои",
@@ -917,7 +943,15 @@ QtObject {
             "settings.about.version": "Версия",
             "settings.about.channel": "Канал",
             "settings.about.storage": "Хранилище",
-            "settings.about.engine": "Движок"
+            "settings.about.engine": "Движок",
+
+            // ── Selection action bar ──
+            "selection.bar.count": "Выделено: %1",
+            "selection.bar.move": "Переместить…",
+            "selection.bar.archive": "Архивировать",
+            "selection.bar.unarchive": "Из архива",
+            "selection.bar.delete": "Удалить",
+            "selection.bar.clear": "Снять"
         }
     })
 

--- a/qml/KanbanBoard.qml
+++ b/qml/KanbanBoard.qml
@@ -14,6 +14,64 @@ Item {
     signal taskClicked(string id)
     signal createInStatus(string statusId)
 
+    // Anchor for shift-click range selection. Reset when the selection
+    // disappears so the next shift-click starts a fresh range.
+    property string shiftAnchorId: ""
+    Connections {
+        target: AppController
+
+        function onSelectedTaskIdsChanged() {
+            if (AppController.selectionCount === 0) root.shiftAnchorId = "";
+        }
+    }
+
+    // Walk every column's TaskCard repeater, collect ids of currently
+    // visible cards (respects search/priority/archived filters), hand them
+    // to AppController as the new selection set.
+    function selectAllVisible() {
+        AppController.setSelectedTaskIds(_flatVisibleIds());
+    }
+
+    // Flat ordered list of visible task ids across the entire board, column
+    // by column in render order, top-to-bottom inside each column. Used by
+    // selectAllVisible() and shift-range select.
+    function _flatVisibleIds() {
+        const out = [];
+        for (let c = 0; c < colRepeater.count; c++) {
+            const col = colRepeater.itemAt(c);
+            if (!col || !col.taskRepeater) continue;
+            const rep = col.taskRepeater;
+            for (let i = 0; i < rep.count; i++) {
+                const it = rep.itemAt(i);
+                if (it && it.visible && it.taskId) out.push(it.taskId);
+            }
+        }
+        return out;
+    }
+
+    // Shift-click range: spans the flat visible list (cross-column). First
+    // shift-click sets the anchor; subsequent shift-click selects every
+    // ticket between anchor and target inclusive.
+    function _rangeSelect(targetId) {
+        const ordered = _flatVisibleIds();
+        if (ordered.length === 0) return;
+        const haveAnchor = root.shiftAnchorId && ordered.indexOf(root.shiftAnchorId) >= 0;
+        if (!haveAnchor) {
+            root.shiftAnchorId = targetId;
+            AppController.toggleTaskSelection(targetId);
+            return;
+        }
+        const ai = ordered.indexOf(root.shiftAnchorId);
+        const ti = ordered.indexOf(targetId);
+        const lo = Math.min(ai, ti);
+        const hi = Math.max(ai, ti);
+        const merged = AppController.selectedTaskIds.slice();
+        for (let i = lo; i <= hi; i++) {
+            if (merged.indexOf(ordered[i]) < 0) merged.push(ordered[i]);
+        }
+        AppController.setSelectedTaskIds(merged);
+    }
+
     function passesFilter(taskObj) {
         const q = (root.searchText || "").toLowerCase();
         if (q && q.length > 0) {
@@ -57,7 +115,10 @@ Item {
         contentHeight: height
         flickableDirection: Flickable.HorizontalFlick
         clip: true
-        pressDelay: 180
+        // pressDelay: 0 — keep card-drag activation instant on press.
+        // Horizontal flick by dragging empty board space is rarely used
+        // on desktop (mouse wheel handles it via WheelHandler below).
+        pressDelay: 0
 
         // Outer wheel: scroll the board horizontally with mouse-wheel.
         // Triggered when an inner WheelHandler sets event.accepted = false
@@ -89,6 +150,7 @@ Item {
                     readonly property string statusId: modelData.id
                     readonly property string statusName: modelData.name
                     readonly property color statusColor: modelData.color
+                    readonly property alias taskRepeater: colRep
                     property bool dragOver: false
                     property int visibleCount: 0
                     property bool renaming: false
@@ -253,7 +315,9 @@ Item {
                                 contentHeight: bodyCol.implicitHeight
                                 clip: true
                                 flickableDirection: Flickable.VerticalFlick
-                                pressDelay: 180
+                                // pressDelay: 0 — same rationale as the
+                                // outer hscroll: instant drag on cards.
+                                pressDelay: 0
 
                                 // Wheel scrolls this column vertically. When the column
                                 // has no overflow or is already at the top/bottom edge,
@@ -329,6 +393,7 @@ Item {
                                                   && (root.showArchived || !tc.archived)
                                                   && root.passesFilter(taskData)
                                             onClicked: root.taskClicked(tc.id)
+                                            onRangeSelectRequested: (anchorId) => root._rangeSelect(anchorId)
 
                                             onVisibleChanged: col.recountSoon()
                                             Component.onCompleted: col.recountSoon()
@@ -356,10 +421,14 @@ Item {
                                 onDropped: (drop) => {
                                     col.dragOver = false;
                                     const src = drop.source;
-                                    if (src && src.taskId) {
+                                    if (!src || !src.taskId) return;
+                                    if (AppController.isTaskSelected(src.taskId)
+                                        && AppController.selectionCount > 1) {
+                                        AppController.moveSelectedTasksToStatus(col.statusId);
+                                    } else {
                                         AppController.moveTask(src.taskId, col.statusId);
-                                        drop.accept(Qt.MoveAction);
                                     }
+                                    drop.accept(Qt.MoveAction);
                                 }
                             }
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -172,17 +172,27 @@ ApplicationWindow {
                     onClearPriorities: win.prioritiesFilter = ({})
                     onToggleArchived: win.showArchived = !win.showArchived
                 }
-                Loader {
-                    id: viewLoader
+                Item {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    sourceComponent: {
-                        if (AppController.currentView === "timeline") return timelineComp;
-                        if (AppController.currentView === "week")     return weekComp;
-                        if (AppController.currentView === "docs")     return docsComp;
-                        if (AppController.currentView === "notes")    return notesComp;
-                        if (AppController.currentView === "settings") return settingsComp;
-                        return boardComp;
+                    Loader {
+                        id: viewLoader
+                        anchors.fill: parent
+                        sourceComponent: {
+                            if (AppController.currentView === "timeline") return timelineComp;
+                            if (AppController.currentView === "week") return weekComp;
+                            if (AppController.currentView === "archive") return archiveComp;
+                            if (AppController.currentView === "docs") return docsComp;
+                            if (AppController.currentView === "notes") return notesComp;
+                            if (AppController.currentView === "settings") return settingsComp;
+                            return boardComp;
+                        }
+                    }
+                    SelectionBar {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.bottom: parent.bottom
+                        anchors.bottomMargin: 16
+                        z: 50
                     }
                 }
                 Component {
@@ -216,6 +226,14 @@ ApplicationWindow {
                         showArchived: win.showArchived
                         onTaskClicked: (id) => taskEditor.showFor(Object.assign({}, AppController.taskById(id)))
                         onEventClicked: (id) => eventEditor.showForId(id)
+                    }
+                }
+                Component {
+                    id: archiveComp
+                    ArchiveView {
+                        searchText: win.searchText
+                        prioritiesFilter: win.prioritiesFilter
+                        onTaskClicked: (id) => taskEditor.showFor(Object.assign({}, AppController.taskById(id)))
                     }
                 }
                 Component {
@@ -465,6 +483,33 @@ ApplicationWindow {
         context: Qt.ApplicationShortcut
         enabled: sequence.length > 0 && !hotkeys.isCapturing
         onActivated: topBar.focusSearch()
+    }
+
+    Shortcut {
+        sequence: _kbd("selection.selectAll")
+        context: Qt.ApplicationShortcut
+        enabled: sequence.length > 0 && !hotkeys.isCapturing
+            && (AppController.currentView === "board"
+                || AppController.currentView === "timeline"
+                || AppController.currentView === "week")
+        onActivated: {
+            const v = viewLoader.item;
+            if (v && v.selectAllVisible) v.selectAllVisible();
+        }
+    }
+    Shortcut {
+        sequence: _kbd("selection.clearSel")
+        context: Qt.ApplicationShortcut
+        enabled: sequence.length > 0 && !hotkeys.isCapturing
+            && AppController.selectionCount > 0
+        onActivated: AppController.clearSelection()
+    }
+    Shortcut {
+        sequence: _kbd("selection.deleteSel")
+        context: Qt.ApplicationShortcut
+        enabled: sequence.length > 0 && !hotkeys.isCapturing
+            && AppController.selectionCount > 0
+        onActivated: AppController.deleteSelectedTasks()
     }
 
     Connections {

--- a/qml/SelectionBar.qml
+++ b/qml/SelectionBar.qml
@@ -1,0 +1,74 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls.Basic
+import QtQuick.Controls as QQC
+import TodoCpp
+
+Rectangle {
+    id: bar
+    visible: AppController.selectionCount > 0
+    opacity: visible ? 1 : 0
+    Behavior on opacity {
+        NumberAnimation {
+            duration: Theme.scaledMs(160); easing.type: Easing.OutCubic
+        }
+    }
+    radius: 10
+    color: Theme.panel2
+    border.color: Theme.borderStrong
+    border.width: 1
+    implicitHeight: 44
+    implicitWidth: row.implicitWidth + 24
+
+    RowLayout {
+        id: row
+        anchors.fill: parent
+        anchors.leftMargin: 12; anchors.rightMargin: 12
+        spacing: 10
+
+        Text {
+            text: I18n.t("selection.bar.count").replace("%1", AppController.selectionCount)
+            color: Theme.text
+            font.family: Theme.fontUi
+            font.pixelSize: 12
+            font.weight: Font.DemiBold
+        }
+        Rectangle {
+            Layout.preferredWidth: 1; Layout.preferredHeight: 18; color: Theme.border
+        }
+
+        PillButton {
+            text: I18n.t("selection.bar.move")
+            onClicked: moveMenu.popup()
+        }
+        PillButton {
+            // Archive view operates on already-archived tickets — the only
+            // sensible bulk action is to restore (unarchive). Elsewhere we
+            // offer the inverse.
+            readonly property bool _restoring: AppController.currentView === "archive"
+            text: I18n.t(_restoring ? "selection.bar.unarchive" : "selection.bar.archive")
+            onClicked: AppController.setSelectedTasksArchived(!_restoring)
+        }
+        PillButton {
+            text: I18n.t("selection.bar.delete")
+            danger: true
+            onClicked: AppController.deleteSelectedTasks()
+        }
+        PillButton {
+            text: I18n.t("selection.bar.clear")
+            onClicked: AppController.clearSelection()
+        }
+    }
+
+    QQC.Menu {
+        id: moveMenu
+        Repeater {
+            model: AppController.statuses
+            QQC.MenuItem {
+                required property var modelData
+                text: modelData.name
+                onTriggered: AppController.moveSelectedTasksToStatus(modelData.id)
+            }
+        }
+    }
+}

--- a/qml/SideRail.qml
+++ b/qml/SideRail.qml
@@ -50,6 +50,11 @@ Rectangle {
             glyph: "◫"; tooltipText: I18n.t("siderail.tip.week")
                    active: AppController.currentView === "week"
                    onActivated: AppController.currentView = "week" }
+        RailBtn {
+            glyph: "▤"; tooltipText: I18n.t("siderail.tip.archive")
+            active: AppController.currentView === "archive"
+            onActivated: AppController.currentView = "archive"
+        }
 
         Rectangle { Layout.alignment: Qt.AlignHCenter; width: 24; height: 1; color: Theme.border; Layout.topMargin: 6; Layout.bottomMargin: 6 }
 

--- a/qml/TaskCard.qml
+++ b/qml/TaskCard.qml
@@ -11,15 +11,24 @@ Rectangle {
     property string taskId: task ? task.id : ""
     readonly property bool _isStuck: card.task && card.task.blockedStuck === true
     readonly property bool _isArchived: card.task && card.task.archived === true
+    // Selection state — re-evaluates via AppController.selectedTaskIdsChanged
+    // (selectionCount is read in the binding so QML tracks the dependency).
+    readonly property bool _selected: AppController.selectionCount >= 0
+        && AppController.isTaskSelected(card.taskId)
     signal clicked()
 
+    signal rangeSelectRequested(string anchorId)
+
     radius: 8
-    color: _isArchived ? Theme.withAlpha(Theme.panel2, 0.55) : Theme.panel2
+    color: _isArchived ? Theme.withAlpha(Theme.panel2, 0.55)
+        : _selected ? Theme.withAlpha(Theme.accent, 0.10)
+            : Theme.panel2
     border.color: dragArea.drag.active ? Theme.accent
+        : _selected ? Theme.accent
                 : _isStuck ? Theme.p0
                 : hoverArea.containsMouse ? Theme.borderStrong
                 : Theme.border
-    border.width: dragArea.drag.active ? 2 : (_isStuck ? 2 : 1)
+    border.width: dragArea.drag.active ? 2 : (_selected ? 2 : (_isStuck ? 2 : 1))
     opacity: dragArea.drag.active ? 0.92 : (_isArchived ? 0.7 : 1.0)
     scale: dragArea.drag.active ? 1.03 : 1.0
     transformOrigin: Item.Center
@@ -239,6 +248,29 @@ Rectangle {
         }
     }
 
+    // "+N" badge shown while dragging a selected card with siblings.
+    Rectangle {
+        visible: dragArea.drag.active && card._selected && AppController.selectionCount > 1
+        anchors.top: parent.top; anchors.right: parent.right
+        anchors.margins: -6
+        z: 5
+        width: bulkT.implicitWidth + 10
+        height: 18
+        radius: 9
+        color: Theme.accent
+        border.color: Theme.accentStrong
+        border.width: 1
+        Text {
+            id: bulkT
+            anchors.centerIn: parent
+            text: "+" + (AppController.selectionCount - 1)
+            color: "#06121a"
+            font.family: Theme.fontMono
+            font.pixelSize: 10
+            font.weight: Font.DemiBold
+        }
+    }
+
     MouseArea {
         id: hoverArea
         anchors.fill: parent
@@ -263,7 +295,18 @@ Rectangle {
             card.Drag.drop();
             card.x = card.homeX; card.y = card.homeY;
             didDrag = false;
-            if (!wasDrag && mouse.button === Qt.LeftButton) card.clicked();
+            if (wasDrag || mouse.button !== Qt.LeftButton) return;
+
+            const ctrl = (mouse.modifiers & Qt.ControlModifier) !== 0;
+            const shift = (mouse.modifiers & Qt.ShiftModifier) !== 0;
+            if (ctrl) {
+                AppController.toggleTaskSelection(card.taskId);
+            } else if (shift) {
+                card.rangeSelectRequested(card.taskId);
+            } else {
+                if (AppController.selectionCount > 0) AppController.clearSelection();
+                card.clicked();
+            }
         }
     }
 

--- a/qml/TimelineView.qml
+++ b/qml/TimelineView.qml
@@ -15,6 +15,49 @@ Item {
     signal taskClicked(string id)
     signal toggleShowDone()
 
+    // Selection plumbing — flat across buckets (reading order).
+    property string shiftAnchorId: ""
+    Connections {
+        target: AppController
+
+        function onSelectedTaskIdsChanged() {
+            if (AppController.selectionCount === 0) root.shiftAnchorId = "";
+        }
+    }
+
+    function _flatVisibleIds() {
+        const out = [];
+        for (const b of root.bucketOrder) {
+            const list = root.groups[b] || [];
+            for (let i = 0; i < list.length; i++) out.push(list[i].id);
+        }
+        return out;
+    }
+
+    function selectAllVisible() {
+        AppController.setSelectedTaskIds(_flatVisibleIds());
+    }
+
+    function _rangeSelect(targetId) {
+        const ordered = _flatVisibleIds();
+        if (ordered.length === 0) return;
+        const haveAnchor = root.shiftAnchorId && ordered.indexOf(root.shiftAnchorId) >= 0;
+        if (!haveAnchor) {
+            root.shiftAnchorId = targetId;
+            AppController.toggleTaskSelection(targetId);
+            return;
+        }
+        const ai = ordered.indexOf(root.shiftAnchorId);
+        const ti = ordered.indexOf(targetId);
+        const lo = Math.min(ai, ti);
+        const hi = Math.max(ai, ti);
+        const merged = AppController.selectedTaskIds.slice();
+        for (let i = lo; i <= hi; i++) {
+            if (merged.indexOf(ordered[i]) < 0) merged.push(ordered[i]);
+        }
+        AppController.setSelectedTaskIds(merged);
+    }
+
     readonly property var bucketOrder: ["overdue", "today", "tomorrow", "thisweek", "nextweek", "later", "nodl"]
     readonly property var bucketMeta: ({
         overdue:  ({ name: "Overdue",     icon: "!", color: Theme.p0,           tone: "danger"  }),
@@ -308,11 +351,15 @@ Item {
                                         readonly property var rd: parent && parent.rowData ? parent.rowData : null
                                         readonly property var t: rd ? rd.task : null
                                         readonly property var st: t ? root.statusInfo(t.status) : null
+                                        readonly property bool _selected: t && AppController.selectionCount >= 0
+                                            && AppController.isTaskSelected(t.id)
                                         width: parent ? parent.width : 0
                                         radius: 8
-                                        color: rowMA.containsMouse ? Theme.panel2 : Theme.panel
-                                        border.color: rowMA.containsMouse ? Theme.borderStrong : Theme.border
-                                        border.width: 1
+                                        color: _selected ? Theme.withAlpha(Theme.accent, 0.10)
+                                            : rowMA.containsMouse ? Theme.panel2 : Theme.panel
+                                        border.color: _selected ? Theme.accent
+                                            : rowMA.containsMouse ? Theme.borderStrong : Theme.border
+                                        border.width: _selected ? 2 : 1
                                         implicitHeight: rowContent.implicitHeight + 16
 
                                         // Left accent stripe
@@ -430,7 +477,19 @@ Item {
                                             anchors.fill: parent
                                             hoverEnabled: true
                                             cursorShape: Qt.PointingHandCursor
-                                            onClicked: root.taskClicked(tlRow.t.id)
+                                            acceptedButtons: Qt.LeftButton
+                                            onClicked: (mouse) => {
+                                                const ctrl = (mouse.modifiers & Qt.ControlModifier) !== 0;
+                                                const shift = (mouse.modifiers & Qt.ShiftModifier) !== 0;
+                                                if (ctrl) {
+                                                    AppController.toggleTaskSelection(tlRow.t.id);
+                                                } else if (shift) {
+                                                    root._rangeSelect(tlRow.t.id);
+                                                } else {
+                                                    if (AppController.selectionCount > 0) AppController.clearSelection();
+                                                    root.taskClicked(tlRow.t.id);
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/qml/WeekView.qml
+++ b/qml/WeekView.qml
@@ -14,6 +14,68 @@ Item {
     signal eventClicked(string id)
     signal dayClicked(date d)
 
+    // Shift-click anchor + day for range select. Shift across days falls back
+    // to single-toggle since the visible-chip order isn't a single flat list.
+    property string shiftAnchorId: ""
+    property int    shiftAnchorDay: -1
+    Connections {
+        target: AppController
+
+        function onSelectedTaskIdsChanged() {
+            if (AppController.selectionCount === 0) {
+                root.shiftAnchorId = "";
+                root.shiftAnchorDay = -1;
+            }
+        }
+    }
+
+    function _renderedIdsForDay(dayIdx) {
+        if (dayIdx < 0 || dayIdx >= days.length) return [];
+        const list = days[dayIdx].tasks.slice(0, 4);
+        const ids = [];
+        for (let i = 0; i < list.length; i++) ids.push(list[i].id);
+        return ids;
+    }
+
+    function _dayIndexOfTask(taskId) {
+        for (let i = 0; i < days.length; i++) {
+            const ids = _renderedIdsForDay(i);
+            if (ids.indexOf(taskId) >= 0) return i;
+        }
+        return -1;
+    }
+
+    function selectAllVisible() {
+        const ids = [];
+        for (let i = 0; i < days.length; i++) {
+            const part = _renderedIdsForDay(i);
+            for (let j = 0; j < part.length; j++) ids.push(part[j]);
+        }
+        AppController.setSelectedTaskIds(ids);
+    }
+
+    function _rangeSelect(targetId) {
+        const targetDay = _dayIndexOfTask(targetId);
+        if (targetDay < 0) return;
+        if (root.shiftAnchorId === "" || root.shiftAnchorDay !== targetDay
+            || _renderedIdsForDay(targetDay).indexOf(root.shiftAnchorId) < 0) {
+            root.shiftAnchorId = targetId;
+            root.shiftAnchorDay = targetDay;
+            AppController.toggleTaskSelection(targetId);
+            return;
+        }
+        const ordered = _renderedIdsForDay(targetDay);
+        const ai = ordered.indexOf(root.shiftAnchorId);
+        const ti = ordered.indexOf(targetId);
+        const lo = Math.min(ai, ti);
+        const hi = Math.max(ai, ti);
+        const merged = AppController.selectedTaskIds.slice();
+        for (let i = lo; i <= hi; i++) {
+            if (merged.indexOf(ordered[i]) < 0) merged.push(ordered[i]);
+        }
+        AppController.setSelectedTaskIds(merged);
+    }
+
     readonly property int hoursStart: AppController.workdayStart
     readonly property int hoursEnd:   AppController.workdayEnd
     readonly property int hourH: 38
@@ -329,12 +391,16 @@ Item {
                                     model: headCol.modelData.tasks.slice(0, 4)
                                     delegate: Rectangle {
                                         required property var modelData
+                                        readonly property bool _selected: AppController.selectionCount >= 0
+                                            && AppController.isTaskSelected(modelData.id)
                                         Layout.fillWidth: true
                                         Layout.preferredHeight: 22
                                         radius: 4
-                                        color: chipMA.containsMouse ? Theme.panel2 : Theme.panel3
-                                        border.color: Theme.withAlpha(Theme.priorityColor(modelData.priority), 0.45)
-                                        border.width: 1
+                                        color: _selected ? Theme.withAlpha(Theme.accent, 0.18)
+                                            : chipMA.containsMouse ? Theme.panel2 : Theme.panel3
+                                        border.color: _selected ? Theme.accent
+                                            : Theme.withAlpha(Theme.priorityColor(modelData.priority), 0.45)
+                                        border.width: _selected ? 2 : 1
 
                                         RowLayout {
                                             anchors.fill: parent
@@ -363,7 +429,19 @@ Item {
                                             anchors.fill: parent
                                             hoverEnabled: true
                                             cursorShape: Qt.PointingHandCursor
-                                            onClicked: root.taskClicked(modelData.id)
+                                            acceptedButtons: Qt.LeftButton
+                                            onClicked: (mouse) => {
+                                                const ctrl = (mouse.modifiers & Qt.ControlModifier) !== 0;
+                                                const shift = (mouse.modifiers & Qt.ShiftModifier) !== 0;
+                                                if (ctrl) {
+                                                    AppController.toggleTaskSelection(modelData.id);
+                                                } else if (shift) {
+                                                    root._rangeSelect(modelData.id);
+                                                } else {
+                                                    if (AppController.selectionCount > 0) AppController.clearSelection();
+                                                    root.taskClicked(modelData.id);
+                                                }
+                                            }
                                             ToolTip.visible: containsMouse
                                             ToolTip.delay: 400
                                             ToolTip.text: modelData.title

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -2620,7 +2620,7 @@ void AppController::setTaskSelected(const QString& id, bool selected) {
 }
 
 void AppController::setSelectedTaskIds(const QStringList& ids) {
-  QSet<QString> next(ids.constBegin(), ids.constEnd());
+  const QSet<QString> next(ids.constBegin(), ids.constEnd());
   if(next == m_selectedTaskIds) {
     return;
   }

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -110,6 +110,26 @@ const QHash<QString, I18nEntry>& i18nTable() {
       {"shortcut.quick-capture.label", {"Quick-capture task", "Быстрое создание задачи"}},
       {"shortcut.quick-capture.desc",
        {"Open Quick-capture with on-the-fly date parsing.", "Открыть Quick-capture с разбором даты на лету."}},
+      {"shortcut.selection.selectAll.label", {"Select all visible", "Выделить все видимые"}},
+      {"shortcut.selection.selectAll.desc",
+       {"Select every ticket visible in the current view.", "Выделить все тикеты, видимые в текущем виде."}},
+      {"shortcut.selection.clearSel.label", {"Clear selection", "Снять выделение"}},
+      {"shortcut.selection.clearSel.desc", {"Drop the current multi-selection.", "Сбросить текущее множественное выделение."}},
+      {"shortcut.selection.deleteSel.label", {"Delete selection", "Удалить выделенные"}},
+      {"shortcut.selection.deleteSel.desc",
+       {"Delete every selected ticket (undoable for 5s).", "Удалить все выделенные тикеты (отменимо 5 с)."}},
+      // ---- Selection action bar ----
+      {"selection.bar.count", {"%1 selected", "Выделено: %1"}},
+      {"selection.bar.move", {"Move to…", "Переместить…"}},
+      {"selection.bar.archive", {"Archive", "Архивировать"}},
+      {"selection.bar.unarchive", {"Unarchive", "Из архива"}},
+      {"selection.bar.delete", {"Delete", "Удалить"}},
+      {"selection.bar.clear", {"Clear", "Снять"}},
+      {"selection.toast.deleted", {"Deleted %1 tasks", "Удалено задач: %1"}},
+      {"selection.toast.restored", {"Restored %1 tasks", "Восстановлено задач: %1"}},
+      {"selection.toast.moved", {"Moved %1 tasks", "Перемещено задач: %1"}},
+      {"selection.toast.archived", {"Archived %1 tasks", "В архив: %1"}},
+      {"selection.toast.unarchived", {"Unarchived %1 tasks", "Из архива: %1"}},
       // ---- Notification copy ----
       {"notify.deadlineTitle", {"Deadline %1", "Дедлайн %1"}},
       {"notify.deadlineWhen.h1", {"in 1 hour", "через час"}},
@@ -382,6 +402,7 @@ void AppController::setCurrentView(const QString& v) {
     return;
   }
   m_currentView = v;
+  clearSelection();
   emit currentViewChanged();
   scheduleSave();
 }
@@ -543,6 +564,22 @@ void AppController::saveTask(const QVariantMap& draft) {
   const bool isNew = draft.value("_isNew").toBool();
   if(isNew && t.title.trimmed().isEmpty()) {
     return;
+  }
+
+  // Preserve fields the editor doesn't expose. Without this, opening an
+  // archived ticket and hitting Save silently unarchives it (struct
+  // defaults to archived=false), and any edit wipes statusChangedAt,
+  // breaking auto-archive-after-N-days. If the draft explicitly carries
+  // the flag (round-tripped through taskById), honour it.
+  if(!isNew) {
+    const QString originalForLookup = draft.value("_originalId").toString().trimmed();
+    const QString priorId = originalForLookup.isEmpty() ? t.id : originalForLookup;
+    const int existing = m_tasks.indexOfId(priorId);
+    if(existing >= 0) {
+      const Task& prev = m_tasks.items().at(existing);
+      t.archived = draft.contains("archived") ? draft.value("archived").toBool() : prev.archived;
+      t.statusChangedAt = prev.statusChangedAt;
+    }
   }
 
   // ── Rename path ──
@@ -1006,6 +1043,7 @@ QVariantMap AppController::taskById(const QString& id) const {
   m["status"] = t.status;
   m["deadline"] = t.deadline;
   m["branch"] = t.branch;
+  m["archived"] = t.archived;
   return m;
 }
 
@@ -1216,6 +1254,19 @@ void AppController::undoLastDeletion() {
         m_events.setTaskId(pair.first, pair.second);
       }
       emit toast(tr_("task.restored").arg(m_pendingUndo.task.id));
+      break;
+    }
+    case PendingUndo::BulkTasks: {
+      // m_pendingUndo.tasks/rows captured in ascending row order; re-insert
+      // in that same order so earlier indices stay valid.
+      for(int i = 0; i < m_pendingUndo.tasks.size(); ++i) {
+        const int row = qBound(0, m_pendingUndo.rows.value(i, m_tasks.rowCount()), m_tasks.rowCount());
+        m_tasks.insertAt(row, m_pendingUndo.tasks.at(i));
+      }
+      for(const auto& pair : m_pendingUndo.detachedEventIds) {
+        m_events.setTaskId(pair.first, pair.second);
+      }
+      emit toast(tr_("selection.toast.restored").arg(m_pendingUndo.tasks.size()));
       break;
     }
     case PendingUndo::Event: {
@@ -1815,6 +1866,7 @@ void AppController::setActiveProfileId(const QString& id) {
   if(next < 0) {
     return;
   }
+  clearSelection();
   snapshotActiveProfile();
   m_activeProfileId = id;
   applyProfileToModels(m_profiles[next]);
@@ -2300,6 +2352,9 @@ void AppController::seedShortcutCatalog() {
   add("undo", "Ctrl+Z");
   add("search.focus", "Ctrl+F");
   add("quick-capture", "Ctrl+Shift+Space");
+  add("selection.selectAll", "Ctrl+A");
+  add("selection.clearSel", "Esc");
+  add("selection.deleteSel", "Del");
 
   if(!existingOverrides.isEmpty()) {
     QVariantMap asMap;
@@ -2501,6 +2556,189 @@ bool AppController::canTransitionStatus(const QString& taskId, const QString& ne
 void AppController::setArchived(const QString& taskId, bool archived) {
   m_tasks.setArchived(taskId, archived);
   scheduleSave();
+}
+
+// ─────────────────────────────────────────────────── Multi-select ──
+
+bool AppController::isTaskSelected(const QString& id) const {
+  return m_selectedTaskIds.contains(id);
+}
+
+void AppController::rebuildSelectionList_() {
+  // Stable order: by current row in m_tasks. Tasks no longer present (e.g.
+  // deleted while selected) drop out of the list.
+  QVector<QPair<int, QString>> rows;
+  rows.reserve(m_selectedTaskIds.size());
+  for(const QString& id : m_selectedTaskIds) {
+    const int r = m_tasks.indexOfId(id);
+    if(r >= 0) {
+      rows.append({r, id});
+    }
+  }
+  std::sort(rows.begin(), rows.end(), [](const auto& a, const auto& b) {
+    return a.first < b.first;
+  });
+  QSet<QString> live;
+  QStringList list;
+  list.reserve(rows.size());
+  for(const auto& p : rows) {
+    list.append(p.second);
+    live.insert(p.second);
+  }
+  m_selectedTaskIds = live;
+  m_selectedTaskIdsList = list;
+}
+
+void AppController::toggleTaskSelection(const QString& id) {
+  if(id.isEmpty()) {
+    return;
+  }
+  if(m_selectedTaskIds.contains(id)) {
+    m_selectedTaskIds.remove(id);
+  } else {
+    m_selectedTaskIds.insert(id);
+  }
+  rebuildSelectionList_();
+  emit selectedTaskIdsChanged();
+}
+
+void AppController::setTaskSelected(const QString& id, bool selected) {
+  if(id.isEmpty()) {
+    return;
+  }
+  const bool had = m_selectedTaskIds.contains(id);
+  if(selected == had) {
+    return;
+  }
+  if(selected) {
+    m_selectedTaskIds.insert(id);
+  } else {
+    m_selectedTaskIds.remove(id);
+  }
+  rebuildSelectionList_();
+  emit selectedTaskIdsChanged();
+}
+
+void AppController::setSelectedTaskIds(const QStringList& ids) {
+  QSet<QString> next(ids.constBegin(), ids.constEnd());
+  if(next == m_selectedTaskIds) {
+    return;
+  }
+  m_selectedTaskIds = next;
+  rebuildSelectionList_();
+  emit selectedTaskIdsChanged();
+}
+
+void AppController::clearSelection() {
+  if(m_selectedTaskIds.isEmpty() && m_selectedTaskIdsList.isEmpty()) {
+    return;
+  }
+  m_selectedTaskIds.clear();
+  m_selectedTaskIdsList.clear();
+  emit selectedTaskIdsChanged();
+}
+
+void AppController::deleteSelectedTasks() {
+  if(m_selectedTaskIdsList.isEmpty()) {
+    return;
+  }
+
+  // Snapshot tasks + rows in ascending-row order for clean re-insertion.
+  QVector<QPair<int, ::Task>> snap;
+  snap.reserve(m_selectedTaskIdsList.size());
+  for(const QString& id : m_selectedTaskIdsList) {
+    const int row = m_tasks.indexOfId(id);
+    if(row < 0) {
+      continue;
+    }
+    snap.append({row, m_tasks.items().at(row)});
+  }
+  if(snap.isEmpty()) {
+    clearSelection();
+    return;
+  }
+  std::sort(snap.begin(), snap.end(), [](const auto& a, const auto& b) {
+    return a.first < b.first;
+  });
+
+  cancelUndo();
+  m_pendingUndo = {};
+  m_pendingUndo.kind = PendingUndo::BulkTasks;
+  m_pendingUndo.tasks.reserve(snap.size());
+  m_pendingUndo.rows.reserve(snap.size());
+  QSet<QString> ids;
+  for(const auto& p : snap) {
+    m_pendingUndo.rows.append(p.first);
+    m_pendingUndo.tasks.append(p.second);
+    ids.insert(p.second.id);
+  }
+  for(const auto& e : m_events.items()) {
+    if(ids.contains(e.taskId)) {
+      m_pendingUndo.detachedEventIds.append({e.id, e.taskId});
+    }
+  }
+  // Detach events first, then remove tasks. Removal order doesn't matter
+  // for removeById; we walk the snapshot in any direction.
+  for(const QString& id : std::as_const(ids)) {
+    m_events.detachTask(id);
+  }
+  for(const auto& p : snap) {
+    m_tasks.removeById(p.second.id);
+  }
+
+  const int n = snap.size();
+  armUndo(5);
+  emit undoableToast(tr_("selection.toast.deleted").arg(n), 5);
+  clearSelection();
+  scheduleSave();
+}
+
+void AppController::moveSelectedTasksToStatus(const QString& statusId) {
+  if(m_selectedTaskIdsList.isEmpty() || statusId.isEmpty()) {
+    return;
+  }
+  if(statusIndexOf(statusId) < 0) {
+    return;
+  }
+  int moved = 0;
+  for(const QString& id : m_selectedTaskIdsList) {
+    const int row = m_tasks.indexOfId(id);
+    if(row < 0) {
+      continue;
+    }
+    if(m_tasks.items().at(row).status == statusId) {
+      continue;
+    }
+    m_tasks.setStatus(id, statusId);
+    m_tasks.stampStatusChange(id);
+    ++moved;
+  }
+  if(moved > 0) {
+    emit toast(tr_("selection.toast.moved").arg(moved));
+    scheduleSave();
+  }
+}
+
+void AppController::setSelectedTasksArchived(bool archived) {
+  if(m_selectedTaskIdsList.isEmpty()) {
+    return;
+  }
+  int n = 0;
+  for(const QString& id : m_selectedTaskIdsList) {
+    if(m_tasks.indexOfId(id) < 0) {
+      continue;
+    }
+    m_tasks.setArchived(id, archived);
+    ++n;
+  }
+  if(n > 0) {
+    emit toast(tr_(archived ? "selection.toast.archived" : "selection.toast.unarchived").arg(n));
+    // Drop the selection after a bulk archive/restore. Tickets just left
+    // the current view (archive view loses unarchived ones; board loses
+    // archived ones), so keeping the prior selection is confusing.
+    clearSelection();
+    scheduleSave();
+  }
 }
 
 void AppController::notify(const QString& title, const QString& body, const QString& kind) {

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -60,6 +60,10 @@ class AppController : public QObject {
   Q_PROPERTY(QVariantList shortcuts READ shortcuts NOTIFY shortcutsChanged)
   Q_PROPERTY(QStringList blockedStuckIds READ blockedStuckIds NOTIFY blockedStuckChanged)
 
+  // ---- Multi-select ----
+  Q_PROPERTY(QStringList selectedTaskIds READ selectedTaskIds NOTIFY selectedTaskIdsChanged)
+  Q_PROPERTY(int selectionCount READ selectionCount NOTIFY selectedTaskIdsChanged)
+
   // Compile-time flag — true for Debug / RelWithDebInfo builds. QML uses
   // it to surface the developer-only "show unimplemented" toggle.
   Q_PROPERTY(bool debugBuild READ debugBuild CONSTANT)
@@ -189,6 +193,26 @@ class AppController : public QObject {
   Q_INVOKABLE void deleteTask(const QString& id);
   Q_INVOKABLE bool canTransitionStatus(const QString& taskId, const QString& newStatus);
   Q_INVOKABLE void setArchived(const QString& taskId, bool archived);
+
+  // ---- Multi-select API ----
+  QStringList selectedTaskIds() const {
+    return m_selectedTaskIdsList;
+  }
+
+  int selectionCount() const {
+    return m_selectedTaskIdsList.size();
+  }
+
+  Q_INVOKABLE bool isTaskSelected(const QString& id) const;
+  Q_INVOKABLE void toggleTaskSelection(const QString& id);
+  Q_INVOKABLE void setTaskSelected(const QString& id, bool selected);
+  Q_INVOKABLE void setSelectedTaskIds(const QStringList& ids);
+  Q_INVOKABLE void clearSelection();
+
+  // Bulk ops — operate on the current selection set.
+  Q_INVOKABLE void deleteSelectedTasks();
+  Q_INVOKABLE void moveSelectedTasksToStatus(const QString& statusId);
+  Q_INVOKABLE void setSelectedTasksArchived(bool archived);
 
   QStringList blockedStuckIds() const {
     return m_blockedStuckIds.values();
@@ -369,6 +393,7 @@ class AppController : public QObject {
   void undoableToast(const QString& message, int seconds);
   void focusedGitChanged();
   void openTaskRequested(const QString& id);
+  void selectedTaskIdsChanged();
 
  private slots:
   void runAutomation();
@@ -435,7 +460,7 @@ class AppController : public QObject {
 
   // Undo machinery
   struct PendingUndo {
-    enum Kind { None, Task, Event, Person, Status, Profile } kind = None;
+    enum Kind { None, Task, BulkTasks, Event, Person, Status, Profile } kind = None;
 
     // payload — only the field matching `kind` is populated
     ::Task task;
@@ -444,6 +469,10 @@ class AppController : public QObject {
     QVariantMap status;
     ::Profile profile;
     int row = -1;
+    // Bulk-task delete — every task and its original row index. Ordered
+    // by ascending row so re-insertion in the same order is safe.
+    QVector<::Task> tasks;
+    QVector<int> rows;
     // when a task is deleted, events lose their taskId — record what to restore
     QVector<QPair<QString, QString>> detachedEventIds;  // (eventId, originalTaskId)
     // when a status is deleted, tasks get re-homed — record what to restore
@@ -454,6 +483,11 @@ class AppController : public QObject {
   QTimer* m_undoTimer = nullptr;
   void armUndo(int seconds);
   void cancelUndo();
+
+  // Selection state
+  QSet<QString> m_selectedTaskIds;
+  QStringList m_selectedTaskIdsList;  // ordered cache for QML
+  void rebuildSelectionList_();
 
   std::unique_ptr<heap::chrono::ChronoParser> m_chrono;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 
 # Qt6::Test (provides QSignalSpy) is needed by heap_notify_tests even when
 # this file is included as a subdirectory of the main project.
-find_package(Qt6 6.2 REQUIRED COMPONENTS Core Test)
+find_package(Qt6 6.2 REQUIRED COMPONENTS Core Gui Widgets Qml Test)
 
 include(FetchContent)
 
@@ -103,3 +103,62 @@ target_link_libraries(heap_notify_tests PRIVATE
 )
 
 add_test(NAME heap_notify_tests COMMAND heap_notify_tests)
+
+# ─── Selection (AppController multi-select) tests ───
+# Cover the multi-select state machine and bulk ops on AppController:
+# toggle/set/clear/selectAll, bulk delete with undo restoration, bulk
+# move/archive, and clearSelection on view/profile change.
+#
+# Links the same sources as the main `heap` target *minus* QML registration
+# (no Qt6::Quick) — AppController's own implementation only needs Core/Gui/
+# Widgets/Qml + Test. Uses offscreen QGuiApplication + AppDataLocation test
+# mode so it runs headless and never touches the user's real state file.
+set(HEAP_SELECTION_SOURCES
+        test_selection.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/SampleData.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/chrono/ChronoTokenizer.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/chrono/ChronoLocale_en.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/chrono/ChronoLocale_ru.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/chrono/ChronoParser.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/BranchTaskMatcher.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/GitWatcher.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notify/NotificationCenter.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notify/NotificationCenter_tray.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notify/NotificationCenter.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/text/TaskTextUtils.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/GitWatcher.h
+)
+if (UNIX AND NOT APPLE)
+    list(APPEND HEAP_SELECTION_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/notify/NotificationCenter_linux.cpp
+    )
+endif ()
+
+add_executable(heap_selection_tests ${HEAP_SELECTION_SOURCES})
+set_target_properties(heap_selection_tests PROPERTIES AUTOMOC ON)
+
+target_include_directories(heap_selection_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src
+)
+
+target_link_libraries(heap_selection_tests PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Widgets
+        Qt6::Qml
+        Qt6::Test
+        GTest::gtest
+        GTest::gtest_main
+)
+if (UNIX AND NOT APPLE)
+    find_package(Qt6 QUIET COMPONENTS DBus)
+    if (TARGET Qt6::DBus)
+        target_link_libraries(heap_selection_tests PRIVATE Qt6::DBus)
+    endif ()
+endif ()
+
+add_test(NAME heap_selection_tests COMMAND heap_selection_tests)

--- a/tests/test_selection.cpp
+++ b/tests/test_selection.cpp
@@ -1,0 +1,351 @@
+// Multi-select coverage for AppController. Verifies the selection state
+// machine (toggle/set/clear/selectAll), bulk delete + undo restoration,
+// bulk move + archive, and the cross-cutting clears triggered by view /
+// profile switches.
+//
+// Runs headless: AppController owns timers, a NotificationCenter (tray
+// fallback on Windows), a GitWatcher and persistence to AppDataLocation.
+// We swap AppDataLocation to a per-process temp dir via QStandardPaths
+// test mode, and force the offscreen QPA platform so QSystemTrayIcon /
+// QClipboard construction stays headless.
+
+#include "AppController.h"
+#include "Models.h"
+
+#include <QApplication>
+#include <QDir>
+#include <QFile>
+#include <QSignalSpy>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QVector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+Task makeTask(const QString& id, const QString& status = QStringLiteral("todo"), const QString& priority = QStringLiteral("P2")) {
+  Task t;
+  t.id = id;
+  t.title = id + QStringLiteral(" title");
+  t.priority = priority;
+  t.status = status;
+  return t;
+}
+
+// Replace whatever the freshly-constructed Example profile seeded with a
+// known three-task set, all in the "todo" column. Returns the ids in row
+// order so tests can assert against deterministic indices.
+QStringList seedTasks(AppController& app, int n) {
+  QVector<Task> items;
+  QStringList ids;
+  for(int i = 0; i < n; ++i) {
+    const QString id = QStringLiteral("T-%1").arg(i + 1);
+    items.append(makeTask(id));
+    ids.append(id);
+  }
+  app.tasks()->reset(items);
+  return ids;
+}
+
+}  // namespace
+
+class SelectionTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    app_ = std::make_unique<AppController>();
+    // Start every test with a clean slate — replaces the "Example"
+    // profile's seeded tasks with whatever the test sets up.
+    app_->tasks()->reset({});
+  }
+
+  void TearDown() override {
+    app_.reset();
+  }
+
+  std::unique_ptr<AppController> app_;
+};
+
+// ─── selection mutators ───────────────────────────────────────────────
+
+TEST_F(SelectionTest, StartsEmpty) {
+  EXPECT_EQ(app_->selectionCount(), 0);
+  EXPECT_TRUE(app_->selectedTaskIds().isEmpty());
+  EXPECT_FALSE(app_->isTaskSelected("T-1"));
+}
+
+TEST_F(SelectionTest, ToggleAddsAndRemoves) {
+  seedTasks(*app_, 3);
+  QSignalSpy spy(app_.get(), &AppController::selectedTaskIdsChanged);
+
+  app_->toggleTaskSelection("T-2");
+  EXPECT_TRUE(app_->isTaskSelected("T-2"));
+  EXPECT_EQ(app_->selectionCount(), 1);
+  EXPECT_EQ(spy.count(), 1);
+
+  app_->toggleTaskSelection("T-2");
+  EXPECT_FALSE(app_->isTaskSelected("T-2"));
+  EXPECT_EQ(app_->selectionCount(), 0);
+  EXPECT_EQ(spy.count(), 2);
+}
+
+TEST_F(SelectionTest, SetTaskSelectedIsIdempotent) {
+  seedTasks(*app_, 2);
+  QSignalSpy spy(app_.get(), &AppController::selectedTaskIdsChanged);
+
+  app_->setTaskSelected("T-1", true);
+  app_->setTaskSelected("T-1", true);  // no-op — already in set
+  EXPECT_EQ(spy.count(), 1);
+  EXPECT_EQ(app_->selectionCount(), 1);
+
+  app_->setTaskSelected("T-1", false);
+  app_->setTaskSelected("T-1", false);  // no-op
+  EXPECT_EQ(spy.count(), 2);
+  EXPECT_EQ(app_->selectionCount(), 0);
+}
+
+TEST_F(SelectionTest, SetSelectedTaskIdsReplacesAndOrdersByRow) {
+  seedTasks(*app_, 4);
+  // Pass ids in reverse — controller stores them ordered by current row.
+  app_->setSelectedTaskIds({"T-3", "T-1", "T-4"});
+  EXPECT_EQ(app_->selectionCount(), 3);
+  const QStringList expected = {"T-1", "T-3", "T-4"};
+  EXPECT_EQ(app_->selectedTaskIds(), expected);
+}
+
+TEST_F(SelectionTest, SetSelectedTaskIdsDropsUnknownIds) {
+  seedTasks(*app_, 2);
+  app_->setSelectedTaskIds({"T-1", "ghost", "T-2"});
+  // "ghost" doesn't exist in the model; rebuildSelectionList_() prunes it.
+  EXPECT_EQ(app_->selectionCount(), 2);
+  EXPECT_FALSE(app_->isTaskSelected("ghost"));
+}
+
+TEST_F(SelectionTest, ClearSelectionEmptiesAndSignalsOnce) {
+  seedTasks(*app_, 2);
+  app_->setSelectedTaskIds({"T-1", "T-2"});
+
+  QSignalSpy spy(app_.get(), &AppController::selectedTaskIdsChanged);
+  app_->clearSelection();
+  EXPECT_EQ(spy.count(), 1);
+  EXPECT_EQ(app_->selectionCount(), 0);
+
+  // Idempotent — second clear emits nothing.
+  app_->clearSelection();
+  EXPECT_EQ(spy.count(), 1);
+}
+
+// ─── bulk delete + undo ───────────────────────────────────────────────
+
+TEST_F(SelectionTest, DeleteSelectedRemovesAndArmsUndo) {
+  seedTasks(*app_, 4);
+  app_->setSelectedTaskIds({"T-1", "T-3"});
+  ASSERT_EQ(app_->selectionCount(), 2);
+
+  app_->deleteSelectedTasks();
+
+  EXPECT_EQ(app_->tasks()->rowCount(), 2);
+  EXPECT_EQ(app_->tasks()->indexOfId("T-1"), -1);
+  EXPECT_EQ(app_->tasks()->indexOfId("T-3"), -1);
+  EXPECT_GE(app_->tasks()->indexOfId("T-2"), 0);
+  EXPECT_GE(app_->tasks()->indexOfId("T-4"), 0);
+  EXPECT_EQ(app_->selectionCount(), 0);
+  EXPECT_TRUE(app_->hasPendingUndo());
+}
+
+TEST_F(SelectionTest, UndoRestoresBulkDeleteToOriginalRows) {
+  seedTasks(*app_, 4);
+  app_->setSelectedTaskIds({"T-1", "T-3"});
+  app_->deleteSelectedTasks();
+  ASSERT_EQ(app_->tasks()->rowCount(), 2);
+
+  app_->undoLastDeletion();
+
+  // All four are back and in their original rows.
+  ASSERT_EQ(app_->tasks()->rowCount(), 4);
+  EXPECT_EQ(app_->tasks()->indexOfId("T-1"), 0);
+  EXPECT_EQ(app_->tasks()->indexOfId("T-2"), 1);
+  EXPECT_EQ(app_->tasks()->indexOfId("T-3"), 2);
+  EXPECT_EQ(app_->tasks()->indexOfId("T-4"), 3);
+  EXPECT_FALSE(app_->hasPendingUndo());
+}
+
+TEST_F(SelectionTest, DeleteSelectedOnEmptyIsNoOp) {
+  seedTasks(*app_, 2);
+  ASSERT_FALSE(app_->hasPendingUndo());
+
+  app_->deleteSelectedTasks();
+
+  EXPECT_EQ(app_->tasks()->rowCount(), 2);
+  EXPECT_FALSE(app_->hasPendingUndo());
+}
+
+// ─── bulk move ────────────────────────────────────────────────────────
+
+TEST_F(SelectionTest, MoveSelectedToStatusRewritesStatus) {
+  seedTasks(*app_, 3);
+  // "prog" is a column id from the default seeded statuses.
+  app_->setSelectedTaskIds({"T-1", "T-3"});
+
+  app_->moveSelectedTasksToStatus("prog");
+
+  EXPECT_EQ(app_->taskById("T-1").value("status").toString(), QStringLiteral("prog"));
+  EXPECT_EQ(app_->taskById("T-2").value("status").toString(), QStringLiteral("todo"));
+  EXPECT_EQ(app_->taskById("T-3").value("status").toString(), QStringLiteral("prog"));
+}
+
+TEST_F(SelectionTest, MoveSelectedToUnknownStatusIsNoOp) {
+  seedTasks(*app_, 2);
+  app_->setSelectedTaskIds({"T-1", "T-2"});
+
+  app_->moveSelectedTasksToStatus("not-a-column");
+
+  EXPECT_EQ(app_->taskById("T-1").value("status").toString(), QStringLiteral("todo"));
+  EXPECT_EQ(app_->taskById("T-2").value("status").toString(), QStringLiteral("todo"));
+}
+
+// ─── bulk archive ─────────────────────────────────────────────────────
+
+TEST_F(SelectionTest, ArchiveSelectedTogglesFlag) {
+  seedTasks(*app_, 3);
+  app_->setSelectedTaskIds({"T-1", "T-2"});
+
+  auto archivedAt = [this](const QString& id) {
+    const int row = app_->tasks()->indexOfId(id);
+    return app_->tasks()->items().at(row).archived;
+  };
+
+  app_->setSelectedTasksArchived(true);
+
+  EXPECT_TRUE(archivedAt("T-1"));
+  EXPECT_TRUE(archivedAt("T-2"));
+  EXPECT_FALSE(archivedAt("T-3"));
+  // Bulk archive empties the selection (rows just left the active view).
+  EXPECT_EQ(app_->selectionCount(), 0);
+
+  // Re-select to test the inverse — bulk unarchive also clears.
+  app_->setSelectedTaskIds({"T-1", "T-2"});
+  app_->setSelectedTasksArchived(false);
+  EXPECT_FALSE(archivedAt("T-1"));
+  EXPECT_FALSE(archivedAt("T-2"));
+  EXPECT_EQ(app_->selectionCount(), 0);
+}
+
+// ─── cross-cutting clears ─────────────────────────────────────────────
+
+TEST_F(SelectionTest, SwitchingViewClearsSelection) {
+  seedTasks(*app_, 2);
+  app_->setSelectedTaskIds({"T-1"});
+  ASSERT_EQ(app_->selectionCount(), 1);
+
+  app_->setCurrentView("timeline");
+
+  EXPECT_EQ(app_->selectionCount(), 0);
+  EXPECT_EQ(app_->currentView(), QStringLiteral("timeline"));
+}
+
+TEST_F(SelectionTest, SwitchingToSameViewDoesNotClear) {
+  seedTasks(*app_, 1);
+  // Normalize: loadStateOnStart() may have restored currentView from a
+  // stale state file written by a prior test run. Pin it to "board"
+  // BEFORE selecting so the assertion below tests the same-value path.
+  app_->setCurrentView("board");
+  app_->setSelectedTaskIds({"T-1"});
+  ASSERT_EQ(app_->selectionCount(), 1);
+
+  app_->setCurrentView("board");  // no-op — selection must survive
+  EXPECT_EQ(app_->selectionCount(), 1);
+}
+
+TEST_F(SelectionTest, SaveTaskPreservesArchivedFlag) {
+  // Reproduces the regression where opening an archived ticket in the
+  // editor and hitting Save silently unarchived it (struct default
+  // archived=false leaked into upsert).
+  QVector<Task> items;
+  Task t = makeTask("T-1");
+  t.title = "kept";
+  t.deadline = QDate(2030, 5, 22);
+  t.archived = true;
+  items.append(t);
+  app_->tasks()->reset(items);
+
+  // Round-trip through editor: read via taskById, save unchanged.
+  QVariantMap draft = app_->taskById("T-1");
+  ASSERT_TRUE(draft.value("archived").toBool());
+  draft["_isNew"] = false;
+  draft["_originalId"] = QStringLiteral("T-1");
+  app_->saveTask(draft);
+
+  const int row = app_->tasks()->indexOfId("T-1");
+  ASSERT_GE(row, 0);
+  const Task& after = app_->tasks()->items().at(row);
+  EXPECT_TRUE(after.archived);
+  EXPECT_EQ(after.deadline, QDate(2030, 5, 22));
+  EXPECT_EQ(after.title, QStringLiteral("kept"));
+}
+
+TEST_F(SelectionTest, SaveTaskOmittingArchivedKeepsPriorState) {
+  // Older drafts (pre-taskById-archived) won't carry the field at all.
+  // saveTask must still preserve whatever was on the existing row.
+  Task t = makeTask("T-1");
+  t.archived = true;
+  app_->tasks()->reset({t});
+
+  QVariantMap draft;
+  draft["_isNew"] = false;
+  draft["_originalId"] = QStringLiteral("T-1");
+  draft["id"] = QStringLiteral("T-1");
+  draft["title"] = QStringLiteral("edited");
+  draft["priority"] = QStringLiteral("P2");
+  draft["status"] = QStringLiteral("todo");
+  // intentionally no "archived" key
+  app_->saveTask(draft);
+
+  const int row = app_->tasks()->indexOfId("T-1");
+  ASSERT_GE(row, 0);
+  EXPECT_TRUE(app_->tasks()->items().at(row).archived);
+}
+
+TEST_F(SelectionTest, ShortcutCatalogIncludesSelectionEntries) {
+  QStringList ids;
+  for(const QVariant& v : app_->shortcuts()) {
+    ids.append(v.toMap().value("id").toString());
+  }
+  EXPECT_TRUE(ids.contains(QStringLiteral("selection.selectAll")));
+  EXPECT_TRUE(ids.contains(QStringLiteral("selection.clearSel")));
+  EXPECT_TRUE(ids.contains(QStringLiteral("selection.deleteSel")));
+}
+
+// ─── headless boot ────────────────────────────────────────────────────
+
+int main(int argc, char** argv) {
+  // Headless QPA — keeps QSystemTrayIcon / QClipboard from touching the
+  // host display. Must run before QApplication is constructed.
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+
+  // Isolate state.json / backups under the QStandardPaths test-mode dir
+  // so the tests never read or overwrite the user's real AppDataLocation.
+  // On Windows setTestModeEnabled() is honoured natively; on Linux the
+  // XDG vars below pin the location to a per-process temp dir.
+  QStandardPaths::setTestModeEnabled(true);
+  QTemporaryDir scratch;
+  scratch.setAutoRemove(true);
+  qputenv("XDG_CONFIG_HOME", scratch.path().toUtf8());
+  qputenv("XDG_DATA_HOME", scratch.path().toUtf8());
+
+  QApplication qapp(argc, argv);
+
+  // Test-mode AppDataLocation can still hold leftovers from a previous
+  // run on the same machine (Windows: %APPDATA%/QtProjectTest/...). Wipe
+  // the state.json / backups dir so AppController boots from a clean
+  // slate every test process — otherwise loadStateOnStart() can revive
+  // a stale currentView / activeProfileId from another suite.
+  const QString appData = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+  if(!appData.isEmpty()) {
+    QFile::remove(appData + QStringLiteral("/state.json"));
+    QDir(appData + QStringLiteral("/backups")).removeRecursively();
+  }
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

<!-- One or two sentences: what changes, why now. Link tickets / issues. -->

## Test plan

- [ ] `cmake --build build --target heap` succeeds locally
- [ ] `ctest --test-dir build --output-on-failure` is green
- [ ] Manual UI smoke if QML / interaction was touched
- [ ] New behaviour covered by a unit test (or explicit reason why not)

## Notes for reviewer

<!--
Anything that needs context: trade-offs, follow-ups, intentionally skipped
checks, screenshots of UI changes, etc. Delete if empty.
-->
