### PR TITLE
feat(ui): wire dead Blocked & Code Review sidebar buttons (HEAP-69)

### DIFF
--- a/qml/KanbanBoard.qml
+++ b/qml/KanbanBoard.qml
@@ -23,6 +23,41 @@ Item {
         function onSelectedTaskIdsChanged() {
             if (AppController.selectionCount === 0) root.shiftAnchorId = "";
         }
+
+        // Sidebar Blocked / Code Review buttons jump the board to a column.
+        function onFocusedStatusChanged() {
+            if (AppController.focusedStatus.length > 0) root.focusColumn(AppController.focusedStatus);
+        }
+    }
+
+    // ── Column focus (sidebar Blocked / Code Review buttons) ──────────
+    // Scroll the target status column into view and briefly highlight it.
+    property string _focusPulseStatus: ""
+    NumberAnimation {
+        id: colScrollAnim
+        target: hscroll; property: "contentX"
+        duration: Theme.scaledMs(260); easing.type: Easing.OutCubic
+    }
+    Timer { id: focusPulseTimer; interval: 1100; onTriggered: root._focusPulseStatus = "" }
+
+    function focusColumn(statusId) {
+        const st = AppController.statuses;
+        let idx = -1;
+        for (let i = 0; i < st.length; ++i) { if (st[i].id === statusId) { idx = i; break; } }
+        if (idx < 0) return;
+        const colW = 280 + rowL.spacing;                 // column width + Row spacing
+        const maxX = Math.max(0, hscroll.contentWidth - hscroll.width);
+        colScrollAnim.to = Math.max(0, Math.min(idx * colW, maxX));
+        colScrollAnim.restart();
+        root._focusPulseStatus = statusId;
+        focusPulseTimer.restart();
+    }
+
+    // A focus requested from another view fires focusedStatusChanged before this
+    // board exists; pick it up once the board is created and laid out.
+    Component.onCompleted: {
+        if (AppController.focusedStatus && AppController.focusedStatus.length > 0)
+            Qt.callLater(function() { root.focusColumn(AppController.focusedStatus); });
     }
 
     // Walk every column's TaskCard repeater, collect ids of currently
