### PR TITLE
feat: SyncSerializer — git-friendly profile/event JSON (HEAP-19)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ qt_add_executable(heap WIN32
     src/text/TaskTextUtils.cpp
     src/notify/NotificationCenter.cpp
     src/notify/NotificationCenter_tray.cpp
+    src/sync/SyncSerializer.cpp
     $<$<PLATFORM_ID:Linux>:${CMAKE_SOURCE_DIR}/src/notify/NotificationCenter_linux.cpp>
         $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/design/brand-export/icon/heap-icon.rc>
 )
@@ -131,6 +132,7 @@ qt_add_qml_module(heap
         src/git/GitWatcher.h
         src/text/TaskTextUtils.h
         src/notify/NotificationCenter.h
+        src/sync/SyncSerializer.h
 )
 
 target_include_directories(heap PRIVATE src)

--- a/src/sync/SyncSerializer.cpp
+++ b/src/sync/SyncSerializer.cpp
@@ -1,0 +1,210 @@
+#include "sync/SyncSerializer.h"
+
+#include <QJsonDocument>
+#include <QJsonValue>
+
+#include <algorithm>
+
+namespace heap::sync {
+
+namespace {
+
+// QDate/QDateTime ↔ ISO string, with invalid mapping to "" (round-trip safe).
+QString dateToStr(const QDate& d) {
+  return d.isValid() ? d.toString(Qt::ISODate) : QString();
+}
+QDate dateFromStr(const QString& s) {
+  return s.isEmpty() ? QDate() : QDate::fromString(s, Qt::ISODate);
+}
+QString dateTimeToStr(const QDateTime& dt) {
+  return dt.isValid() ? dt.toString(Qt::ISODate) : QString();
+}
+QDateTime dateTimeFromStr(const QString& s) {
+  return s.isEmpty() ? QDateTime() : QDateTime::fromString(s, Qt::ISODate);
+}
+
+}  // namespace
+
+QJsonArray SyncSerializer::sortedById(const QJsonArray& arr) {
+  QVector<QJsonObject> items;
+  items.reserve(arr.size());
+  for(const QJsonValue& v : arr) {
+    items.append(v.toObject());
+  }
+  std::stable_sort(items.begin(), items.end(), [](const QJsonObject& a, const QJsonObject& b) {
+    return a.value(QStringLiteral("id")).toString() < b.value(QStringLiteral("id")).toString();
+  });
+  QJsonArray out;
+  for(const QJsonObject& o : items) {
+    out.append(o);
+  }
+  return out;
+}
+
+// ── Task ──
+QJsonObject SyncSerializer::taskToJson(const Task& t) {
+  QJsonObject o;
+  o[QStringLiteral("id")] = t.id;
+  o[QStringLiteral("title")] = t.title;
+  o[QStringLiteral("desc")] = t.desc;
+  o[QStringLiteral("priority")] = t.priority;
+  o[QStringLiteral("status")] = t.status;
+  o[QStringLiteral("deadline")] = dateToStr(t.deadline);
+  o[QStringLiteral("branch")] = t.branch;
+  o[QStringLiteral("statusChangedAt")] = dateTimeToStr(t.statusChangedAt);
+  o[QStringLiteral("archived")] = t.archived;
+  return o;
+}
+
+Task SyncSerializer::taskFromJson(const QJsonObject& o) {
+  Task t;
+  t.id = o.value(QStringLiteral("id")).toString();
+  t.title = o.value(QStringLiteral("title")).toString();
+  t.desc = o.value(QStringLiteral("desc")).toString();
+  t.priority = o.value(QStringLiteral("priority")).toString();
+  t.status = o.value(QStringLiteral("status")).toString();
+  t.deadline = dateFromStr(o.value(QStringLiteral("deadline")).toString());
+  t.branch = o.value(QStringLiteral("branch")).toString();
+  t.statusChangedAt = dateTimeFromStr(o.value(QStringLiteral("statusChangedAt")).toString());
+  t.archived = o.value(QStringLiteral("archived")).toBool();
+  return t;
+}
+
+// ── Person ──
+QJsonObject SyncSerializer::personToJson(const Person& p) {
+  QJsonObject o;
+  o[QStringLiteral("id")] = p.id;
+  o[QStringLiteral("name")] = p.name;
+  o[QStringLiteral("role")] = p.role;
+  o[QStringLiteral("question")] = p.question;
+  o[QStringLiteral("state")] = p.state;
+  o[QStringLiteral("color")] = p.color.isValid() ? p.color.name(QColor::HexRgb) : QString();
+  return o;
+}
+
+Person SyncSerializer::personFromJson(const QJsonObject& o) {
+  Person p;
+  p.id = o.value(QStringLiteral("id")).toString();
+  p.name = o.value(QStringLiteral("name")).toString();
+  p.role = o.value(QStringLiteral("role")).toString();
+  p.question = o.value(QStringLiteral("question")).toString();
+  p.state = o.value(QStringLiteral("state")).toString();
+  const QString c = o.value(QStringLiteral("color")).toString();
+  p.color = c.isEmpty() ? QColor() : QColor(c);
+  return p;
+}
+
+// ── CalEvent ──
+QJsonObject SyncSerializer::eventToJson(const CalEvent& e) {
+  QJsonObject o;
+  o[QStringLiteral("id")] = e.id;
+  o[QStringLiteral("title")] = e.title;
+  o[QStringLiteral("type")] = e.type;
+  o[QStringLiteral("start")] = e.start;
+  o[QStringLiteral("end")] = e.end;
+  o[QStringLiteral("attendees")] = e.attendees;
+  o[QStringLiteral("date")] = dateToStr(e.date);
+  o[QStringLiteral("taskId")] = e.taskId;
+  o[QStringLiteral("profileId")] = e.profileId;
+  o[QStringLiteral("context")] = e.context;
+  return o;
+}
+
+CalEvent SyncSerializer::eventFromJson(const QJsonObject& o) {
+  CalEvent e;
+  e.id = o.value(QStringLiteral("id")).toString();
+  e.title = o.value(QStringLiteral("title")).toString();
+  e.type = o.value(QStringLiteral("type")).toString();
+  e.start = o.value(QStringLiteral("start")).toDouble();
+  e.end = o.value(QStringLiteral("end")).toDouble();
+  e.attendees = o.value(QStringLiteral("attendees")).toString();
+  e.date = dateFromStr(o.value(QStringLiteral("date")).toString());
+  e.taskId = o.value(QStringLiteral("taskId")).toString();
+  e.profileId = o.value(QStringLiteral("profileId")).toString();
+  e.context = o.value(QStringLiteral("context")).toString();
+  return e;
+}
+
+// ── Profile ──
+QByteArray SyncSerializer::serializeProfile(const Profile& p) {
+  QJsonObject root;
+  root[QStringLiteral("id")] = p.id;
+  root[QStringLiteral("name")] = p.name;
+  root[QStringLiteral("color")] = p.color;
+  root[QStringLiteral("createdAt")] = dateTimeToStr(p.createdAt);
+
+  QJsonArray tasks;
+  for(const Task& t : p.tasks) {
+    tasks.append(taskToJson(t));
+  }
+  root[QStringLiteral("tasks")] = sortedById(tasks);
+
+  QJsonArray people;
+  for(const Person& person : p.people) {
+    people.append(personToJson(person));
+  }
+  root[QStringLiteral("people")] = sortedById(people);
+
+  QJsonArray statuses;
+  for(const QVariant& v : p.statuses) {
+    statuses.append(QJsonObject::fromVariantMap(v.toMap()));
+  }
+  root[QStringLiteral("statuses")] = sortedById(statuses);
+
+  // Free-form blobs kept verbatim: lossless and idempotent across round-trips.
+  root[QStringLiteral("docsState")] = p.docsState;
+  root[QStringLiteral("notesState")] = p.notesState;
+
+  return QJsonDocument(root).toJson(QJsonDocument::Indented);
+}
+
+std::optional<Profile> SyncSerializer::deserializeProfile(const QByteArray& json) {
+  const QJsonDocument doc = QJsonDocument::fromJson(json);
+  if(!doc.isObject()) {
+    return std::nullopt;
+  }
+  const QJsonObject root = doc.object();
+  Profile p;
+  p.id = root.value(QStringLiteral("id")).toString();
+  p.name = root.value(QStringLiteral("name")).toString();
+  p.color = root.value(QStringLiteral("color")).toString();
+  p.createdAt = dateTimeFromStr(root.value(QStringLiteral("createdAt")).toString());
+
+  for(const QJsonValue& v : root.value(QStringLiteral("tasks")).toArray()) {
+    p.tasks.append(taskFromJson(v.toObject()));
+  }
+  for(const QJsonValue& v : root.value(QStringLiteral("people")).toArray()) {
+    p.people.append(personFromJson(v.toObject()));
+  }
+  for(const QJsonValue& v : root.value(QStringLiteral("statuses")).toArray()) {
+    p.statuses.append(v.toObject().toVariantMap());
+  }
+  p.docsState = root.value(QStringLiteral("docsState")).toString();
+  p.notesState = root.value(QStringLiteral("notesState")).toString();
+  return p;
+}
+
+// ── Events file ──
+QByteArray SyncSerializer::serializeEvents(const QVector<CalEvent>& events) {
+  QJsonArray arr;
+  for(const CalEvent& e : events) {
+    arr.append(eventToJson(e));
+  }
+  QJsonObject root;
+  root[QStringLiteral("events")] = sortedById(arr);
+  return QJsonDocument(root).toJson(QJsonDocument::Indented);
+}
+
+QVector<CalEvent> SyncSerializer::deserializeEvents(const QByteArray& json) {
+  QVector<CalEvent> out;
+  const QJsonDocument doc = QJsonDocument::fromJson(json);
+  if(!doc.isObject()) {
+    return out;
+  }
+  for(const QJsonValue& v : doc.object().value(QStringLiteral("events")).toArray()) {
+    out.append(eventFromJson(v.toObject()));
+  }
+  return out;
+}
+
+}  // namespace heap::sync

