### PR TITLE
feat: JsonMerger — 3-way structural merge for non-git sync (HEAP-27)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ qt_add_executable(heap WIN32
     src/text/TaskTextUtils.cpp
     src/notify/NotificationCenter.cpp
     src/notify/NotificationCenter_tray.cpp
+    src/sync/JsonMerger.cpp
     $<$<PLATFORM_ID:Linux>:${CMAKE_SOURCE_DIR}/src/notify/NotificationCenter_linux.cpp>
         $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/design/brand-export/icon/heap-icon.rc>
 )
@@ -131,6 +132,7 @@ qt_add_qml_module(heap
         src/git/GitWatcher.h
         src/text/TaskTextUtils.h
         src/notify/NotificationCenter.h
+        src/sync/JsonMerger.h
 )
 
 target_include_directories(heap PRIVATE src)

--- a/src/sync/JsonMerger.cpp
+++ b/src/sync/JsonMerger.cpp
@@ -1,0 +1,215 @@
+#include "sync/JsonMerger.h"
+
+#include <QHash>
+#include <QJsonArray>
+#include <QSet>
+#include <QStringList>
+
+#include <algorithm>
+
+namespace heap::sync {
+
+namespace {
+
+const QLatin1String kId("id");
+const QLatin1String kUpdatedAt("updatedAt");
+const QLatin1String kCreatedAt("createdAt");
+
+QString joinPath(const QString& prefix, const QString& key) {
+  return prefix + QLatin1Char('/') + key;
+}
+
+QString idOf(const QJsonValue& v) {
+  return v.isObject() ? v.toObject().value(kId).toString() : QString();
+}
+
+bool isIdObject(const QJsonValue& v) {
+  return v.isObject() && !v.toObject().value(kId).toString().isEmpty();
+}
+
+// Forward decls for the mutual recursion.
+QJsonObject mergeObject(const QJsonObject& base, const QJsonObject& local, const QJsonObject& remote, const QString& path,
+                        QVector<MergeConflict>& conflicts);
+QJsonArray mergeArray(const QJsonArray& base, const QJsonArray& local, const QJsonArray& remote, const QString& path,
+                      QVector<MergeConflict>& conflicts);
+
+void recordConflict(QVector<MergeConflict>& conflicts, const QString& path, const QJsonValue& b, const QJsonValue& l,
+                    const QJsonValue& r) {
+  conflicts.append(MergeConflict{path, b, l, r});
+}
+
+// Resolve one value slot. Returns the chosen value; if the slot should be
+// absent from the parent (both sides deleted, or delete-vs-unchanged), returns
+// Undefined. `key` is the leaf name (for the createdAt special-case).
+QJsonValue mergeValue(const QString& key, const QString& path, const QJsonValue& b, const QJsonValue& l,
+                      const QJsonValue& r, QVector<MergeConflict>& conflicts) {
+  if(l == r) {
+    return l;  // both agree (Undefined == Undefined → key dropped)
+  }
+  if(l == b) {
+    return r;  // only remote changed (incl. remote deletion → Undefined)
+  }
+  if(r == b) {
+    return l;  // only local changed
+  }
+
+  // Both diverged from base and from each other.
+  if(key == kCreatedAt && l.isString() && r.isString()) {
+    return l.toString() <= r.toString() ? l : r;  // earlier timestamp wins
+  }
+  if(l.isObject() && r.isObject()) {
+    return mergeObject(b.isObject() ? b.toObject() : QJsonObject(), l.toObject(), r.toObject(), path, conflicts);
+  }
+  if(l.isArray() && r.isArray()) {
+    return mergeArray(b.isArray() ? b.toArray() : QJsonArray(), l.toArray(), r.toArray(), path, conflicts);
+  }
+  recordConflict(conflicts, path, b, l, r);
+  return l;  // keep local; conflict recorded
+}
+
+QJsonObject mergeObject(const QJsonObject& base, const QJsonObject& local, const QJsonObject& remote, const QString& path,
+                        QVector<MergeConflict>& conflicts) {
+  QStringList keys;
+  for(const QString& k : base.keys()) {
+    keys << k;
+  }
+  for(const QString& k : local.keys()) {
+    if(!keys.contains(k)) {
+      keys << k;
+    }
+  }
+  for(const QString& k : remote.keys()) {
+    if(!keys.contains(k)) {
+      keys << k;
+    }
+  }
+
+  QJsonObject out;
+  for(const QString& k : keys) {
+    const QJsonValue merged =
+        mergeValue(k, joinPath(path, k), base.value(k), local.value(k), remote.value(k), conflicts);
+    if(!merged.isUndefined()) {
+      out.insert(k, merged);
+    }
+  }
+  return out;
+}
+
+// Element-level LWW for a task/person/event that both sides edited differently.
+QJsonValue lwwOrConflict(const QString& path, const QJsonValue& b, const QJsonValue& l, const QJsonValue& r,
+                         QVector<MergeConflict>& conflicts) {
+  const QString lu = l.toObject().value(kUpdatedAt).toString();
+  const QString ru = r.toObject().value(kUpdatedAt).toString();
+  if(!lu.isEmpty() && !ru.isEmpty()) {
+    return lu >= ru ? l : r;  // later write wins (tie → local)
+  }
+  recordConflict(conflicts, path, b, l, r);
+  return l;
+}
+
+QJsonArray mergeArray(const QJsonArray& base, const QJsonArray& local, const QJsonArray& remote, const QString& path,
+                      QVector<MergeConflict>& conflicts) {
+  // If any element isn't an id-carrying object, treat the whole array as opaque.
+  auto allIdObjects = [](const QJsonArray& a) {
+    for(const QJsonValue& v : a) {
+      if(!isIdObject(v)) {
+        return false;
+      }
+    }
+    return true;
+  };
+  if(!allIdObjects(local) || !allIdObjects(remote)) {
+    // Fall back to scalar-style resolution on the array as a whole.
+    if(local == remote) {
+      return local;
+    }
+    if(local == base) {
+      return remote;
+    }
+    if(remote == base) {
+      return local;
+    }
+    recordConflict(conflicts, path, base, local, remote);
+    return local;
+  }
+
+  auto byId = [](const QJsonArray& a) {
+    QHash<QString, QJsonValue> m;
+    for(const QJsonValue& v : a) {
+      m.insert(idOf(v), v);
+    }
+    return m;
+  };
+  const QHash<QString, QJsonValue> bm = byId(base);
+  const QHash<QString, QJsonValue> lm = byId(local);
+  const QHash<QString, QJsonValue> rm = byId(remote);
+
+  QSet<QString> ids;
+  for(const QString& id : lm.keys()) {
+    ids.insert(id);
+  }
+  for(const QString& id : rm.keys()) {
+    ids.insert(id);
+  }
+
+  QVector<QJsonValue> kept;
+  for(const QString& id : ids) {
+    const bool hb = bm.contains(id);
+    const bool hl = lm.contains(id);
+    const bool hr = rm.contains(id);
+    const QJsonValue b = hb ? bm.value(id) : QJsonValue(QJsonValue::Undefined);
+    const QJsonValue l = hl ? lm.value(id) : QJsonValue(QJsonValue::Undefined);
+    const QJsonValue r = hr ? rm.value(id) : QJsonValue(QJsonValue::Undefined);
+    const QString elemPath = joinPath(path, id);
+
+    if(hl && hr) {
+      if(l == r) {
+        kept.append(l);
+      } else if(hb && l == b) {
+        kept.append(r);  // only remote edited
+      } else if(hb && r == b) {
+        kept.append(l);  // only local edited
+      } else {
+        kept.append(lwwOrConflict(elemPath, b, l, r, conflicts));  // both edited / both added
+      }
+    } else if(hl && !hr) {
+      if(!hb) {
+        kept.append(l);  // local add
+      } else if(l == b) {
+        // remote deleted, local unchanged → drop
+      } else {
+        recordConflict(conflicts, elemPath, b, l, r);  // edit vs delete
+        kept.append(l);
+      }
+    } else if(!hl && hr) {
+      if(!hb) {
+        kept.append(r);  // remote add
+      } else if(r == b) {
+        // local deleted, remote unchanged → drop
+      } else {
+        recordConflict(conflicts, elemPath, b, l, r);
+        kept.append(r);
+      }
+    }
+  }
+
+  // Deterministic output — sort by id (matches SyncSerializer's stable order).
+  std::sort(kept.begin(), kept.end(),
+            [](const QJsonValue& a, const QJsonValue& b) { return idOf(a) < idOf(b); });
+  QJsonArray out;
+  for(const QJsonValue& v : kept) {
+    out.append(v);
+  }
+  return out;
+}
+
+}  // namespace
+
+MergeResult JsonMerger::merge(const QJsonObject& base, const QJsonObject& local, const QJsonObject& remote) {
+  MergeResult res;
+  res.merged = mergeObject(base, local, remote, QString(), res.conflicts);
+  res.ok = res.conflicts.isEmpty();
+  return res;
+}
+
+}  // namespace heap::sync