@@ -156,14 +191,18 @@ Item {
                     property bool renaming: false
                     readonly property bool isFirst: index === 0
                     readonly property bool isLast:  index === AppController.statuses.length - 1
+                    // Briefly emphasised when the sidebar Blocked / Code Review
+                    // button jumps focus to this column.
+                    readonly property bool focusPulse: root._focusPulseStatus === col.statusId
 
                     width: 280
                     height: rowL.height
                     radius: Theme.radius
                     color: Theme.panel
-                    border.color: dragOver ? Theme.accent : Theme.border
-                    border.width: 1
+                    border.color: (dragOver || focusPulse) ? Theme.accent : Theme.border
+                    border.width: focusPulse ? 2 : 1
                     clip: true
+                    Behavior on border.color { ColorAnimation { duration: Theme.scaledMs(180) } }
 
                     ColumnLayout {
                         anchors.fill: parent

--- a/qml/SideRail.qml
+++ b/qml/SideRail.qml
@@ -61,11 +61,15 @@ Rectangle {
         RailBtn {
             glyph: "⊘"; tooltipText: I18n.t("siderail.tip.blocked")
                    countText: root._blockedCount > 0 ? root._blockedCount : ""
-                   countColor: Theme.p0 }
+                   countColor: Theme.p0
+                   active: AppController.currentView === "board" && AppController.focusedStatus === "blocked"
+                   onActivated: AppController.focusStatusColumn("blocked") }
         RailBtn {
             glyph: "⎇"; tooltipText: I18n.t("siderail.tip.review")
                    countText: root._reviewCount > 0 ? root._reviewCount : ""
-                   countColor: Theme.stReview }
+                   countColor: Theme.stReview
+                   active: AppController.currentView === "board" && AppController.focusedStatus === "review"
+                   onActivated: AppController.focusStatusColumn("review") }
 
         Rectangle { Layout.alignment: Qt.AlignHCenter; width: 24; height: 1; color: Theme.border; Layout.topMargin: 6; Layout.bottomMargin: 6 }
 

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -455,6 +455,17 @@ void AppController::setCurrentView(const QString& v) {
   scheduleSave();
 }
 
+void AppController::focusStatusColumn(const QString& statusId) {
+  // Sidebar Blocked / Code Review entry point: make sure the Board is the
+  // active view, then flag the target status column so KanbanBoard can scroll
+  // to and briefly highlight it. focusedStatus is transient UI state (not
+  // persisted). Emitted unconditionally so a repeat click re-triggers the
+  // scroll/pulse even when the same column is already focused.
+  setCurrentView(QStringLiteral("board"));
+  m_focusedStatus = statusId;
+  emit focusedStatusChanged();
+}
+
 void AppController::setWorkdayStart(int v) {
   v = qBound(0, v, 23);
   if(v >= m_workdayEnd) {

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -48,6 +48,7 @@ class AppController : public QObject {
   Q_PROPERTY(QString density READ density WRITE setDensity NOTIFY densityChanged)
   Q_PROPERTY(QString language READ language WRITE setLanguage NOTIFY languageChanged)
   Q_PROPERTY(QString currentView READ currentView WRITE setCurrentView NOTIFY currentViewChanged)
+  Q_PROPERTY(QString focusedStatus READ focusedStatus NOTIFY focusedStatusChanged)
 
   Q_PROPERTY(int workdayStart READ workdayStart WRITE setWorkdayStart NOTIFY workdayChanged)
   Q_PROPERTY(int workdayEnd READ workdayEnd WRITE setWorkdayEnd NOTIFY workdayChanged)
@@ -152,6 +153,13 @@ class AppController : public QObject {
   }
 
   void setCurrentView(const QString& v);
+
+  QString focusedStatus() const {
+    return m_focusedStatus;
+  }
+
+  // Jump the Board to a specific status column (sidebar Blocked / Code Review).
+  Q_INVOKABLE void focusStatusColumn(const QString& statusId);
 
   int workdayStart() const {
     return m_workdayStart;
@@ -425,6 +433,7 @@ class AppController : public QObject {
   void densityChanged();
   void languageChanged();
   void currentViewChanged();
+  void focusedStatusChanged();
   void workdayChanged();
   void crumbProjectChanged();
   void crumbUserChanged();
@@ -466,6 +475,7 @@ class AppController : public QObject {
   QString m_density = "comfy";
   QString m_language = "en";
   QString m_currentView = "board";
+  QString m_focusedStatus;
   int m_workdayStart = 9;
   int m_workdayEnd = 19;
   QString m_crumbProject = "eNB-core";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -586,6 +586,67 @@ endif ()
 
 add_test(NAME heap_undo_tests COMMAND heap_undo_tests)
 
+# ─── View navigation / status-column focus tests ───
+# Cover AppController::focusStatusColumn — the sidebar Blocked / Code Review
+# entry point (HEAP-69): switches to the board view and records the focused
+# status; plus countByStatus which feeds the sidebar badges. Same headless boot
+# as the other AppController suites.
+set(HEAP_VIEW_SOURCES
+        test_view.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/SampleData.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/chrono/ChronoTokenizer.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/chrono/ChronoLocale_en.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/chrono/ChronoLocale_ru.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/chrono/ChronoParser.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/BranchTaskMatcher.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/GitWatcher.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notify/NotificationCenter.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notify/NotificationCenter_tray.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notify/NotificationCenter.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/text/TaskTextUtils.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/GitWatcher.h
+)
+if (WIN32)
+    list(APPEND HEAP_VIEW_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_win.cpp
+    )
+endif ()
+if (UNIX AND NOT APPLE)
+    list(APPEND HEAP_VIEW_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/notify/NotificationCenter_linux.cpp
+    )
+endif ()
+
+add_executable(heap_view_tests ${HEAP_VIEW_SOURCES})
+set_target_properties(heap_view_tests PROPERTIES AUTOMOC ON)
+
+target_include_directories(heap_view_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src
+)
+
+target_link_libraries(heap_view_tests PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Widgets
+        Qt6::Qml
+        Qt6::Test
+        GTest::gtest
+)
+if (UNIX AND NOT APPLE)
+    find_package(Qt6 QUIET COMPONENTS DBus)
+    if (TARGET Qt6::DBus)
+        target_link_libraries(heap_view_tests PRIVATE Qt6::DBus)
+    endif ()
+endif ()
+
+add_test(NAME heap_view_tests COMMAND heap_view_tests)
+
 # ─── QML (Qt Quick Test) tests ───
 # Drive the QML layer directly instead of only the C++ backend. Currently
 # covers the mention-commit helper (qml/Mention.js) — caret placement after an

--- a/tests/test_view.cpp
+++ b/tests/test_view.cpp
@@ -1,0 +1,97 @@
+// View navigation + status-column focus (HEAP-69).
+//
+// The sidebar Blocked / Code Review buttons call focusStatusColumn(id): it must
+// switch the active view to "board" and record the focused status so the board
+// can scroll to + highlight that column. Also covers countByStatus, which feeds
+// the sidebar count badges.
+//
+// Headless via offscreen QPA + AppDataLocation test mode.
+
+#include "AppController.h"
+#include "Models.h"
+
+#include <QApplication>
+#include <QSignalSpy>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+Task mk(const QString& id, const QString& status) {
+  Task t;
+  t.id = id;
+  t.title = id;
+  t.priority = QStringLiteral("P2");
+  t.status = status;
+  return t;
+}
+
+}  // namespace
+
+class ViewFocusTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    app_ = std::make_unique<AppController>();
+    app_->tasks()->reset({
+        mk(QStringLiteral("A"), QStringLiteral("todo")),
+        mk(QStringLiteral("B"), QStringLiteral("blocked")),
+        mk(QStringLiteral("C"), QStringLiteral("blocked")),
+        mk(QStringLiteral("D"), QStringLiteral("review")),
+    });
+  }
+  void TearDown() override {
+    app_.reset();
+  }
+  std::unique_ptr<AppController> app_;
+};
+
+TEST_F(ViewFocusTest, FocusStatusColumnSwitchesToBoardAndRecordsStatus) {
+  app_->setCurrentView(QStringLiteral("notes"));
+  ASSERT_EQ(app_->currentView(), QStringLiteral("notes"));
+
+  QSignalSpy viewSpy(app_.get(), &AppController::currentViewChanged);
+  QSignalSpy focusSpy(app_.get(), &AppController::focusedStatusChanged);
+
+  app_->focusStatusColumn(QStringLiteral("blocked"));
+
+  EXPECT_EQ(app_->currentView(), QStringLiteral("board"));
+  EXPECT_EQ(app_->focusedStatus(), QStringLiteral("blocked"));
+  EXPECT_EQ(viewSpy.count(), 1);   // notes -> board
+  EXPECT_GE(focusSpy.count(), 1);
+}
+
+TEST_F(ViewFocusTest, RepeatFocusOnSameStatusReEmits) {
+  app_->focusStatusColumn(QStringLiteral("review"));  // from default "board"
+  EXPECT_EQ(app_->currentView(), QStringLiteral("board"));
+  EXPECT_EQ(app_->focusedStatus(), QStringLiteral("review"));
+
+  // A repeat click on the already-focused status must re-emit so the board
+  // re-runs its scroll/pulse.
+  QSignalSpy focusSpy(app_.get(), &AppController::focusedStatusChanged);
+  app_->focusStatusColumn(QStringLiteral("review"));
+  EXPECT_EQ(focusSpy.count(), 1);
+  EXPECT_EQ(app_->focusedStatus(), QStringLiteral("review"));
+}
+
+TEST_F(ViewFocusTest, CountByStatusFeedsBadges) {
+  EXPECT_EQ(app_->countByStatus(QStringLiteral("blocked")), 2);
+  EXPECT_EQ(app_->countByStatus(QStringLiteral("review")), 1);
+  EXPECT_EQ(app_->countByStatus(QStringLiteral("todo")), 1);
+  EXPECT_EQ(app_->countByStatus(QStringLiteral("nonexistent")), 0);
+}
+
+int main(int argc, char** argv) {
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+  QStandardPaths::setTestModeEnabled(true);
+  QTemporaryDir scratch;
+  scratch.setAutoRemove(true);
+  qputenv("XDG_CONFIG_HOME", scratch.path().toUtf8());
+  qputenv("XDG_DATA_HOME", scratch.path().toUtf8());
+
+  QApplication qapp(argc, argv);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The ⊘ Blocked and ⎇ Code Review rail buttons had a count badge but no click action. Now they jump the Board to that status column (scroll + brief highlight) via a new `AppController.focusStatusColumn(id)` (sets `currentView=board` + transient `focusedStatus`).

- SideRail: buttons wired + reflect focused column as active.
- KanbanBoard: `focusColumn()` scrolls + pulses; picks up cross-view focus on load.
- New `heap_view_tests` C++ suite. **15/15 ctest green**, offscreen smoke clean.