### PR TITLE
feat: tracker-sync foundation — integration types + StatusMap (HEAP-18)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ qt_add_executable(heap WIN32
     src/text/TaskTextUtils.cpp
     src/notify/NotificationCenter.cpp
     src/notify/NotificationCenter_tray.cpp
+    src/integrations/StatusMap.cpp
     $<$<PLATFORM_ID:Linux>:${CMAKE_SOURCE_DIR}/src/notify/NotificationCenter_linux.cpp>
         $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/design/brand-export/icon/heap-icon.rc>
 )
@@ -131,6 +132,9 @@ qt_add_qml_module(heap
         src/git/GitWatcher.h
         src/text/TaskTextUtils.h
         src/notify/NotificationCenter.h
+        src/integrations/IntegrationTypes.h
+        src/integrations/StatusMap.h
+        src/integrations/IntegrationProvider.h
 )
 
 target_include_directories(heap PRIVATE src)

--- a/src/integrations/IntegrationProvider.h
+++ b/src/integrations/IntegrationProvider.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "integrations/IntegrationTypes.h"
+
+#include <QObject>
+#include <QString>
+#include <QVector>
+
+namespace heap::integrations {
+
+// Abstract interface every tracker connector (Jira / GitHub / GitLab) will
+// implement. Defined now as the foundation for the post-release two-way sync;
+// concrete providers, the OAuth flow, the SecretStore and the SyncScheduler
+// land in follow-up work. All operations are async — results arrive via the
+// signals so the UI thread never blocks on the network.
+class IntegrationProvider : public QObject {
+  Q_OBJECT
+ public:
+  ~IntegrationProvider() override = default;
+
+  virtual QString id() const = 0;           // "jira" | "github" | "gitlab"
+  virtual QString displayName() const = 0;
+
+  // Validate credentials. Emits connectionTested.
+  virtual void testConnection() = 0;
+  // Pull external tasks matching the configured filter. Emits tasksFetched.
+  virtual void pullTasks() = 0;
+  // Push a local status change back to the tracker. Emits taskPushed.
+  virtual void pushStatusChange(const QString& externalId, const QString& newStatus) = 0;
+
+ signals:
+  void connectionTested(bool ok, const QString& error);
+  void tasksFetched(const QVector<ExternalTask>& tasks);
+  void taskPushed(const QString& externalId, bool ok, const QString& error);
+
+ protected:
+  using QObject::QObject;
+};
+
+}  // namespace heap::integrations

--- a/src/integrations/IntegrationTypes.h
+++ b/src/integrations/IntegrationTypes.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QDateTime>
+#include <QHash>
+#include <QString>
+#include <QStringList>
+
+namespace heap::integrations {
+
+// A task pulled from an external tracker (Jira / GitHub / GitLab). Kept as a
+// plain value type — no QObject — so it can be serialized, compared and unit-
+// tested without an event loop.
+struct ExternalTask {
+  QString providerId;   // "jira" | "github" | "gitlab"
+  QString externalId;   // Jira "PROJ-123", GH issue number as string
+  QString url;
+  QString title;
+  QString body;
+  QString status;       // provider-native status (map with StatusMap on use)
+  QString priority;     // provider-native priority (map with StatusMap on use)
+  QStringList labels;
+  QDateTime updatedAt;
+  QHash<QString, QString> extra;  // provider-specific fields
+};
+
+// Outcome of one sync cycle for a provider.
+struct SyncResult {
+  int pulled = 0;
+  int pushed = 0;
+  QStringList errors;
+
+  bool ok() const {
+    return errors.isEmpty();
+  }
+};
+
+}  // namespace heap::integrations