--- a/src/sync/JsonMerger.h
+++ b/src/sync/JsonMerger.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QString>
+#include <QVector>
+
+namespace heap::sync {
+
+// One unresolved field/element where local and remote both diverged from base.
+struct MergeConflict {
+  QString path;  // JSON pointer-ish, e.g. "/tasks/T-1/title"
+  QJsonValue baseValue;
+  QJsonValue localValue;
+  QJsonValue remoteValue;
+};
+
+struct MergeResult {
+  bool ok = false;  // true when there were no unresolved conflicts
+  QJsonObject merged;
+  QVector<MergeConflict> conflicts;
+};
+
+// Structural 3-way merge of two JSON documents against a known base — the
+// non-git BYOS backends (WebDAV / SSH+rsync) need this because, unlike git,
+// they have no built-in merge. Rules:
+//   - scalars: if only one side changed vs base, take it; if both changed
+//     differently → conflict (the merged doc keeps the local value).
+//   - nested objects: recurse field by field.
+//   - arrays of objects with an "id": merge by id. Items on one side only are
+//     kept (add) or dropped (delete-vs-unchanged); items edited on both sides
+//     use last-write-wins by an "updatedAt" field when present, else conflict.
+//     Arrays without id-objects are treated as an opaque scalar value.
+//   - "createdAt" is never a conflict — the earlier value always wins.
+// The merged document is always populated (conflicts resolve to local) so a
+// caller can proceed and surface `conflicts` in a resolver UI.
+class JsonMerger {
+ public:
+  static MergeResult merge(const QJsonObject& base, const QJsonObject& local, const QJsonObject& remote);
+};
+
+}  // namespace heap::sync

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -218,6 +218,21 @@ endif ()
 
 add_test(NAME heap_notes_tests COMMAND heap_notes_tests)
 
