### PR TITLE
docs: onboarding tutorial, hotkeys & data references (HEAP-29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ for visual reference. The brand bundle lives under `design/brand-export/`; see [
 - **Automation.** A 60-second tick auto-archives done tasks, surfaces blocked-stuck warnings, and fires deadline and
   standup reminders via the system tray. Respects quiet hours.
 
+## Documentation
+
+- [**First day in heap.**](docs/TUTORIAL.md) — a ten-minute walkthrough of the
+  whole app, including the Quick-capture syntax.
+- [**Keyboard reference**](docs/HOTKEYS.md) — every (rebindable) shortcut.
+- [**Data & backups**](docs/DATA.md) — where your data lives, backups, and
+  moving a profile between machines.
+
 ## Build
 
 Requires Qt 6.4+ and a C++20 toolchain.
@@ -168,24 +176,28 @@ cmake --build build -j
 ## Keyboard
 
 Defaults. Every entry is rebindable from **Settings → Shortcuts** or the
-floating Hotkeys panel.
+floating Hotkeys panel. Full list: [docs/HOTKEYS.md](docs/HOTKEYS.md).
 
 | Action            | Default      |
 | ----------------- | ------------ |
 | Open palette      | `Ctrl+K` / `Ctrl+P` |
 | New task          | `Ctrl+N`     |
+| Quick-capture task  | `Ctrl+Shift+Space` |
+| Quick-capture note  | `Ctrl+Shift+N` |
 | Switch to Board   | `Ctrl+1`     |
 | Switch to Timeline| `Ctrl+2`     |
 | Switch to Week    | `Ctrl+3`     |
 | Switch to Docs    | `Ctrl+4`     |
 | Switch to Notes   | `Ctrl+5`     |
-| Switch to Settings| `Ctrl+,`     |
-| Next profile      | `Ctrl+Tab`   |
-| Prev profile      | `Ctrl+Shift+Tab` |
-| Focus search      | `/`          |
+| Switch to Settings| `Ctrl+6`     |
+| Next profile      | `Ctrl+]`     |
+| Prev profile      | `Ctrl+[`     |
+| Export profile → Markdown | `Ctrl+Shift+E` |
+| Focus search      | `Ctrl+F`     |
 | Undo last deletion| `Ctrl+Z`     |
-| Open Tweaks       | `Ctrl+T`     |
-| Open Hotkeys      | `Ctrl+Shift+K` |
+| Open Tweaks       | `Ctrl+,`     |
+| Open Hotkeys      | `Ctrl+/`     |
+| Select all / clear / delete | `Ctrl+A` / `Esc` / `Del` |
 
 ## Accessibility
 

--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -1,0 +1,51 @@
+# Data, backups & moving your work
+
+heap. stores everything locally — there is no account and no server. This page
+covers where your data lives, how backups work, and how to move a profile
+between machines today.
+
+## Where your data lives
+
+All state is one JSON file, `state.json`, under the platform's application-data
+location (`QStandardPaths::AppDataLocation`):
+
+| OS | Typical path |
+|----|--------------|
+| Windows | `%APPDATA%\heap\state.json` |
+| macOS | `~/Library/Application Support/heap/state.json` |
+| Linux | `~/.local/share/heap/state.json` |
+
+`state.json` holds every profile (tasks, people, statuses, docs, notes), the
+global events, and your settings blob. It is human-readable — safe to inspect,
+and easy to back up by copying.
+
+## Automatic backups
+
+heap. rotates a timestamped copy of `state.json` into `<AppDataLocation>/backups/`.
+Retention (how many copies to keep) is configurable in **Settings → Data**. To
+restore, pick a backup from the same panel — the current state is replaced and
+a fresh backup of the pre-restore state is taken first.
+
+## Move one profile between machines
+
+Each profile can be exported and re-imported independently:
+
+1. **Export.** Top-bar profile menu → *Export* (or **Settings → Data → Export
+   profile**) writes a `<profile>.todocpp.json` file.
+2. **Import.** On the other machine, **Settings → Data → Import profile** (or the
+   profile menu) reads that file and adds it as a new profile.
+3. For a quick text snapshot instead, `Ctrl+Shift+E` copies a Markdown summary
+   of the active profile to the clipboard.
+
+Export/import is content-only — it never carries settings or other profiles, so
+importing is always non-destructive.
+
+## Multi-device sync (roadmap)
+
+Continuous multi-device sync — pointing heap. at your own **private git remote**
+as canonical storage, with one human-readable file per profile and git history
+for free — is on the roadmap. The serialization layer that produces those
+stable, diff-friendly per-entity files already exists
+(`src/sync/SyncSerializer`); the git backend, scheduler and conflict resolver
+land in a later release. Until then, the export/import flow above is the
+supported way to move work between machines.

--- a/docs/HOTKEYS.md
+++ b/docs/HOTKEYS.md
@@ -1,0 +1,58 @@
+# Keyboard reference
+
+Every shortcut below is **rebindable** — open the floating Hotkeys panel
+(`Ctrl+/`) or **Settings → Shortcuts**, click a binding, and press the new
+combination. Conflicts are resolved VS Code-style: the new binding wins and the
+previous owner is unbound (you'll see a toast naming what was freed). *Reset*
+restores a single default; *Reset all* restores the whole catalog.
+
+## Global
+
+| Action | Default |
+|--------|---------|
+| Open Command Palette | `Ctrl+K` (also the fixed alias `Ctrl+P`) |
+| New task | `Ctrl+N` |
+| Quick-capture task | `Ctrl+Shift+Space` |
+| Quick-capture note | `Ctrl+Shift+N` |
+| Focus the header search | `Ctrl+F` |
+| Undo last deletion | `Ctrl+Z` |
+
+## Views
+
+| Action | Default |
+|--------|---------|
+| Board | `Ctrl+1` |
+| Timeline | `Ctrl+2` |
+| Week | `Ctrl+3` |
+| Docs | `Ctrl+4` |
+| Notes | `Ctrl+5` |
+| Settings | `Ctrl+6` |
+
+## Profiles
+
+| Action | Default |
+|--------|---------|
+| Next profile | `Ctrl+]` |
+| Previous profile | `Ctrl+[` |
+| Export active profile to Markdown (clipboard) | `Ctrl+Shift+E` |
+
+## Panels
+
+| Action | Default |
+|--------|---------|
+| Open Tweaks (theme / density / a11y) | `Ctrl+,` |
+| Open Hotkeys panel | `Ctrl+/` |
+
+## Selection (Board / Timeline / Week)
+
+| Action | Default |
+|--------|---------|
+| Select all visible tickets | `Ctrl+A` |
+| Clear selection | `Esc` |
+| Delete selection (undoable 5 s) | `Del` |
+
+## Notes
+
+- **Quick-capture** opens a single-field popup that parses your line as you type
+  — see [TUTORIAL.md](TUTORIAL.md#quick-capture-syntax) for the syntax.
+- `Esc` also closes any open modal or popup before it clears a selection.

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1,0 +1,105 @@
+# Your first day in heap.
+
+A ten-minute walkthrough of the whole app. heap. is one native binary — no
+account, no server, no browser. Everything you create lives on your machine.
+
+> Keyboard-first throughout. The full shortcut list is in
+> [HOTKEYS.md](HOTKEYS.md); the essentials appear inline below.
+
+## 1. Launch & the layout
+
+On first run heap. seeds an **Example** profile so nothing is empty. The window
+has three regions: the **side rail** (view switcher, left), the **main view**
+(center), and the **calendar + people** column (right).
+
+![The board with the calendar column](assets/img/screens/board-full.png)
+
+Switch views with `Ctrl+1…6`: **Board**, **Timeline**, **Week**, **Docs**,
+**Notes**, **Settings**.
+
+## 2. Capture a task in under two seconds
+
+Press **`Ctrl+Shift+Space`** for Quick-capture, type a line, hit `Enter`. The
+popup previews what it parsed (date chip, title) before you commit.
+
+### Quick-capture syntax
+
+Everything is optional and order-independent:
+
+| You type | heap. does |
+|----------|-----------|
+| `fix login race` | task titled "fix login race" in the active profile's To Do |
+| `ship v1 tomorrow` / `ship v1 завтра 14:00` | task with a parsed deadline (date, and time when given) |
+| `pay invoice // net-30, portal is slow` | text after `//` becomes the task **description** |
+| `review PR @andrey @lena` | keeps the `@mentions` and links them to matching people |
+| `напиши @viktor про релиз` | routes to a **contact ping** in the People column, not the board |
+| `focus refactor parser 10:00` | schedules a **focus block** on today's calendar |
+| `standup 10:00` / `созвон 15:00-15:30` | schedules a **meeting** event (honours a time range) |
+| `задача: подготовить синк` | stays a pure to-do — never put on the calendar |
+
+Dates parse in **English and Russian** (`tomorrow`, `friday`, `завтра`,
+`пятница`, `May 22`, `22.05`, `14:00`, `12:00-13:00`).
+
+Prefer a full form? `Ctrl+N` opens the task editor with every field.
+
+## 3. Work the board
+
+![Board columns and cards](assets/img/screens/board-full.png)
+
+- **Drag** cards between status columns; the color of each column is editable.
+- Cards show a **priority chip** (P0–P3), a **branch** tag, a **deadline**, and
+  a scheduled-time pill when a focus block exists.
+- **Multi-select:** `Ctrl+A` selects everything visible; then move, archive, or
+  `Del` (undoable for 5 s). `Esc` clears the selection.
+- Toggle **Archived** in the filter bar to see auto-archived done tasks.
+
+## 4. See it by time
+
+- **Timeline** (`Ctrl+2`) buckets tasks into overdue / today / tomorrow / this
+  week / later, with a show-done toggle.
+  ![Timeline](assets/img/screens/board-timeline.png)
+- **Week** (`Ctrl+3`) is a 7-day grid — drag, resize, and move events across
+  days; all-day deadline chips sit on top.
+  ![Week](assets/img/screens/board-week.png)
+- The **day calendar** (right column) lets you drag on empty space to create an
+  event, resize from either edge, and **drop a task onto it to schedule a focus
+  block**. Overlapping events sit side-by-side.
+  ![Day calendar with a focus block](assets/img/screens/calendar-focus.png)
+
+## 5. Docs & Notes
+
+- **Docs** (`Ctrl+4`): sections, custom fields, a syntax-highlighted snippet
+  editor, and contact cards.
+  ![Docs](assets/img/screens/board-docs.png)
+- **Notes** (`Ctrl+5`): a per-profile markdown canvas with `@people` and
+  `#ticket` autocomplete. `Ctrl+Shift+N` appends a quick note from anywhere.
+  ![Notes](assets/img/screens/board-notes.png)
+
+## 6. Profiles
+
+A **profile** is a feature-scoped workspace: its own tasks, people, statuses,
+docs and notes. Create one from the profile pill in the top bar, cycle with
+`Ctrl+]` / `Ctrl+[`, and export the active profile to Markdown with
+`Ctrl+Shift+E`. Full JSON import/export lives in **Settings → Data** — see
+[DATA.md](DATA.md).
+
+## 7. Command palette & tweaks
+
+- **`Ctrl+K`** (or `Ctrl+P`) — fuzzy search across tasks, docs, snippets,
+  contacts, people and profiles. Enter jumps straight to the item.
+- **`Ctrl+,`** — Tweaks: theme, density, accent, reduced motion, high contrast.
+- **`Ctrl+/`** — rebind any shortcut inline.
+
+![Hotkeys & tweaks](assets/img/screens/hotkeys-tweaks.png)
+
+## 8. It nudges you
+
+A background tick (every 60 s) auto-archives long-done tasks, flags tasks that
+have been *blocked* too long, and fires **deadline** and **standup** reminders
+through the system tray — all muted during **quiet hours** (Settings →
+Notifications).
+
+---
+
+That's the whole surface. Next: skim [HOTKEYS.md](HOTKEYS.md) once, then just
+live in Quick-capture.


### PR DESCRIPTION
Adds docs/TUTORIAL.md, docs/HOTKEYS.md, docs/DATA.md + README updates. Docs-only, merges cleanly.