### PR TITLE
docs: dev-friendly + accurate landing and README (HEAP-72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,15 @@ for visual reference. The brand bundle lives under `design/brand-export/`; see [
 
 - **Kanban board.** Drag-and-drop columns, status color picker, per-card priority chips, branch decoration,
   scheduled-time pill.
+- **Git-aware.** heap. watches the working copy: the current branch is matched to a task by id, the matching card
+  is decorated with its branch, and a focused-repo banner surfaces branch and PR state — so the board tracks what
+  you're actually building, with no manual linking.
 - **Timeline.** Overdue / today / tomorrow / week / later buckets, with sub-grouping by date and a show-done toggle.
 - **Week view.** 7-day grid with all-day deadline chips and an hourly event grid. Drag, resize, and cross-day move for
   events.
 - **Day calendar.** Drag-to-create events, top and bottom resize, drop a task to schedule a focus block, live now-line.
-- **Docs.** Sections (3GPP, internal, C++, tools) with custom fields. Snippet editor with syntax highlighting. Contact
-  cards.
+- **Docs.** Custom sections (API, internal, C++, tooling) with custom fields. Snippet editor with syntax
+  highlighting. Contact cards.
 - **Notes.** Per-profile markdown canvas with `@people` and `#ticket`
   autocomplete.
 - **Profiles.** Feature-scoped workspaces with JSON import and export.
@@ -60,7 +63,12 @@ for visual reference. The brand bundle lives under `design/brand-export/`; see [
 - [**Data & backups**](docs/DATA.md) — where your data lives, backups, and
   moving a profile between machines.
 
-## Build
+## Get it
+
+**Prebuilt binaries** — a Windows installer, a Linux AppImage, and a portable zip are attached to each
+[GitHub release](https://github.com/sectapunterx/heap/releases). No dependencies to install; download and run.
+
+## Build from source
 
 Requires Qt 6.4+ and a C++20 toolchain.
 
@@ -119,14 +127,22 @@ cmake --build build -j
 
 ```
 .
-├─ CMakeLists.txt          ← qt_add_executable + qt_add_qml_module + qt_add_resources
+├─ CMakeLists.txt          ← heap_core (qt_add_library + qt_add_qml_module) + thin heap exe
 ├─ src/
 │  ├─ main.cpp             ← QApplication entry, window icon, signal handlers
 │  ├─ AppController.{h,cpp}← QML_SINGLETON exposing models, profiles, automation, undo
 │  ├─ Models.{h,cpp}       ← TaskModel / EventModel / PersonModel (QAbstractListModel)
 │  ├─ SampleData.{h,cpp}   ← seed tasks / events / people for first run
 │  ├─ CodeHighlighter.{h,cpp}  ← QSyntaxHighlighter for the docs snippet editor
-│  └─ NotesHighlighter.{h,cpp} ← markdown highlighter for the Notes view
+│  ├─ NotesHighlighter.{h,cpp} ← markdown highlighter for the Notes view
+│  ├─ chrono/              ← natural-language date parser (Quick-capture)
+│  ├─ git/                 ← GitWatcher + branch↔task matcher (git-aware board)
+│  ├─ text/                ← task-text classification / parsing helpers
+│  ├─ notify/              ← cross-platform notifications (tray / D-Bus)
+│  ├─ platform/            ← global hotkey backend (Win32 RegisterHotKey)
+│  ├─ integrations/        ← tracker-sync status mapping (post-release)
+│  ├─ sync/                ← BYOS serializer + 3-way JSON merge
+│  └─ query/              ← Notes query-language parser
 ├─ qml/
 │  ├─ Main.qml             ← top-level window
 │  ├─ Theme.qml            ← singleton: surfaces, accent (reactive), highContrast, reducedMotion
@@ -141,7 +157,7 @@ cmake --build build -j
 │  ├─ WeekView.qml         ← 7-day grid with interactive events
 │  ├─ DayCalendar.qml      ← hourly grid with drag-to-create + resize handles
 │  ├─ MiniWeek.qml         ← week navigator with per-day dots
-│  ├─ PeopleList.qml       ← "Кому написать" todo → pinged → replied
+│  ├─ PeopleList.qml       ← people to follow up with: todo → pinged → replied
 │  ├─ DocsView.qml         ← docs canvas (sections, snippets, contacts)
 │  ├─ DocsEditor.qml       ← modal editor for docs / snippets / contacts
 │  ├─ NotesView.qml        ← markdown notes canvas

--- a/docs/index.html
+++ b/docs/index.html
@@ -111,7 +111,7 @@
         <div class="hero-surface">
             <div class="surface-bar">
                 <div class="dots"><span></span><span></span><span></span></div>
-                <span>heap. — board · eNB-core / sprint-10</span>
+                <span>heap. — board · web-app / sprint-10</span>
                 <span class="meta">qml · 1920 × 1080</span>
             </div>
             <img src="assets/img/screens/board-full.png"
@@ -212,8 +212,8 @@
             <div class="feature-card">
                 <span class="num">05 · know</span>
                 <h4>Docs</h4>
-                <p>Sections (3GPP, internal, C++, tools) with custom fields. Snippet editor with syntax highlighting.
-                    Contact cards.</p>
+                <p>Custom sections (API, internal, C++, tooling) with custom fields. Snippet editor with syntax
+                    highlighting. Contact cards.</p>
             </div>
             <div class="feature-card">
                 <span class="num">06 · know</span>
@@ -238,6 +238,13 @@
                 <h4>Automation</h4>
                 <p>60-second tick auto-archives done tasks, surfaces blocked-stuck warnings, fires deadline and standup
                     reminders. Quiet hours respected.</p>
+            </div>
+            <div class="feature-card">
+                <span class="num">10 · git</span>
+                <h4>Git-aware</h4>
+                <p>Watches the working copy: the current branch is matched to a task by id, the card is decorated with
+                    its <span class="mono">branch</span>, and a focused-repo banner surfaces branch and PR state — no
+                    manual linking.</p>
             </div>
         </div>
     </section>
@@ -347,7 +354,7 @@
                 <div class="screen-caption">
                     <h4>Docs</h4>
                     <p>
-                        Sections (3GPP, internal, C++, tools) with custom fields. A snippet editor with syntax
+                        Custom sections (API, internal, C++, tooling) with custom fields. A snippet editor with syntax
                         highlighting and contact cards sit alongside.
                     </p>
                 </div>
@@ -387,6 +394,11 @@
                 <p class="desc">
                     The build is plain CMake. No package manager, no submodule recursion, no codegen. Qt 6.4+ and a
                     C++20 toolchain are the only prerequisites.
+                </p>
+                <p class="desc" style="font-size:15px;color:var(--text3);">
+                    Prefer a binary? A Windows installer, a Linux AppImage, and a portable zip ship on every
+                    <a href="https://github.com/sectapunterx/heap/releases"
+                       style="color:var(--text2);border-bottom:1px solid var(--border)">release</a>.
                 </p>
                 <p class="fine mono" style="margin-top:8px;">
                     cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j


### PR DESCRIPTION
Polishes the single-page site (docs/index.html) + README for developers:

- Drops telecom leftovers (eNB-core, 3GPP) — consistent with the generic-dev seed.
- Surfaces the **git integration** (branch↔task matching, focused-repo banner) — new Git-aware feature card + README highlight.
- Fixes a stray Russian string; refreshes the README layout for the heap_core refactor + new src/ modules.
- Adds a prebuilt-binary path (installer / AppImage / zip) alongside build-from-source.

Landing verified in-browser (hero, 10-card grid incl. Git-aware, build section). Docs/HTML only.