### PR TITLE
test(ui): component test harness — extract heap_core lib, test real QML (HEAP-49)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,12 @@ find_package(Qt6 6.2 QUIET OPTIONAL_COMPONENTS Svg)
 
 qt_standard_project_setup(REQUIRES 6.4)
 
-qt_add_executable(heap WIN32
-    src/main.cpp
+# ── Core library: all app logic + the TodoCpp QML module ──────────
+# Extracted from the heap executable so the Qt Quick Test harness (tests/) can
+# link the same C++ types + QML module and instantiate real components
+# (SideRail, KanbanBoard, FilterBar, …) against a live AppController. The heap
+# executable below becomes a thin shell that just loads Main.qml.
+qt_add_library(heap_core STATIC
     src/AppController.cpp
     src/Models.cpp
     src/SampleData.cpp
@@ -68,7 +72,6 @@ qt_add_executable(heap WIN32
     src/platform/GlobalHotkey.cpp
     $<$<PLATFORM_ID:Linux>:${CMAKE_SOURCE_DIR}/src/notify/NotificationCenter_linux.cpp>
         $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/src/platform/GlobalHotkey_win.cpp>
-        $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/design/brand-export/icon/heap-icon.rc>
 )
 
 set_source_files_properties(qml/Theme.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)
@@ -77,7 +80,7 @@ set_source_files_properties(qml/I18n.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)
 
 # URI stays "TodoCpp" so existing `import TodoCpp` statements throughout qml/
 # don't have to be touched. The user-facing app name is heap.
-qt_add_qml_module(heap
+qt_add_qml_module(heap_core
     URI TodoCpp
     VERSION 1.0
     RESOURCE_PREFIX "/qt/qml"
@@ -138,8 +141,8 @@ qt_add_qml_module(heap
         src/platform/GlobalHotkey.h
 )
 
-target_include_directories(heap PRIVATE src)
-target_link_libraries(heap PRIVATE
+target_include_directories(heap_core PUBLIC src)
+target_link_libraries(heap_core PUBLIC
     Qt6::Core
     Qt6::Gui
     Qt6::Qml
@@ -148,20 +151,31 @@ target_link_libraries(heap PRIVATE
     Qt6::Widgets
 )
 if(UNIX AND NOT APPLE)
-    target_link_libraries(heap PRIVATE Qt6::DBus)
+    target_link_libraries(heap_core PUBLIC Qt6::DBus)
 endif()
 
 # Compile-time flag that AppController exposes as a CONSTANT Q_PROPERTY so QML
 # can adapt the Settings UI: unimplemented sections are shown disabled in
 # Release, and the "show unimplemented" toggle is added in Debug only.
-target_compile_definitions(heap PRIVATE
+target_compile_definitions(heap_core PRIVATE
     $<$<CONFIG:Debug>:HEAP_DEBUG_BUILD=1>
     $<$<CONFIG:RelWithDebInfo>:HEAP_DEBUG_BUILD=1>
 )
 if (TARGET Qt6::Svg)
-    target_link_libraries(heap PRIVATE Qt6::Svg)
-    target_compile_definitions(heap PRIVATE HEAP_HAS_SVG=1)
+    target_link_libraries(heap_core PUBLIC Qt6::Svg)
+    target_compile_definitions(heap_core PRIVATE HEAP_HAS_SVG=1)
 endif()
+
+# ── Application executable — thin shell that loads Main.qml from heap_core ──
+qt_add_executable(heap WIN32
+    src/main.cpp
+    $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/design/brand-export/icon/heap-icon.rc>
+)
+# Link the QML module plugin too: for a statically-linked qml module the plugin
+# carries the type-registration + qmlcache resource init. Linking only the
+# backing library lets the linker drop those symbols, so `import TodoCpp` (and
+# Main.qml) fail to load at runtime. Linking the plugin force-references them.
+target_link_libraries(heap PRIVATE heap_core heap_coreplugin)
 
 # ── Brand assets (heap. logo + app icon, exported by design/brand-export) ──
 qt_add_resources(heap "brand"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -656,6 +656,8 @@ add_test(NAME heap_view_tests COMMAND heap_view_tests)
 find_package(Qt6 REQUIRED COMPONENTS QuickTest Quick QuickControls2)
 
 add_executable(heap_qml_tests quick_test_main.cpp)
+# AUTOMOC for the Setup QObject in quick_test_main.cpp (has Q_OBJECT).
+set_target_properties(heap_qml_tests PROPERTIES AUTOMOC ON)
 
 # QUICK_TEST_MAIN scans this directory for tst_*.qml at runtime. Baking it as a
 # compile definition is the canonical wiring (more reliable than -input across
@@ -663,12 +665,12 @@ add_executable(heap_qml_tests quick_test_main.cpp)
 target_compile_definitions(heap_qml_tests PRIVATE
         QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/qml")
 
+# Link the app's core library + its QML module plugin so the tests can
+# `import TodoCpp` and instantiate real components (SideRail, KanbanBoard,
+# FilterBar, …) against a live AppController. heap_core PUBLIC-links Quick etc.
 target_link_libraries(heap_qml_tests PRIVATE
-        Qt6::Core
-        Qt6::Gui
-        Qt6::Qml
-        Qt6::Quick
-        Qt6::QuickControls2
+        heap_core
+        heap_coreplugin
         Qt6::QuickTest
 )
 

--- a/tests/qml/tst_components.qml
+++ b/tests/qml/tst_components.qml
@@ -1,0 +1,67 @@
+// Component load-smoke for the real UI (HEAP-49).
+//
+// Instantiates each top-level QML component from the TodoCpp module against a
+// live AppController (linked via heap_core). A component that references a
+// removed property, a renamed signal, or a missing type fails to instantiate
+// and createTemporaryQmlObject returns null — so this catches whole classes of
+// UI regressions the pure-logic tests can't see.
+//
+// Delegates that declare `required property` (TaskCard, …) are intentionally
+// omitted: they cannot be instantiated standalone without their row context.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "ComponentsLoad"
+    when: windowShown
+    visible: true
+    width: 400
+    height: 400
+
+    Item { id: host; anchors.fill: parent }
+
+    function load(typeName) {
+        const o = createTemporaryQmlObject('import TodoCpp; ' + typeName + ' { }', host);
+        verify(o !== null, "failed to instantiate " + typeName);
+        return o;
+    }
+
+    function test_siderail()    { load("SideRail"); }
+    function test_filterbar()   { load("FilterBar"); }
+    function test_kanbanboard() { load("KanbanBoard"); }
+    function test_timelineview(){ load("TimelineView"); }
+    function test_weekview()    { load("WeekView"); }
+    function test_daycalendar() { load("DayCalendar"); }
+    function test_peoplelist()  { load("PeopleList"); }
+    function test_archiveview() { load("ArchiveView"); }
+    function test_docsview()    { load("DocsView"); }
+    function test_notesview()   { load("NotesView"); }
+    function test_settingsview(){ load("SettingsView"); }
+    function test_toast()       { load("Toast"); }
+    function test_topbar()      { load("TopBar"); }
+    function test_selectionbar(){ load("SelectionBar"); }
+    function test_commandpalette() { load("CommandPalette"); }
+
+    // FilterBar signal contract: togglePriority carries the priority id.
+    function test_filterbar_toggle_signal() {
+        const fb = load("FilterBar");
+        let got = "";
+        fb.togglePriority.connect(function(p) { got = p; });
+        fb.togglePriority("P1");
+        compare(got, "P1");
+    }
+
+    // SideRail integration: focusStatusColumn drives AppController view state
+    // (the wiring the ⊘/⎇ buttons use). Exercises the live singleton the rail
+    // component binds to.
+    function test_siderail_focus_status_integration() {
+        load("SideRail");
+        AppController.currentView = "notes";
+        AppController.focusStatusColumn("blocked");
+        compare(AppController.currentView, "board");
+        compare(AppController.focusedStatus, "blocked");
+    }
+}

--- a/tests/quick_test_main.cpp
+++ b/tests/quick_test_main.cpp
@@ -1,8 +1,25 @@
 // Qt Quick Test entry point for the QML-side unit tests.
 //
-// QUICK_TEST_MAIN loads every tst_*.qml under the directory passed via
-// `-input <dir>` (wired in tests/CMakeLists.txt) and runs each TestCase.
-// Runs headless under the offscreen QPA platform in CI.
+// QUICK_TEST_MAIN_WITH_SETUP loads every tst_*.qml under the directory passed
+// via the QUICK_TEST_SOURCE_DIR compile definition (see tests/CMakeLists.txt)
+// and runs each TestCase. Runs headless under the offscreen QPA platform.
+//
+// The Setup object enables QStandardPaths test mode before any test loads, so
+// component tests that construct AppController (which reads/seeds state.json
+// under AppDataLocation) never touch the real user data.
 #include <QtQuickTest/quicktest.h>
 
-QUICK_TEST_MAIN(heap_qml)
+#include <QObject>
+#include <QStandardPaths>
+
+class Setup : public QObject {
+  Q_OBJECT
+ public slots:
+  void applicationAvailable() {
+    QStandardPaths::setTestModeEnabled(true);
+  }
+};
+
+QUICK_TEST_MAIN_WITH_SETUP(heap_qml, Setup)
+
+#include "quick_test_main.moc"

--- a/tests/quick_test_main.cpp
+++ b/tests/quick_test_main.cpp
@@ -7,14 +7,14 @@
 // The Setup object enables QStandardPaths test mode before any test loads, so
 // component tests that construct AppController (which reads/seeds state.json
 // under AppDataLocation) never touch the real user data.
-#include <QtQuickTest/quicktest.h>
-
 #include <QObject>
 #include <QStandardPaths>
+#include <QtQuickTest/quicktest.h>
 
 class Setup : public QObject {
   Q_OBJECT
  public slots:
+
   void applicationAvailable() {
     QStandardPaths::setTestModeEnabled(true);
   }


### PR DESCRIPTION
Stands up **UI component testing**. Extracts app logic + the TodoCpp QML module from the `heap` executable into a **`heap_core` static library**; `heap` becomes a thin shell linking `heap_core` + `heap_coreplugin`. (Linking the module plugin is required so the static qml module's type-registration + qmlcache init aren't dropped by the linker — otherwise Main.qml fails to load.)

`heap_qml_tests` now links `heap_core`, so tst_*.qml can `import TodoCpp` and instantiate **real components against a live AppController**. `quick_test_main` enables QStandardPaths test mode (never touches real state.json).

New `tst_components.qml` load-smokes every top-level component (SideRail, KanbanBoard, FilterBar, all views, TopBar, CommandPalette…) + FilterBar signal + SideRail→focusStatusColumn integration.

**Verified locally:** heap.exe builds + loads the module at runtime; 15/15 ctest suites green (heap_qml_tests: 25 cases). CI validates Linux + Windows.