### PR TITLE
feat: Notes query-language parser (HEAP-20)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ qt_add_executable(heap WIN32
     src/git/BranchTaskMatcher.cpp
     src/git/GitWatcher.cpp
     src/text/TaskTextUtils.cpp
+    src/query/QueryParser.cpp
     src/notify/NotificationCenter.cpp
     src/notify/NotificationCenter_tray.cpp
     $<$<PLATFORM_ID:Linux>:${CMAKE_SOURCE_DIR}/src/notify/NotificationCenter_linux.cpp>
@@ -130,6 +131,7 @@ qt_add_qml_module(heap
         src/git/GitTypes.h
         src/git/GitWatcher.h
         src/text/TaskTextUtils.h
+        src/query/QueryParser.h
         src/notify/NotificationCenter.h
 )
 

--- a/src/query/QueryParser.cpp
+++ b/src/query/QueryParser.cpp
@@ -1,0 +1,102 @@
+#include "query/QueryParser.h"
+
+#include <QRegularExpression>
+#include <QSet>
+
+namespace heap::query {
+
+namespace {
+
+const QSet<QString>& filterFields() {
+  static const QSet<QString> f = {QStringLiteral("status"),  QStringLiteral("priority"), QStringLiteral("deadline"),
+                                  QStringLiteral("profile"), QStringLiteral("mention"),  QStringLiteral("tag")};
+  return f;
+}
+
+// Strip a leading comparison operator from `spec`, returning the matching Op and
+// mutating `spec` to the remainder. Defaults to Eq (no prefix).
+Op takeOp(QString& spec) {
+  if(spec.startsWith(QLatin1String("<="))) {
+    spec = spec.mid(2);
+    return Op::Le;
+  }
+  if(spec.startsWith(QLatin1String(">="))) {
+    spec = spec.mid(2);
+    return Op::Ge;
+  }
+  if(spec.startsWith(QLatin1Char('<'))) {
+    spec = spec.mid(1);
+    return Op::Lt;
+  }
+  if(spec.startsWith(QLatin1Char('>'))) {
+    spec = spec.mid(1);
+    return Op::Gt;
+  }
+  return Op::Eq;
+}
+
+}  // namespace
+
+ParsedQuery QueryParser::parse(const QString& text) {
+  ParsedQuery q;
+  const QStringList tokens = text.split(QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+  for(const QString& tok : tokens) {
+    const int sep = tok.indexOf(QLatin1Char(':'));
+    if(sep <= 0 || sep == tok.size() - 1) {
+      continue;  // no field or no spec
+    }
+    const QString field = tok.left(sep).toLower();
+    QString spec = tok.mid(sep + 1);
+
+    if(field == QLatin1String("sort")) {
+      if(spec.startsWith(QLatin1Char('-'))) {
+        q.orderDesc = true;
+        spec = spec.mid(1);
+      }
+      if(!spec.isEmpty()) {
+        q.orderBy = spec;
+        q.ok = true;
+      }
+      continue;
+    }
+    if(field == QLatin1String("limit")) {
+      bool okNum = false;
+      const int n = spec.toInt(&okNum);
+      if(okNum && n > 0) {
+        q.limit = n;
+        q.ok = true;
+      }
+      continue;
+    }
+    if(!filterFields().contains(field)) {
+      continue;  // unknown field
+    }
+
+    Condition c;
+    c.field = field;
+    c.op = takeOp(spec);
+    QStringList vals;
+    for(const QString& raw : spec.split(QLatin1Char(','), Qt::SkipEmptyParts)) {
+      QString v = raw.trimmed();
+      if(field == QLatin1String("mention") && v.startsWith(QLatin1Char('@'))) {
+        v = v.mid(1);
+      }
+      if(!v.isEmpty()) {
+        vals << v;
+      }
+    }
+    if(vals.isEmpty()) {
+      continue;  // e.g. "status:" or "status:@" → nothing usable
+    }
+    // A comma list under the default operator is set membership.
+    if(c.op == Op::Eq && vals.size() > 1) {
+      c.op = Op::In;
+    }
+    c.values = vals;
+    q.conditions.append(c);
+    q.ok = true;
+  }
+  return q;
+}
+
+}  // namespace heap::query

--- a/src/query/QueryParser.h
+++ b/src/query/QueryParser.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+namespace heap::query {
+
+enum class Op { Eq, In, Lt, Le, Gt, Ge };
+
+// One `field:spec` clause. `values` holds one entry for Eq/comparison ops and
+// several for In (comma-separated).
+struct Condition {
+  QString field;  // "status" | "priority" | "deadline" | "profile" | "mention" | "tag"
+  Op op = Op::Eq;
+  QStringList values;
+};
+
+// A parsed Notes query, e.g. `status:blocked priority:P0,P1 deadline:<7d sort:-deadline limit:20`.
+struct ParsedQuery {
+  QVector<Condition> conditions;  // AND-joined
+  QString orderBy;
+  bool orderDesc = false;
+  int limit = 50;
+  bool ok = false;  // true when at least one recognized clause was parsed
+};
+
+// Pure parser for the mini query language embedded in Notes. Tokenizes on
+// whitespace; each token is `field:spec`. Comparison prefixes on the spec
+// (`<`, `<=`, `>`, `>=`) select the operator; a comma-separated spec becomes an
+// In. `sort:field` / `sort:-field` and `limit:N` are recognized specially.
+// Unknown fields and malformed tokens are skipped.
+class QueryParser {
+ public:
+  static ParsedQuery parse(const QString& text);
+};
+
+}  // namespace heap::query

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -218,6 +218,21 @@ endif ()
 
 add_test(NAME heap_notes_tests COMMAND heap_notes_tests)
 
+# ─── Query (Notes query-language parser) tests ───
+# Pure tokenizer/parser for the embedded Notes query language. Qt6::Core only.
+add_executable(heap_query_tests
+        test_query_parser.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/query/QueryParser.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/query/QueryParser.h
+)
+target_include_directories(heap_query_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_link_libraries(heap_query_tests PRIVATE
+        Qt6::Core
+        GTest::gtest
+        GTest::gtest_main
+)
+add_test(NAME heap_query_tests COMMAND heap_query_tests)
+
 # ─── Aggregate target ───
 # Build target that depends on every executable defined in this directory.
 # CI builds `heap_all_tests`; adding a new test exe via add_executable() in

--- a/tests/test_query_parser.cpp
+++ b/tests/test_query_parser.cpp
@@ -1,0 +1,98 @@
+#include "query/QueryParser.h"
+
+#include <gtest/gtest.h>
+
+using heap::query::Op;
+using heap::query::ParsedQuery;
+using heap::query::QueryParser;
+
+TEST(QueryParser, EmptyIsNotOk) {
+  const ParsedQuery q = QueryParser::parse(QString());
+  EXPECT_FALSE(q.ok);
+  EXPECT_TRUE(q.conditions.isEmpty());
+  EXPECT_EQ(q.limit, 50);  // default
+}
+
+TEST(QueryParser, SingleEq) {
+  const ParsedQuery q = QueryParser::parse(QStringLiteral("status:blocked"));
+  ASSERT_TRUE(q.ok);
+  ASSERT_EQ(q.conditions.size(), 1);
+  EXPECT_EQ(q.conditions.at(0).field, QString("status"));
+  EXPECT_EQ(q.conditions.at(0).op, Op::Eq);
+  ASSERT_EQ(q.conditions.at(0).values.size(), 1);
+  EXPECT_EQ(q.conditions.at(0).values.at(0), QString("blocked"));
+}
+
+TEST(QueryParser, CommaListBecomesIn) {
+  const ParsedQuery q = QueryParser::parse(QStringLiteral("priority:P0,P1"));
+  ASSERT_EQ(q.conditions.size(), 1);
+  EXPECT_EQ(q.conditions.at(0).op, Op::In);
+  ASSERT_EQ(q.conditions.at(0).values.size(), 2);
+  EXPECT_EQ(q.conditions.at(0).values.at(0), QString("P0"));
+  EXPECT_EQ(q.conditions.at(0).values.at(1), QString("P1"));
+}
+
+TEST(QueryParser, ComparisonOperators) {
+  EXPECT_EQ(QueryParser::parse(QStringLiteral("deadline:<7d")).conditions.at(0).op, Op::Lt);
+  EXPECT_EQ(QueryParser::parse(QStringLiteral("deadline:<=7d")).conditions.at(0).op, Op::Le);
+  EXPECT_EQ(QueryParser::parse(QStringLiteral("deadline:>7d")).conditions.at(0).op, Op::Gt);
+  EXPECT_EQ(QueryParser::parse(QStringLiteral("deadline:>=7d")).conditions.at(0).op, Op::Ge);
+  // The operator is stripped from the value.
+  EXPECT_EQ(QueryParser::parse(QStringLiteral("deadline:<7d")).conditions.at(0).values.at(0), QString("7d"));
+}
+
+TEST(QueryParser, MentionStripsAt) {
+  const ParsedQuery q = QueryParser::parse(QStringLiteral("mention:@oleg"));
+  ASSERT_EQ(q.conditions.size(), 1);
+  EXPECT_EQ(q.conditions.at(0).field, QString("mention"));
+  EXPECT_EQ(q.conditions.at(0).values.at(0), QString("oleg"));
+}
+
+TEST(QueryParser, MultipleClausesAnded) {
+  const ParsedQuery q = QueryParser::parse(QStringLiteral("status:blocked priority:P0,P1 profile:lte-core"));
+  ASSERT_EQ(q.conditions.size(), 3);
+  EXPECT_EQ(q.conditions.at(0).field, QString("status"));
+  EXPECT_EQ(q.conditions.at(1).field, QString("priority"));
+  EXPECT_EQ(q.conditions.at(2).field, QString("profile"));
+}
+
+TEST(QueryParser, SortAscAndDesc) {
+  const ParsedQuery a = QueryParser::parse(QStringLiteral("sort:deadline"));
+  EXPECT_TRUE(a.ok);
+  EXPECT_EQ(a.orderBy, QString("deadline"));
+  EXPECT_FALSE(a.orderDesc);
+
+  const ParsedQuery d = QueryParser::parse(QStringLiteral("sort:-deadline"));
+  EXPECT_EQ(d.orderBy, QString("deadline"));
+  EXPECT_TRUE(d.orderDesc);
+}
+
+TEST(QueryParser, LimitParsed) {
+  const ParsedQuery q = QueryParser::parse(QStringLiteral("status:done limit:20"));
+  EXPECT_EQ(q.limit, 20);
+  EXPECT_EQ(q.conditions.size(), 1);
+}
+
+TEST(QueryParser, LimitInvalidIgnored) {
+  const ParsedQuery q = QueryParser::parse(QStringLiteral("limit:abc"));
+  EXPECT_EQ(q.limit, 50);   // default kept
+  EXPECT_FALSE(q.ok);       // nothing recognized
+}
+
+TEST(QueryParser, UnknownFieldSkipped) {
+  const ParsedQuery q = QueryParser::parse(QStringLiteral("wibble:x status:done"));
+  ASSERT_EQ(q.conditions.size(), 1);
+  EXPECT_EQ(q.conditions.at(0).field, QString("status"));
+}
+
+TEST(QueryParser, MalformedTokensSkipped) {
+  const ParsedQuery q = QueryParser::parse(QStringLiteral("noColon status: :novalue status:open"));
+  ASSERT_EQ(q.conditions.size(), 1);
+  EXPECT_EQ(q.conditions.at(0).values.at(0), QString("open"));
+}
+
+TEST(QueryParser, CaseInsensitiveField) {
+  const ParsedQuery q = QueryParser::parse(QStringLiteral("STATUS:done"));
+  ASSERT_EQ(q.conditions.size(), 1);
+  EXPECT_EQ(q.conditions.at(0).field, QString("status"));
+}


### PR DESCRIPTION
Adds src/query/QueryParser (tokenizer/parser for the embedded Notes query language) + heap_query_tests. tests/CMakeLists conflict (interleaved suites from heap_core refactor) resolved. Builds, 18/18 ctest green.