+# ─── Sync (JsonMerger 3-way merge) tests ───
+# Pure structural merge for the non-git BYOS backends. Qt6::Core only.
+add_executable(heap_json_merger_tests
+        test_json_merger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/sync/JsonMerger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/sync/JsonMerger.h
+)
+target_include_directories(heap_json_merger_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_link_libraries(heap_json_merger_tests PRIVATE
+        Qt6::Core
+        GTest::gtest
+        GTest::gtest_main
+)
+add_test(NAME heap_json_merger_tests COMMAND heap_json_merger_tests)
+
 # ─── Aggregate target ───
 # Build target that depends on every executable defined in this directory.
 # CI builds `heap_all_tests`; adding a new test exe via add_executable() in

--- a/tests/test_json_merger.cpp
+++ b/tests/test_json_merger.cpp
@@ -1,0 +1,176 @@
+#include "sync/JsonMerger.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include <gtest/gtest.h>
+
+using heap::sync::JsonMerger;
+using heap::sync::MergeResult;
+
+namespace {
+
+QJsonObject O(const char* json) {
+  return QJsonDocument::fromJson(QByteArray(json)).object();
+}
+
+}  // namespace
+
+// ─── scalars ──────────────────────────────────────────────────────────
+
+TEST(JsonMerger, NoChange) {
+  const QJsonObject b = O(R"({"a":1,"b":"x"})");
+  const MergeResult m = JsonMerger::merge(b, b, b);
+  EXPECT_TRUE(m.ok);
+  EXPECT_EQ(m.merged, b);
+}
+
+TEST(JsonMerger, LocalOnlyEditTaken) {
+  const QJsonObject b = O(R"({"a":1})");
+  const MergeResult m = JsonMerger::merge(b, O(R"({"a":2})"), b);
+  EXPECT_TRUE(m.ok);
+  EXPECT_EQ(m.merged.value("a").toInt(), 2);
+}
+
+TEST(JsonMerger, RemoteOnlyEditTaken) {
+  const QJsonObject b = O(R"({"a":1})");
+  const MergeResult m = JsonMerger::merge(b, b, O(R"({"a":9})"));
+  EXPECT_TRUE(m.ok);
+  EXPECT_EQ(m.merged.value("a").toInt(), 9);
+}
+
+TEST(JsonMerger, EditEditConflictKeepsLocal) {
+  const QJsonObject b = O(R"({"a":1})");
+  const MergeResult m = JsonMerger::merge(b, O(R"({"a":2})"), O(R"({"a":3})"));
+  EXPECT_FALSE(m.ok);
+  ASSERT_EQ(m.conflicts.size(), 1);
+  EXPECT_EQ(m.conflicts.at(0).path, QString("/a"));
+  EXPECT_EQ(m.merged.value("a").toInt(), 2);  // local kept
+}
+
+TEST(JsonMerger, AddAddSameNoConflict) {
+  const QJsonObject b = O(R"({})");
+  const MergeResult m = JsonMerger::merge(b, O(R"({"k":"v"})"), O(R"({"k":"v"})"));
+  EXPECT_TRUE(m.ok);
+  EXPECT_EQ(m.merged.value("k").toString(), QString("v"));
+}
+
+TEST(JsonMerger, AddAddConflict) {
+  const QJsonObject b = O(R"({})");
+  const MergeResult m = JsonMerger::merge(b, O(R"({"k":"l"})"), O(R"({"k":"r"})"));
+  EXPECT_FALSE(m.ok);
+  EXPECT_EQ(m.merged.value("k").toString(), QString("l"));
+}
+
+TEST(JsonMerger, RemoteDeleteLocalUnchangedDrops) {
+  const QJsonObject b = O(R"({"a":1,"b":2})");
+  const MergeResult m = JsonMerger::merge(b, b, O(R"({"a":1})"));
+  EXPECT_TRUE(m.ok);
+  EXPECT_FALSE(m.merged.contains("b"));
+}
+
+TEST(JsonMerger, EditDeleteConflictKeepsLocal) {
+  const QJsonObject b = O(R"({"a":1,"b":2})");
+  const MergeResult m = JsonMerger::merge(b, O(R"({"a":1,"b":5})"), O(R"({"a":1})"));
+  EXPECT_FALSE(m.ok);
+  EXPECT_EQ(m.merged.value("b").toInt(), 5);
+}
+
+TEST(JsonMerger, NestedObjectRecurseMergesBothFields) {
+  const QJsonObject b = O(R"({"o":{"x":1,"y":1}})");
+  const MergeResult m = JsonMerger::merge(b, O(R"({"o":{"x":2,"y":1}})"), O(R"({"o":{"x":1,"y":3}})"));
+  EXPECT_TRUE(m.ok);
+  EXPECT_EQ(m.merged.value("o").toObject().value("x").toInt(), 2);
+  EXPECT_EQ(m.merged.value("o").toObject().value("y").toInt(), 3);
+}
+
+TEST(JsonMerger, CreatedAtEarliestWinsNoConflict) {
+  const QJsonObject b = O(R"({"createdAt":"2026-05-01T00:00"})");
+  const MergeResult m = JsonMerger::merge(
+      b, O(R"({"createdAt":"2026-04-01T00:00"})"), O(R"({"createdAt":"2026-06-01T00:00"})"));
+  EXPECT_TRUE(m.ok);
+  EXPECT_EQ(m.merged.value("createdAt").toString(), QString("2026-04-01T00:00"));
+}
+
+// ─── arrays merged by id ──────────────────────────────────────────────
+
+TEST(JsonMerger, ArrayAddOnEachSideMergesById) {
+  const QJsonObject b = O(R"({"tasks":[{"id":"T1","t":"a"}]})");
+  const QJsonObject l = O(R"({"tasks":[{"id":"T1","t":"a"},{"id":"T2","t":"b"}]})");
+  const QJsonObject r = O(R"({"tasks":[{"id":"T1","t":"a"},{"id":"T3","t":"c"}]})");
+  const MergeResult m = JsonMerger::merge(b, l, r);
+  EXPECT_TRUE(m.ok);
+  const QJsonArray a = m.merged.value("tasks").toArray();
+  ASSERT_EQ(a.size(), 3);
+  EXPECT_EQ(a.at(0).toObject().value("id").toString(), QString("T1"));
+  EXPECT_EQ(a.at(1).toObject().value("id").toString(), QString("T2"));
+  EXPECT_EQ(a.at(2).toObject().value("id").toString(), QString("T3"));
+}
+
+TEST(JsonMerger, ArrayElementLocalOnlyEdit) {
+  const QJsonObject b = O(R"({"tasks":[{"id":"T1","t":"a"}]})");
+  const QJsonObject l = O(R"({"tasks":[{"id":"T1","t":"b"}]})");
+  const MergeResult m = JsonMerger::merge(b, l, b);
+  EXPECT_TRUE(m.ok);
+  EXPECT_EQ(m.merged.value("tasks").toArray().at(0).toObject().value("t").toString(), QString("b"));
+}
+
+TEST(JsonMerger, ArrayElementBothEditLwwByUpdatedAt) {
+  const QJsonObject b = O(R"({"tasks":[{"id":"T1","t":"a","updatedAt":"2026-01-01T00:00"}]})");
+  const QJsonObject l = O(R"({"tasks":[{"id":"T1","t":"local","updatedAt":"2026-07-01T10:00"}]})");
+  const QJsonObject r = O(R"({"tasks":[{"id":"T1","t":"remote","updatedAt":"2026-07-02T10:00"}]})");
+  const MergeResult m = JsonMerger::merge(b, l, r);
+  EXPECT_TRUE(m.ok);  // LWW resolves it
+  EXPECT_EQ(m.merged.value("tasks").toArray().at(0).toObject().value("t").toString(), QString("remote"));
+}
+
+TEST(JsonMerger, ArrayElementBothEditNoTimestampConflict) {
+  const QJsonObject b = O(R"({"tasks":[{"id":"T1","t":"a"}]})");
+  const QJsonObject l = O(R"({"tasks":[{"id":"T1","t":"local"}]})");
+  const QJsonObject r = O(R"({"tasks":[{"id":"T1","t":"remote"}]})");
+  const MergeResult m = JsonMerger::merge(b, l, r);
+  EXPECT_FALSE(m.ok);
+  ASSERT_EQ(m.conflicts.size(), 1);
+  EXPECT_EQ(m.conflicts.at(0).path, QString("/tasks/T1"));
+  EXPECT_EQ(m.merged.value("tasks").toArray().at(0).toObject().value("t").toString(), QString("local"));
+}
+
+TEST(JsonMerger, ArrayDeleteVsUnchangedDrops) {
+  const QJsonObject b = O(R"({"tasks":[{"id":"T1"},{"id":"T2"}]})");
+  const QJsonObject l = O(R"({"tasks":[{"id":"T1"}]})");  // local dropped T2
+  const MergeResult m = JsonMerger::merge(b, l, b);       // remote unchanged
+  EXPECT_TRUE(m.ok);
+  const QJsonArray a = m.merged.value("tasks").toArray();
+  ASSERT_EQ(a.size(), 1);
+  EXPECT_EQ(a.at(0).toObject().value("id").toString(), QString("T1"));
+}
+
+TEST(JsonMerger, ArrayEditVsDeleteConflict) {
+  const QJsonObject b = O(R"({"tasks":[{"id":"T1","t":"a"}]})");
+  const QJsonObject l = O(R"({"tasks":[{"id":"T1","t":"edited"}]})");  // local edits
+  const QJsonObject r = O(R"({"tasks":[]})");                          // remote deletes
+  const MergeResult m = JsonMerger::merge(b, l, r);
+  EXPECT_FALSE(m.ok);
+  ASSERT_EQ(m.conflicts.size(), 1);
+  EXPECT_EQ(m.merged.value("tasks").toArray().size(), 1);  // local kept
+}
+
+// ─── opaque (non-id) arrays ───────────────────────────────────────────
+
+TEST(JsonMerger, OpaqueArrayLocalOnlyChange) {
+  const QJsonObject b = O(R"({"labels":["a","b"]})");
+  const QJsonObject l = O(R"({"labels":["a","b","c"]})");
+  const MergeResult m = JsonMerger::merge(b, l, b);
+  EXPECT_TRUE(m.ok);
+  EXPECT_EQ(m.merged.value("labels").toArray().size(), 3);
+}
+
+TEST(JsonMerger, OpaqueArrayBothChangeConflict) {
+  const QJsonObject b = O(R"({"labels":["a"]})");
+  const QJsonObject l = O(R"({"labels":["a","l"]})");
+  const QJsonObject r = O(R"({"labels":["a","r"]})");
+  const MergeResult m = JsonMerger::merge(b, l, r);
+  EXPECT_FALSE(m.ok);
+  EXPECT_EQ(m.merged.value("labels").toArray().size(), 2);  // local kept
+}


### PR DESCRIPTION
Adds src/sync/JsonMerger (3-way structural merge for WebDAV/SSH BYOS backends) + heap_json_merger_tests. Conflicts (CMakeLists/tests, heap_core refactor) resolved. Builds, 19/19 ctest green.