--- a/src/sync/SyncSerializer.h
+++ b/src/sync/SyncSerializer.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "Models.h"
+
+#include <QByteArray>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QVector>
+
+#include <optional>
+
+namespace heap::sync {
+
+// Serializes heap. entities to/from the human-readable, git-friendly JSON that
+// the BYOS git-remote backend (HEAP-19) stores one-file-per-entity in the sync
+// repository.
+//
+// The single non-obvious requirement is STABLE ordering: git merges and diffs
+// line-by-line, so the byte output for a given logical state must not depend on
+// in-memory ordering. QJsonObject already keeps its keys sorted, so the only
+// remaining source of churn is entity arrays — those are sorted by "id" before
+// emission. Two profiles that differ only in task/person/status vector order
+// therefore serialize to identical bytes, and a round-trip is idempotent.
+class SyncSerializer {
+ public:
+  // Profile → pretty-printed JSON (tasks/people/statuses sorted by id).
+  static QByteArray serializeProfile(const Profile& p);
+  // JSON → Profile. Returns nullopt when the document is not a JSON object.
+  static std::optional<Profile> deserializeProfile(const QByteArray& json);
+
+  // Global calendar events → JSON (events.json), sorted by id.
+  static QByteArray serializeEvents(const QVector<CalEvent>& events);
+  static QVector<CalEvent> deserializeEvents(const QByteArray& json);
+
+  // ── Building blocks (exposed for reuse / testing) ──
+  static QJsonObject taskToJson(const Task& t);
+  static Task taskFromJson(const QJsonObject& o);
+  static QJsonObject personToJson(const Person& p);
+  static Person personFromJson(const QJsonObject& o);
+  static QJsonObject eventToJson(const CalEvent& e);
+  static CalEvent eventFromJson(const QJsonObject& o);
+
+  // Sort a JSON array of objects by their "id" field (stable ordering helper).
+  static QJsonArray sortedById(const QJsonArray& arr);
+};
+
+}  // namespace heap::sync

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -218,6 +218,31 @@ endif ()
 
 add_test(NAME heap_notes_tests COMMAND heap_notes_tests)
 
