### PR TITLE
ci: Authenticode-sign Windows binaries + installer (HEAP-62)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,12 @@ jobs:
     name: Package (Windows)
     needs: meta
     runs-on: windows-latest
+    # Job-level env so the optional signing steps' `if:` can read the secret (a
+    # step's own env is not reliably visible to its own `if`, and `secrets`
+    # cannot be referenced in `if` directly). Mirrors the macOS signing pattern.
+    env:
+      WINDOWS_CERT_PFX: ${{ secrets.WINDOWS_CERT_PFX }}
+      WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -97,6 +103,32 @@ jobs:
           export PATH="$MSYS_BASE_UNIX/ucrt64/bin:$MSYS_BASE_UNIX/ucrt64/share/qt6/libexec:$MSYS_BASE_UNIX/ucrt64/share/qt6/bin:$PATH"
           cmake --build build --target portable
 
+      # Authenticode-sign heap.exe + the bundled Qt DLLs before they are
+      # packaged, so both the portable zip and the installer carry signed
+      # binaries. Runs only when the signing secret is configured — unsigned
+      # builds still ship (default). See docs/PACKAGING.md for the secrets.
+      - name: Sign binaries (optional)
+        if: ${{ env.WINDOWS_CERT_PFX != '' }}
+        shell: msys2 {0}
+        run: |
+          set -eu
+          pacman -S --noconfirm --needed mingw-w64-ucrt-x86_64-osslsigncode
+          printf '%s' "$WINDOWS_CERT_PFX" | base64 -d > cert.pfx
+          sign() {
+            osslsigncode sign \
+              -pkcs12 cert.pfx -pass "$WINDOWS_CERT_PASSWORD" \
+              -n "heap." -i "https://github.com/sectapunterx/heap" \
+              -ts http://timestamp.digicert.com -h sha256 \
+              -in "$1" -out "$1.signed"
+            mv -f "$1.signed" "$1"
+          }
+          find build/heap-portable -type f \( -iname '*.exe' -o -iname '*.dll' \) -print0 |
+            while IFS= read -r -d '' f; do
+              echo "signing: $f"
+              sign "$f"
+            done
+          rm -f cert.pfx
+
       - name: Zip portable bundle
         shell: pwsh
         run: Compress-Archive -Path "build\heap-portable\*" -DestinationPath "heap-${{ needs.meta.outputs.tag }}-windows-portable.zip"
@@ -115,6 +147,24 @@ jobs:
             /DBundleDir="$($PWD.Path)\build\heap-portable" `
             "/Fheap-${{ needs.meta.outputs.tag }}-windows-setup" `
             installer\heap.iss
+
+      # Sign the finished installer .exe (the portable binaries it wraps were
+      # already signed above). Same gate — no-op without the cert secret.
+      - name: Sign installer (optional)
+        if: ${{ env.WINDOWS_CERT_PFX != '' }}
+        shell: msys2 {0}
+        run: |
+          set -eu
+          pacman -S --noconfirm --needed mingw-w64-ucrt-x86_64-osslsigncode
+          printf '%s' "$WINDOWS_CERT_PFX" | base64 -d > cert.pfx
+          SETUP="installer/Output/heap-${{ needs.meta.outputs.tag }}-windows-setup.exe"
+          osslsigncode sign \
+            -pkcs12 cert.pfx -pass "$WINDOWS_CERT_PASSWORD" \
+            -n "heap. installer" -i "https://github.com/sectapunterx/heap" \
+            -ts http://timestamp.digicert.com -h sha256 \
+            -in "$SETUP" -out "$SETUP.signed"
+          mv -f "$SETUP.signed" "$SETUP"
+          rm -f cert.pfx
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -43,6 +43,26 @@ present:
 | `MACOS_NOTARY_PASSWORD` | app-specific password for that Apple ID |
 | `MACOS_NOTARY_TEAM_ID` | Apple Developer Team ID |
 
+## Windows signing
+
+Windows binaries and the installer are **unsigned** by default, so SmartScreen
+shows an *"Unknown publisher"* warning on first download/run. To Authenticode-sign
+`heap.exe`, the bundled Qt DLLs and the setup `.exe` automatically, add these repo
+secrets — the workflow's optional signing steps activate when `WINDOWS_CERT_PFX`
+is present (mirrors the macOS pattern):
+
+| Secret | Meaning |
+|--------|---------|
+| `WINDOWS_CERT_PFX` | base64 of an Authenticode code-signing `.pfx`/`.p12` certificate (OV or EV) |
+| `WINDOWS_CERT_PASSWORD` | password for that `.pfx` |
+
+Signing uses [`osslsigncode`](https://github.com/mtrojnar/osslsigncode) with an
+RFC-3161 SHA-256 timestamp, so signatures stay valid after the certificate
+expires. An **EV** certificate earns SmartScreen reputation instantly; an **OV**
+certificate builds it up over downloads. The uninstaller (`unins000.exe`, which
+Inno generates on the target machine) is not signed — add Inno's
+`SignedUninstaller` directive later if that warning needs to go too.
+
 ## Follow-ups (not yet automated)
 
 These formats from the original scope are intentionally deferred — each needs
@@ -52,5 +72,3 @@ proven:
 - **Flatpak** — a `org.heap.heap.yaml` manifest built via `flatpak-builder`
   and pushed to a Flathub repo.
 - **`.rpm`** — an `fpm`/`rpmbuild` job mirroring the `.deb` staging.
-- **Windows code-signing** — an Authenticode certificate to remove the
-  SmartScreen warning (mirrors the macOS secrets pattern).


### PR DESCRIPTION
## HEAP-62 · Code signing (Authenticode) for Windows binaries + installer

**Why:** unsigned binaries trigger Windows SmartScreen *"Unknown publisher"* — a hard trust barrier for a public release (release-blocker).

### What
Wires optional Authenticode signing into the `package-windows` job of `release.yml`, mirroring the existing macOS codesign/notarize pattern:

- Job-level `WINDOWS_CERT_PFX` / `WINDOWS_CERT_PASSWORD` env from repo secrets so the step `if:` guards can read them.
- **Sign binaries** — signs `heap.exe` + bundled Qt DLLs right after the portable bundle is assembled, so *both* the portable zip and the installer wrap signed binaries.
- **Sign installer** — signs the finished Inno Setup `setup.exe`.
- Uses [`osslsigncode`](https://github.com/mtrojnar/osslsigncode) with an RFC-3161 SHA-256 timestamp (signatures survive cert expiry).
- Gated on `WINDOWS_CERT_PFX` being set → **unsigned builds still ship by default**; no behavior change until the secret exists.

Docs: added a *Windows signing* section to `docs/PACKAGING.md` and dropped the now-implemented follow-up bullet.

### Activation (external, out of band)
The steps stay inert until:
1. An OV/EV Authenticode certificate is **purchased** (external procurement — the long pole).
2. `WINDOWS_CERT_PFX` (base64 of the `.pfx`) and `WINDOWS_CERT_PASSWORD` are added as repo secrets.

### Validation
- `release.yml` parses as valid YAML; `ci.yml`'s actionlint job lints it on this PR.
- `release.yml` only triggers on tag push / `workflow_dispatch`, so the signing path is not exercised by PR CI — it can only be end-to-end verified on a real release run once the cert secret is present. The default (unsigned) path is unchanged.
- Uninstaller (`unins000.exe`, generated on the target machine) is intentionally left unsigned; noted as a follow-up in PACKAGING.md.