--- a/src/integrations/StatusMap.cpp
+++ b/src/integrations/StatusMap.cpp
@@ -1,0 +1,77 @@
+#include "integrations/StatusMap.h"
+
+namespace heap::integrations {
+
+namespace {
+
+QString norm(const QString& s) {
+  return s.trimmed().toLower();
+}
+
+}  // namespace
+
+QString StatusMap::defaultColumn(const QString& providerStatus) {
+  static const QHash<QString, QString> kTable = {
+      // backlog
+      {QStringLiteral("backlog"), QStringLiteral("backlog")},
+      // todo
+      {QStringLiteral("to do"), QStringLiteral("todo")},
+      {QStringLiteral("todo"), QStringLiteral("todo")},
+      {QStringLiteral("open"), QStringLiteral("todo")},
+      {QStringLiteral("reopened"), QStringLiteral("todo")},
+      {QStringLiteral("selected for development"), QStringLiteral("todo")},
+      // in progress
+      {QStringLiteral("in progress"), QStringLiteral("prog")},
+      {QStringLiteral("in development"), QStringLiteral("prog")},
+      {QStringLiteral("doing"), QStringLiteral("prog")},
+      {QStringLiteral("started"), QStringLiteral("prog")},
+      // review
+      {QStringLiteral("in review"), QStringLiteral("review")},
+      {QStringLiteral("review"), QStringLiteral("review")},
+      {QStringLiteral("code review"), QStringLiteral("review")},
+      {QStringLiteral("in code review"), QStringLiteral("review")},
+      // blocked
+      {QStringLiteral("blocked"), QStringLiteral("blocked")},
+      {QStringLiteral("impediment"), QStringLiteral("blocked")},
+      {QStringLiteral("on hold"), QStringLiteral("blocked")},
+      // done
+      {QStringLiteral("done"), QStringLiteral("done")},
+      {QStringLiteral("closed"), QStringLiteral("done")},
+      {QStringLiteral("resolved"), QStringLiteral("done")},
+      {QStringLiteral("complete"), QStringLiteral("done")},
+      {QStringLiteral("completed"), QStringLiteral("done")},
+      {QStringLiteral("merged"), QStringLiteral("done")},
+  };
+  return kTable.value(norm(providerStatus));
+}
+
+QString StatusMap::column(const QString& providerStatus, const QHash<QString, QString>& overrides, const QString& fallback) {
+  const QString key = norm(providerStatus);
+  // User overrides win. Match case-insensitively against normalized keys.
+  for(auto it = overrides.constBegin(); it != overrides.constEnd(); ++it) {
+    if(norm(it.key()) == key) {
+      return it.value();
+    }
+  }
+  const QString built = defaultColumn(providerStatus);
+  return built.isEmpty() ? fallback : built;
+}
+
+QString StatusMap::priority(const QString& providerPriority, const QString& fallback) {
+  static const QHash<QString, QString> kTable = {
+      {QStringLiteral("highest"), QStringLiteral("P0")},
+      {QStringLiteral("critical"), QStringLiteral("P0")},
+      {QStringLiteral("blocker"), QStringLiteral("P0")},
+      {QStringLiteral("high"), QStringLiteral("P1")},
+      {QStringLiteral("major"), QStringLiteral("P1")},
+      {QStringLiteral("medium"), QStringLiteral("P2")},
+      {QStringLiteral("normal"), QStringLiteral("P2")},
+      {QStringLiteral("low"), QStringLiteral("P3")},
+      {QStringLiteral("lowest"), QStringLiteral("P3")},
+      {QStringLiteral("minor"), QStringLiteral("P3")},
+      {QStringLiteral("trivial"), QStringLiteral("P3")},
+  };
+  return kTable.value(norm(providerPriority), fallback);
+}
+
+}  // namespace heap::integrations

--- a/src/integrations/StatusMap.h
+++ b/src/integrations/StatusMap.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <QHash>
+#include <QString>
+
+namespace heap::integrations {
+
+// Pure translation between external-tracker vocabularies and heap.'s own
+// kanban columns / priority tiers. No network, no QObject — the deterministic
+// core of the (post-release) tracker-sync feature, unit-tested on its own.
+//
+// heap. column ids: "backlog" | "todo" | "prog" | "review" | "blocked" | "done".
+// heap. priority ids: "P0" | "P1" | "P2" | "P3".
+class StatusMap {
+ public:
+  // Built-in mapping for common Jira/GitHub/GitLab status names → heap column.
+  // Matching is case-insensitive and whitespace-trimmed. Unrecognized input
+  // returns an empty string (callers pass it through map() with a fallback).
+  static QString defaultColumn(const QString& providerStatus);
+
+  // Resolve a provider status to a heap column: user \p overrides win (also
+  // matched case-insensitively), then the built-in table, then \p fallback.
+  static QString column(const QString& providerStatus,
+                        const QHash<QString, QString>& overrides = {},
+                        const QString& fallback = QStringLiteral("todo"));
+
+  // Jira-style priority name → heap tier. Highest→P0, High→P1, Medium→P2,
+  // Low/Lowest→P3. Unknown → \p fallback (default "P2").
+  static QString priority(const QString& providerPriority,
+                          const QString& fallback = QStringLiteral("P2"));
+};
+
+}  // namespace heap::integrations

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -218,6 +218,22 @@ endif ()
 
 add_test(NAME heap_notes_tests COMMAND heap_notes_tests)
 