+# ─── Sync (BYOS serializer) tests ───
+# Cover heap::sync::SyncSerializer — Profile/CalEvent ↔ git-friendly JSON with
+# stable (id-sorted) ordering and idempotent round-trips. Pure data code; needs
+# Qt6::Gui for QColor and Qt6::Qml only for the qqmlregistration.h header pulled
+# in transitively by Models.h.
+add_executable(heap_sync_tests
+        test_sync_serializer.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/sync/SyncSerializer.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/sync/SyncSerializer.h
+)
+
+target_include_directories(heap_sync_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src
+)
+
+target_link_libraries(heap_sync_tests PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        GTest::gtest
+        GTest::gtest_main
+)
+
+add_test(NAME heap_sync_tests COMMAND heap_sync_tests)
+
 # ─── Aggregate target ───
 # Build target that depends on every executable defined in this directory.
 # CI builds `heap_all_tests`; adding a new test exe via add_executable() in

--- a/tests/test_sync_serializer.cpp
+++ b/tests/test_sync_serializer.cpp
@@ -1,0 +1,165 @@
+#include "sync/SyncSerializer.h"
+
+#include <QByteArray>
+#include <QColor>
+#include <QDate>
+#include <QDateTime>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+using heap::sync::SyncSerializer;
+
+namespace {
+
+Task makeTask(const QString& id, const QString& title) {
+  Task t;
+  t.id = id;
+  t.title = title;
+  t.desc = QStringLiteral("desc of ") + id;
+  t.priority = QStringLiteral("P1");
+  t.status = QStringLiteral("prog");
+  t.deadline = QDate(2026, 7, 15);
+  t.branch = QStringLiteral("fix/") + id;
+  t.statusChangedAt = QDateTime(QDate(2026, 7, 1), QTime(14, 30));
+  t.archived = false;
+  return t;
+}
+
+Profile makeProfile() {
+  Profile p;
+  p.id = QStringLiteral("lte-core");
+  p.name = QStringLiteral("LTE Core");
+  p.color = QStringLiteral("#5cc2dd");
+  p.createdAt = QDateTime(QDate(2026, 1, 2), QTime(9, 0));
+  // Deliberately out of id order to exercise stable sorting.
+  p.tasks = {makeTask("T-3", "third"), makeTask("T-1", "first"), makeTask("T-2", "second")};
+
+  Person a;
+  a.id = QStringLiteral("a.ivanov");
+  a.name = QStringLiteral("Anton Ivanov");
+  a.role = QStringLiteral("dev");
+  a.question = QStringLiteral("review?");
+  a.state = QStringLiteral("pinged");
+  a.color = QColor("#d97a6c");
+  p.people = {a};
+
+  p.statuses = QVariantList{
+      QVariantMap{{"id", "prog"}, {"name", "In progress"}, {"color", "#83a598"}},
+      QVariantMap{{"id", "done"}, {"name", "Done"}, {"color", "#b8bb26"}},
+  };
+  p.docsState = QStringLiteral("{\"docs\":{}}");
+  p.notesState = QStringLiteral("# Notes\n- one\n- two");
+  return p;
+}
+
+}  // namespace
+
+// ─── Round-trip idempotency ───
+
+TEST(SyncSerializer, ProfileRoundTripPreservesFields) {
+  const Profile p = makeProfile();
+  const QByteArray json = SyncSerializer::serializeProfile(p);
+  const auto back = SyncSerializer::deserializeProfile(json);
+  ASSERT_TRUE(back.has_value());
+
+  EXPECT_EQ(back->id, p.id);
+  EXPECT_EQ(back->name, p.name);
+  EXPECT_EQ(back->color, p.color);
+  EXPECT_EQ(back->createdAt, p.createdAt);
+  EXPECT_EQ(back->tasks.size(), 3);
+  EXPECT_EQ(back->people.size(), 1);
+  EXPECT_EQ(back->statuses.size(), 2);
+  EXPECT_EQ(back->docsState, p.docsState);
+  EXPECT_EQ(back->notesState, p.notesState);
+}
+
+TEST(SyncSerializer, TaskFieldsSurviveRoundTrip) {
+  const Profile p = makeProfile();
+  const auto back = SyncSerializer::deserializeProfile(SyncSerializer::serializeProfile(p));
+  ASSERT_TRUE(back.has_value());
+  // Tasks come back sorted by id: T-1, T-2, T-3.
+  const Task& first = back->tasks.at(0);
+  EXPECT_EQ(first.id, QString("T-1"));
+  EXPECT_EQ(first.title, QString("first"));
+  EXPECT_EQ(first.priority, QString("P1"));
+  EXPECT_EQ(first.deadline, QDate(2026, 7, 15));
+  EXPECT_EQ(first.statusChangedAt, QDateTime(QDate(2026, 7, 1), QTime(14, 30)));
+  EXPECT_FALSE(first.archived);
+  EXPECT_EQ(first.branch, QString("fix/T-1"));
+}
+
+TEST(SyncSerializer, PersonColorSurvivesRoundTrip) {
+  const Profile p = makeProfile();
+  const auto back = SyncSerializer::deserializeProfile(SyncSerializer::serializeProfile(p));
+  ASSERT_TRUE(back.has_value());
+  ASSERT_EQ(back->people.size(), 1);
+  EXPECT_EQ(back->people.at(0).color.name(QColor::HexRgb), QString("#d97a6c"));
+}
+
+TEST(SyncSerializer, SerializeIsIdempotent) {
+  const Profile p = makeProfile();
+  const QByteArray once = SyncSerializer::serializeProfile(p);
+  const auto back = SyncSerializer::deserializeProfile(once);
+  ASSERT_TRUE(back.has_value());
+  const QByteArray twice = SyncSerializer::serializeProfile(*back);
+  EXPECT_EQ(once, twice);
+}
+
+// ─── Stable ordering: byte output must not depend on vector order ───
+
+TEST(SyncSerializer, StableOrderingIndependentOfTaskVectorOrder) {
+  Profile a = makeProfile();  // tasks: T-3, T-1, T-2
+  Profile b = makeProfile();
+  // Reverse b's task vector — same logical content, different order.
+  std::reverse(b.tasks.begin(), b.tasks.end());
+  EXPECT_EQ(SyncSerializer::serializeProfile(a), SyncSerializer::serializeProfile(b));
+}
+
+TEST(SyncSerializer, TasksEmittedSortedById) {
+  const Profile p = makeProfile();
+  const QByteArray json = SyncSerializer::serializeProfile(p);
+  const QString s = QString::fromUtf8(json);
+  const int i1 = s.indexOf(QStringLiteral("\"T-1\""));
+  const int i2 = s.indexOf(QStringLiteral("\"T-2\""));
+  const int i3 = s.indexOf(QStringLiteral("\"T-3\""));
+  ASSERT_GE(i1, 0);
+  ASSERT_GE(i2, 0);
+  ASSERT_GE(i3, 0);
+  EXPECT_LT(i1, i2);
+  EXPECT_LT(i2, i3);
+}
+
+// ─── Events file ───
+
+TEST(SyncSerializer, EventsRoundTrip) {
+  CalEvent e;
+  e.id = QStringLiteral("ev-1");
+  e.title = QStringLiteral("Standup");
+  e.type = QStringLiteral("standup");
+  e.start = 10.0;
+  e.end = 10.5;
+  e.attendees = QStringLiteral("team");
+  e.date = QDate(2026, 7, 2);
+  e.taskId = QStringLiteral("T-1");
+  e.profileId = QStringLiteral("lte-core");
+  e.context = QStringLiteral("daily");
+
+  const QByteArray json = SyncSerializer::serializeEvents({e});
+  const QVector<CalEvent> back = SyncSerializer::deserializeEvents(json);
+  ASSERT_EQ(back.size(), 1);
+  EXPECT_EQ(back.at(0).id, QString("ev-1"));
+  EXPECT_DOUBLE_EQ(back.at(0).start, 10.0);
+  EXPECT_DOUBLE_EQ(back.at(0).end, 10.5);
+  EXPECT_EQ(back.at(0).date, QDate(2026, 7, 2));
+  EXPECT_EQ(back.at(0).taskId, QString("T-1"));
+}
+
+// ─── Malformed input ───
+
+TEST(SyncSerializer, DeserializeRejectsNonObject) {
+  EXPECT_FALSE(SyncSerializer::deserializeProfile(QByteArray("[]")).has_value());
+  EXPECT_FALSE(SyncSerializer::deserializeProfile(QByteArray("not json")).has_value());
+  EXPECT_TRUE(SyncSerializer::deserializeEvents(QByteArray("garbage")).isEmpty());
+}


### PR DESCRIPTION
Adds src/sync/SyncSerializer (Profile/CalEvent ↔ stable id-sorted JSON, idempotent round-trips) + heap_sync_tests. Conflicts (CMakeLists, from heap_core refactor) resolved by grafting sources into heap_core + the suite. Builds, 17/17 ctest green.