### PR TITLE
feat: rotating log file + Report an issue / Open logs folder (HEAP-64)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ qt_standard_project_setup(REQUIRES 6.4)
 # executable below becomes a thin shell that just loads Main.qml.
 qt_add_library(heap_core STATIC
     src/AppController.cpp
+    src/Logger.cpp
     src/Models.cpp
     src/SampleData.cpp
     src/CodeHighlighter.cpp

--- a/qml/I18n.qml
+++ b/qml/I18n.qml
@@ -516,6 +516,10 @@ QtObject {
             "settings.about.channel": "Channel",
             "settings.about.storage": "Storage",
             "settings.about.engine": "Engine",
+            "settings.about.diagnostics": "Diagnostics",
+            "settings.about.diagnostics.hint": "Logs are written locally under your data folder. Reporting an issue opens GitHub with your version and a recent log tail pre-filled.",
+            "settings.about.reportIssue": "Report an issue",
+            "settings.about.openLogs": "Open logs folder",
 
             // ── Selection action bar ──
             "selection.bar.count": "%1 selected",
@@ -1002,6 +1006,10 @@ QtObject {
             "settings.about.channel": "Канал",
             "settings.about.storage": "Хранилище",
             "settings.about.engine": "Движок",
+            "settings.about.diagnostics": "Диагностика",
+            "settings.about.diagnostics.hint": "Логи пишутся локально в папке данных. «Сообщить о проблеме» открывает GitHub с уже заполненной версией и хвостом лога.",
+            "settings.about.reportIssue": "Сообщить о проблеме",
+            "settings.about.openLogs": "Открыть папку логов",
 
             // ── Selection action bar ──
             "selection.bar.count": "Выделено: %1",

--- a/qml/SettingsView.qml
+++ b/qml/SettingsView.qml
@@ -1948,6 +1948,45 @@ Item {
                     }
                 }
             }
+            SectionCard {
+                ColumnLayout {
+                    spacing: 12
+                    Layout.fillWidth: true
+                    Sub {
+                        label: I18n.t("settings.about.diagnostics")
+                    }
+                    Text {
+                        text: I18n.t("settings.about.diagnostics.hint")
+                        color: Theme.textMuted
+                        font.pixelSize: 11
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+                    RowLayout {
+                        spacing: 8
+                        Rectangle {
+                            radius: 6
+                            color: reportMA.containsMouse ? Theme.panel3 : Theme.panel2
+                            border.color: Theme.border; border.width: 1
+                            implicitWidth: reportTxt.implicitWidth + 24; implicitHeight: 30
+                            Text {
+                                id: reportTxt; anchors.centerIn: parent; text: I18n.t("settings.about.reportIssue"); color: Theme.text; font.pixelSize: 12
+                            }
+                            MouseArea { id: reportMA; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor; onClicked: AppController.reportAnIssue() }
+                        }
+                        Rectangle {
+                            radius: 6
+                            color: logsMA.containsMouse ? Theme.panel3 : Theme.panel2
+                            border.color: Theme.border; border.width: 1
+                            implicitWidth: logsTxt.implicitWidth + 24; implicitHeight: 30
+                            Text {
+                                id: logsTxt; anchors.centerIn: parent; text: I18n.t("settings.about.openLogs"); color: Theme.text; font.pixelSize: 12
+                            }
+                            MouseArea { id: logsMA; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor; onClicked: AppController.openLogsFolder() }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -1,4 +1,5 @@
 #include "AppController.h"
+#include "Logger.h"
 #include "SampleData.h"
 
 #include "chrono/ChronoParser.h"
@@ -10,7 +11,9 @@
 
 #include <QApplication>
 #include <QClipboard>
+#include <QCoreApplication>
 #include <QDateTime>
+#include <QDesktopServices>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
@@ -23,8 +26,11 @@
 #include <QLocale>
 #include <QSaveFile>
 #include <QStandardPaths>
+#include <QSysInfo>
 #include <QSystemTrayIcon>
 #include <QTime>
+#include <QUrl>
+#include <QUrlQuery>
 #include <QUuid>
 
 #include <cmath>
@@ -1589,6 +1595,35 @@ QString AppController::dataDir() const {
 
 QString AppController::qtVersion() const {
   return QString::fromLatin1(qVersion());
+}
+
+void AppController::openLogsFolder() const {
+  QDesktopServices::openUrl(QUrl::fromLocalFile(heap::logging::logDirPath()));
+}
+
+void AppController::reportAnIssue() const {
+  const QString body = QStringLiteral(
+                           "<!-- Describe the problem above this line. The diagnostics below are "
+                           "filled in automatically — please keep them. -->\n\n"
+                           "---\n"
+                           "**Diagnostics**\n"
+                           "- heap version: %1\n"
+                           "- OS: %2 (%3)\n"
+                           "- Qt: %4\n\n"
+                           "<details><summary>Recent log tail</summary>\n\n"
+                           "```\n%5\n```\n</details>\n")
+                           .arg(QCoreApplication::applicationVersion(),
+                                QSysInfo::prettyProductName(),
+                                QSysInfo::currentCpuArchitecture(),
+                                QString::fromLatin1(qVersion()),
+                                heap::logging::logTail());
+
+  QUrl url(QStringLiteral("https://github.com/sectapunterx/heap/issues/new"));
+  QUrlQuery query;
+  query.addQueryItem(QStringLiteral("title"), QStringLiteral("[bug] "));
+  query.addQueryItem(QStringLiteral("body"), body);
+  url.setQuery(query);
+  QDesktopServices::openUrl(url);
 }
 
 void AppController::scheduleSave() {

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -279,6 +279,14 @@ class AppController : public QObject {
   QString dataDir() const;
   QString qtVersion() const;
 
+  // ---- Diagnostics (HEAP-64) ----
+  // Open the rotating-log directory in the system file manager.
+  Q_INVOKABLE void openLogsFolder() const;
+  // Open a pre-filled GitHub "new issue" page carrying version / OS / Qt
+  // version / recent-log-tail diagnostics, so a user can file a report in one
+  // click.
+  Q_INVOKABLE void reportAnIssue() const;
+
   // ---- Notifications & automation ----
   Q_INVOKABLE void notify(const QString& title, const QString& body, const QString& kind = QString());
   // Post the given rich payload via the native notification backend.

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,0 +1,142 @@
+#include "Logger.h"
+
+#include <QByteArray>
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QIODevice>
+#include <QMutex>
+#include <QStandardPaths>
+#include <QtGlobal>
+
+#include <cstdio>
+#include <cstdlib>
+
+// Rotation policy: keep the live log under kMaxLogBytes; when it grows past
+// that, roll it to a timestamped sibling and keep only the newest
+// kKeepRotated rolled files. Mirrors the keep-last-N backup pruning in
+// AppController::pruneBackups.
+namespace {
+
+constexpr qint64 kMaxLogBytes = 1 * 1024 * 1024;  // 1 MiB
+constexpr int kKeepRotated = 5;
+
+QMutex g_mutex;
+QFile g_logFile;
+QtMessageHandler g_previousHandler = nullptr;
+
+const char* levelName(QtMsgType type) {
+  switch(type) {
+    case QtDebugMsg:
+      return "DEBUG";
+    case QtInfoMsg:
+      return "INFO ";
+    case QtWarningMsg:
+      return "WARN ";
+    case QtCriticalMsg:
+      return "CRIT ";
+    case QtFatalMsg:
+      return "FATAL";
+  }
+  return "LOG  ";
+}
+
+// Caller must hold g_mutex and g_logFile must be open.
+void rotateIfNeeded() {
+  if(g_logFile.size() < kMaxLogBytes) {
+    return;
+  }
+  const QString base = heap::logging::logFilePath();
+  g_logFile.close();
+  const QString rolled = base + '.' + QDateTime::currentDateTime().toString("yyyyMMdd-HHmmss");
+  QFile::rename(base, rolled);
+
+  QDir dir(heap::logging::logDirPath());
+  const QStringList rolledLogs = dir.entryList({"heap.log.*"}, QDir::Files | QDir::NoSymLinks, QDir::Time);
+  for(int i = kKeepRotated; i < rolledLogs.size(); ++i) {
+    dir.remove(rolledLogs[i]);
+  }
+
+  g_logFile.setFileName(base);
+  g_logFile.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text);
+}
+
+void messageHandler(QtMsgType type, const QMessageLogContext& ctx, const QString& msg) {
+  QString line = QDateTime::currentDateTime().toString(Qt::ISODateWithMs);
+  line += ' ';
+  line += QLatin1String(levelName(type));
+  line += ' ';
+  if(ctx.category && qstrcmp(ctx.category, "default") != 0) {
+    line += QLatin1String(ctx.category);
+    line += QLatin1String(": ");
+  }
+  line += msg;
+  line += '\n';
+
+  {
+    QMutexLocker lock(&g_mutex);
+    if(g_logFile.isOpen()) {
+      g_logFile.write(line.toUtf8());
+      g_logFile.flush();
+      rotateIfNeeded();
+    }
+  }
+
+  // Forward to the original handler so stderr/console output is preserved.
+  if(g_previousHandler) {
+    g_previousHandler(type, ctx, msg);
+  } else {
+    fputs(line.toUtf8().constData(), stderr);
+  }
+  if(type == QtFatalMsg) {
+    abort();
+  }
+}
+
+}  // namespace
+
+namespace heap::logging {
+
+QString logDirPath() {
+  const QString dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/logs";
+  QDir().mkpath(dir);
+  return dir;
+}
+
+QString logFilePath() {
+  return logDirPath() + "/heap.log";
+}
+
+void installFileLogger() {
+  QMutexLocker lock(&g_mutex);
+  if(g_logFile.isOpen()) {
+    return;
+  }
+  g_logFile.setFileName(logFilePath());
+  if(g_logFile.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
+    g_previousHandler = qInstallMessageHandler(messageHandler);
+  }
+}
+
+QString logTail(int maxBytes) {
+  QFile file(logFilePath());
+  if(!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    return {};
+  }
+  const qint64 size = file.size();
+  const bool truncated = size > maxBytes;
+  if(truncated) {
+    file.seek(size - maxBytes);
+  }
+  QString tail = QString::fromUtf8(file.readAll());
+  // Drop the partial first line left by seeking into the middle of the file.
+  if(truncated) {
+    const int nl = tail.indexOf('\n');
+    if(nl >= 0) {
+      tail = tail.mid(nl + 1);
+    }
+  }
+  return tail;
+}
+
+}  // namespace heap::logging

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -74,7 +74,7 @@ void messageHandler(QtMsgType type, const QMessageLogContext& ctx, const QString
   line += '\n';
 
   {
-    QMutexLocker lock(&g_mutex);
+    const QMutexLocker lock(&g_mutex);
     if(g_logFile.isOpen()) {
       g_logFile.write(line.toUtf8());
       g_logFile.flush();
@@ -108,7 +108,7 @@ QString logFilePath() {
 }
 
 void installFileLogger() {
-  QMutexLocker lock(&g_mutex);
+  const QMutexLocker lock(&g_mutex);
   if(g_logFile.isOpen()) {
     return;
   }

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QString>
+
+// Rotating file logger. Installs a qInstallMessageHandler that mirrors every
+// qDebug/qInfo/qWarning/qCritical/qFatal line to a size-capped log file under
+// QStandardPaths::AppDataLocation/logs, while still forwarding to the previous
+// handler (so console output is preserved). Used by HEAP-64 diagnostics: the
+// "Report an issue" and "Open logs folder" actions read back from here.
+namespace heap::logging {
+
+// Install the file message handler. Safe to call once, early in main() — after
+// the application/organization names are set so AppDataLocation resolves to the
+// heap folder, and before the QML engine loads. No-op if already installed.
+void installFileLogger();
+
+// Absolute path to the log directory (…/AppDataLocation/logs), created on demand.
+QString logDirPath();
+
+// Absolute path to the current log file (…/logs/heap.log).
+QString logFilePath();
+
+// Last \p maxBytes of the current log, trimmed to whole lines. Empty if no log
+// exists yet. Used to pre-fill the bug-report body.
+QString logTail(int maxBytes = 3000);
+
+}  // namespace heap::logging

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,12 +17,12 @@ void quitOnSignal(int) {
 
 int main(int argc, char* argv[]) {
   QApplication app(argc, argv);
-  app.setOrganizationName("heap");
-  app.setOrganizationDomain("heap.local");
-  app.setApplicationName("heap");
-  app.setApplicationDisplayName(QStringLiteral("heap."));
-  app.setApplicationVersion(QStringLiteral("0.4.2"));
-  app.setWindowIcon(QIcon(QStringLiteral(":/brand/icon/heap-icon.svg")));
+  QApplication::setOrganizationName("heap");
+  QApplication::setOrganizationDomain("heap.local");
+  QApplication::setApplicationName("heap");
+  QApplication::setApplicationDisplayName(QStringLiteral("heap."));
+  QApplication::setApplicationVersion(QStringLiteral("0.4.2"));
+  QApplication::setWindowIcon(QIcon(QStringLiteral(":/brand/icon/heap-icon.svg")));
 
   // Route qDebug/qWarning/… to a rotating log file (must come after the
   // org/app names are set so AppDataLocation resolves to the heap folder).
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
   std::signal(SIGTERM, quitOnSignal);
 
   QString initialView;
-  const QStringList args = app.arguments();
+  const QStringList args = QApplication::arguments();
   for(int i = 1; i < args.size() - 1; ++i) {
     if(args[i] == "--view") {
       initialView = args[i + 1];
@@ -54,5 +54,5 @@ int main(int argc, char* argv[]) {
       },
       Qt::QueuedConnection);
   engine.load(QUrl(QStringLiteral("qrc:/qt/qml/TodoCpp/qml/Main.qml")));
-  return app.exec();
+  return QApplication::exec();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,5 @@
+#include "Logger.h"
+
 #include <QApplication>
 #include <QIcon>
 #include <QQmlApplicationEngine>
@@ -8,33 +10,49 @@
 #include <csignal>
 
 namespace {
-void quitOnSignal(int) { QCoreApplication::quit(); }
+void quitOnSignal(int) {
+  QCoreApplication::quit();
 }
+}  // namespace
 
-int main(int argc, char *argv[]) {
-    QApplication app(argc, argv);
-    app.setOrganizationName("heap");
-    app.setOrganizationDomain("heap.local");
-    app.setApplicationName("heap");
-    app.setApplicationDisplayName(QStringLiteral("heap."));
-    app.setApplicationVersion(QStringLiteral("0.4.2"));
-    app.setWindowIcon(QIcon(QStringLiteral(":/brand/icon/heap-icon.svg")));
+int main(int argc, char* argv[]) {
+  QApplication app(argc, argv);
+  app.setOrganizationName("heap");
+  app.setOrganizationDomain("heap.local");
+  app.setApplicationName("heap");
+  app.setApplicationDisplayName(QStringLiteral("heap."));
+  app.setApplicationVersion(QStringLiteral("0.4.2"));
+  app.setWindowIcon(QIcon(QStringLiteral(":/brand/icon/heap-icon.svg")));
 
-    QQuickStyle::setStyle("Basic");
+  // Route qDebug/qWarning/… to a rotating log file (must come after the
+  // org/app names are set so AppDataLocation resolves to the heap folder).
+  heap::logging::installFileLogger();
+  qInfo("heap %s starting", qUtf8Printable(app.applicationVersion()));
 
-    std::signal(SIGINT,  quitOnSignal);
-    std::signal(SIGTERM, quitOnSignal);
+  QQuickStyle::setStyle("Basic");
 
-    QString initialView;
-    const QStringList args = app.arguments();
-    for (int i = 1; i < args.size() - 1; ++i) {
-        if (args[i] == "--view") { initialView = args[i + 1]; break; }
+  std::signal(SIGINT, quitOnSignal);
+  std::signal(SIGTERM, quitOnSignal);
+
+  QString initialView;
+  const QStringList args = app.arguments();
+  for(int i = 1; i < args.size() - 1; ++i) {
+    if(args[i] == "--view") {
+      initialView = args[i + 1];
+      break;
     }
+  }
 
-    QQmlApplicationEngine engine;
-    engine.rootContext()->setContextProperty("INITIAL_VIEW", initialView);
-    QObject::connect(&engine, &QQmlApplicationEngine::objectCreationFailed,
-                     &app, []() { QCoreApplication::exit(-1); }, Qt::QueuedConnection);
-    engine.load(QUrl(QStringLiteral("qrc:/qt/qml/TodoCpp/qml/Main.qml")));
-    return app.exec();
+  QQmlApplicationEngine engine;
+  engine.rootContext()->setContextProperty("INITIAL_VIEW", initialView);
+  QObject::connect(
+      &engine,
+      &QQmlApplicationEngine::objectCreationFailed,
+      &app,
+      []() {
+        QCoreApplication::exit(-1);
+      },
+      Qt::QueuedConnection);
+  engine.load(QUrl(QStringLiteral("qrc:/qt/qml/TodoCpp/qml/Main.qml")));
+  return app.exec();
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -116,6 +116,7 @@ add_test(NAME heap_notify_tests COMMAND heap_notify_tests)
 set(HEAP_SELECTION_SOURCES
         test_selection.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -179,6 +180,7 @@ add_test(NAME heap_selection_tests COMMAND heap_selection_tests)
 set(HEAP_NOTES_SOURCES
         test_notes.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -275,6 +277,7 @@ add_test(NAME heap_platform_tests COMMAND heap_platform_tests)
 set(HEAP_PERSISTENCE_SOURCES
         test_persistence.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -336,6 +339,7 @@ add_test(NAME heap_persistence_tests COMMAND heap_persistence_tests)
 set(HEAP_EXPORT_SOURCES
         test_export_markdown.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -396,6 +400,7 @@ add_test(NAME heap_export_tests COMMAND heap_export_tests)
 set(HEAP_PROFILE_IO_SOURCES
         test_profile_io.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -455,6 +460,7 @@ add_test(NAME heap_profile_io_tests COMMAND heap_profile_io_tests)
 set(HEAP_ONBOARDING_SOURCES
         test_onboarding.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -533,6 +539,7 @@ add_test(NAME heap_sampledata_tests COMMAND heap_sampledata_tests)
 set(HEAP_UNDO_SOURCES
         test_undo.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -594,6 +601,7 @@ add_test(NAME heap_undo_tests COMMAND heap_undo_tests)
 set(HEAP_VIEW_SOURCES
         test_view.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -798,6 +806,7 @@ add_test(NAME heap_models_tests COMMAND heap_models_tests)
 set(HEAP_APPCTRL_SOURCES
         test_appcontroller.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h


### PR DESCRIPTION
## HEAP-64 · Diagnostics: rotating log file + "Report an issue"

**Why:** the app had no logs or crash reporting — when it misbehaved in the field there was nothing to diagnose from (release-blocker: supportability).

### What
- **`src/Logger`** — installs a `qInstallMessageHandler` that mirrors every `qDebug`/`qInfo`/`qWarning`/`qCritical`/`qFatal` line to a size-capped **rotating log file** under `QStandardPaths::AppDataLocation/logs` (1 MiB cap, keep last 5 rolled files, pruning mirrors `AppController::pruneBackups`). Still forwards to the previous handler so console output is preserved; thread-safe via a mutex.
- **`main.cpp`** installs the logger right after the org/app names are set (so `AppDataLocation` resolves to the heap folder) and logs a startup banner with the version.
- **`AppController::openLogsFolder()`** opens the log directory in the file manager; **`reportAnIssue()`** opens a pre-filled GitHub *new issue* page carrying heap version, OS (`QSysInfo::prettyProductName`), Qt version, and the recent log tail.
- **Settings → About** gains a *Diagnostics* card with **Report an issue** + **Open logs folder** buttons (en + ru strings).
- **`tests/CMakeLists.txt`** compiles `Logger.cpp` into the test targets that build `AppController.cpp` directly.

### Verification
- Built locally (MSYS2 UCRT64, Qt 6) — `heap.exe` links; **all 21 ctest targets pass** (incl. `heap_qml_tests`, `heap_appcontroller_tests`).
- Ran the app: it writes `…/AppData/Roaming/heap/heap/logs/heap.log` with `INFO heap 0.4.2 starting` on launch.
- clang-format applied to the touched C++ (matches the auto-format CI job).

### Notes
- Version in the startup banner comes from `QCoreApplication::applicationVersion()` (still the hardcoded `0.4.2`); single-sourcing it from `PROJECT_VERSION` is folded into the next ticket (HEAP-63).