+# ─── Integrations (tracker-sync StatusMap) tests ───
+# Pure status/priority translation for the post-release tracker sync. No QObject,
+# no network — Qt6::Core only.
+add_executable(heap_integrations_tests
+        test_integrations.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
+)
+target_include_directories(heap_integrations_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_link_libraries(heap_integrations_tests PRIVATE
+        Qt6::Core
+        GTest::gtest
+        GTest::gtest_main
+)
+add_test(NAME heap_integrations_tests COMMAND heap_integrations_tests)
+
 # ─── Aggregate target ───
 # Build target that depends on every executable defined in this directory.
 # CI builds `heap_all_tests`; adding a new test exe via add_executable() in

--- a/tests/test_integrations.cpp
+++ b/tests/test_integrations.cpp
@@ -1,0 +1,73 @@
+#include "integrations/StatusMap.h"
+
+#include <QHash>
+#include <QString>
+
+#include <gtest/gtest.h>
+
+using heap::integrations::StatusMap;
+
+// ─── defaultColumn ────────────────────────────────────────────────────
+
+TEST(StatusMap, DefaultColumnKnownStatuses) {
+  EXPECT_EQ(StatusMap::defaultColumn(QStringLiteral("To Do")), QString("todo"));
+  EXPECT_EQ(StatusMap::defaultColumn(QStringLiteral("In Progress")), QString("prog"));
+  EXPECT_EQ(StatusMap::defaultColumn(QStringLiteral("In Review")), QString("review"));
+  EXPECT_EQ(StatusMap::defaultColumn(QStringLiteral("Blocked")), QString("blocked"));
+  EXPECT_EQ(StatusMap::defaultColumn(QStringLiteral("Done")), QString("done"));
+  EXPECT_EQ(StatusMap::defaultColumn(QStringLiteral("Backlog")), QString("backlog"));
+}
+
+TEST(StatusMap, DefaultColumnCaseAndWhitespaceInsensitive) {
+  EXPECT_EQ(StatusMap::defaultColumn(QStringLiteral("  in progress  ")), QString("prog"));
+  EXPECT_EQ(StatusMap::defaultColumn(QStringLiteral("CLOSED")), QString("done"));
+  EXPECT_EQ(StatusMap::defaultColumn(QStringLiteral("Merged")), QString("done"));
+}
+
+TEST(StatusMap, DefaultColumnUnknownIsEmpty) {
+  EXPECT_TRUE(StatusMap::defaultColumn(QStringLiteral("Wibble")).isEmpty());
+  EXPECT_TRUE(StatusMap::defaultColumn(QString()).isEmpty());
+}
+
+// ─── column (overrides + fallback) ────────────────────────────────────
+
+TEST(StatusMap, ColumnUsesBuiltinThenFallback) {
+  EXPECT_EQ(StatusMap::column(QStringLiteral("In Review")), QString("review"));
+  // Unknown → default fallback "todo".
+  EXPECT_EQ(StatusMap::column(QStringLiteral("Wibble")), QString("todo"));
+  // Unknown → explicit fallback.
+  EXPECT_EQ(StatusMap::column(QStringLiteral("Wibble"), {}, QStringLiteral("backlog")), QString("backlog"));
+}
+
+TEST(StatusMap, ColumnOverrideWins) {
+  QHash<QString, QString> ov;
+  ov.insert(QStringLiteral("In Review"), QStringLiteral("prog"));  // team maps review→prog
+  EXPECT_EQ(StatusMap::column(QStringLiteral("In Review"), ov), QString("prog"));
+  // Override matched case-insensitively.
+  EXPECT_EQ(StatusMap::column(QStringLiteral("in review"), ov), QString("prog"));
+  // A status not in the override falls back to the built-in table.
+  EXPECT_EQ(StatusMap::column(QStringLiteral("Done"), ov), QString("done"));
+}
+
+TEST(StatusMap, ColumnOverrideCanMapUnknownStatus) {
+  QHash<QString, QString> ov;
+  ov.insert(QStringLiteral("Awaiting QA"), QStringLiteral("review"));
+  EXPECT_EQ(StatusMap::column(QStringLiteral("Awaiting QA"), ov), QString("review"));
+}
+
+// ─── priority ─────────────────────────────────────────────────────────
+
+TEST(StatusMap, PriorityMapping) {
+  EXPECT_EQ(StatusMap::priority(QStringLiteral("Highest")), QString("P0"));
+  EXPECT_EQ(StatusMap::priority(QStringLiteral("High")), QString("P1"));
+  EXPECT_EQ(StatusMap::priority(QStringLiteral("Medium")), QString("P2"));
+  EXPECT_EQ(StatusMap::priority(QStringLiteral("Low")), QString("P3"));
+  EXPECT_EQ(StatusMap::priority(QStringLiteral("Lowest")), QString("P3"));
+  EXPECT_EQ(StatusMap::priority(QStringLiteral("critical")), QString("P0"));
+}
+
+TEST(StatusMap, PriorityUnknownFallback) {
+  EXPECT_EQ(StatusMap::priority(QStringLiteral("Sometime")), QString("P2"));
+  EXPECT_EQ(StatusMap::priority(QStringLiteral("Sometime"), QStringLiteral("P3")), QString("P3"));
+  EXPECT_EQ(StatusMap::priority(QString()), QString("P2"));
+}


### PR DESCRIPTION
Adds src/integrations (IntegrationTypes, IntegrationProvider, StatusMap) + heap_integrations_tests. Rebased onto current master (heap_core refactor); conflicts in CMakeLists resolved by grafting the new sources into heap_core + the test suite. Builds, 16/16 ctest green.