### PR TITLE
feat: auto-update check via GitHub Releases + single-sourced version (HEAP-63)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if(HEAP_ENABLE_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     add_link_options(-fsanitize=address,undefined)
 endif()
 
-find_package(Qt6 6.2 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2 Widgets)
+find_package(Qt6 6.2 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2 Widgets Network)
 # DBus is only needed for the Linux native notifications backend.
 if(UNIX AND NOT APPLE)
     find_package(Qt6 6.2 REQUIRED COMPONENTS DBus)
@@ -75,6 +75,7 @@ qt_add_library(heap_core STATIC
     src/integrations/StatusMap.cpp
     src/sync/SyncSerializer.cpp
     src/sync/JsonMerger.cpp
+    src/update/Updater.cpp
     $<$<PLATFORM_ID:Linux>:${CMAKE_SOURCE_DIR}/src/notify/NotificationCenter_linux.cpp>
         $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/src/platform/GlobalHotkey_win.cpp>
 )
@@ -150,12 +151,14 @@ qt_add_qml_module(heap_core
         src/integrations/IntegrationProvider.h
         src/sync/SyncSerializer.h
         src/sync/JsonMerger.h
+        src/update/Updater.h
 )
 
 target_include_directories(heap_core PUBLIC src)
 target_link_libraries(heap_core PUBLIC
     Qt6::Core
     Qt6::Gui
+    Qt6::Network
     Qt6::Qml
     Qt6::Quick
     Qt6::QuickControls2
@@ -172,6 +175,10 @@ target_compile_definitions(heap_core PRIVATE
     $<$<CONFIG:Debug>:HEAP_DEBUG_BUILD=1>
     $<$<CONFIG:RelWithDebInfo>:HEAP_DEBUG_BUILD=1>
 )
+# Single source of truth for the app version: the project() VERSION above.
+# PUBLIC so the thin `heap` executable (src/main.cpp) inherits it for
+# setApplicationVersion; AppController exposes it to QML as `appVersion`.
+target_compile_definitions(heap_core PUBLIC HEAP_VERSION="${PROJECT_VERSION}")
 if (TARGET Qt6::Svg)
     target_link_libraries(heap_core PUBLIC Qt6::Svg)
     target_compile_definitions(heap_core PRIVATE HEAP_HAS_SVG=1)

--- a/qml/Brand.qml
+++ b/qml/Brand.qml
@@ -12,7 +12,8 @@ QtObject {
     readonly property string name:    "heap."
     readonly property string tagline: "Work, in one place."
     readonly property string taglineLong: "A quiet place for the work you owe."
-    readonly property string version: "0.4.2"
+    // Version is single-sourced from CMake PROJECT_VERSION via
+    // AppController.appVersion — do not hardcode it here.
 
     // ── Color palette (dark, primary) ─────────────────────────
     readonly property color bg:        "#0b0e13"

--- a/qml/I18n.qml
+++ b/qml/I18n.qml
@@ -520,6 +520,13 @@ QtObject {
             "settings.about.diagnostics.hint": "Logs are written locally under your data folder. Reporting an issue opens GitHub with your version and a recent log tail pre-filled.",
             "settings.about.reportIssue": "Report an issue",
             "settings.about.openLogs": "Open logs folder",
+            "settings.about.updates": "Updates",
+            "settings.about.updates.hint": "Check GitHub for a newer release. heap never downloads or installs anything without you.",
+            "settings.about.checkUpdates": "Check for updates",
+            "settings.about.download": "Download",
+            "settings.about.autoCheck": "Check for updates automatically",
+            "update.available": "Update available: %1",
+            "update.download": "Download",
 
             // ── Selection action bar ──
             "selection.bar.count": "%1 selected",
@@ -1010,6 +1017,13 @@ QtObject {
             "settings.about.diagnostics.hint": "Логи пишутся локально в папке данных. «Сообщить о проблеме» открывает GitHub с уже заполненной версией и хвостом лога.",
             "settings.about.reportIssue": "Сообщить о проблеме",
             "settings.about.openLogs": "Открыть папку логов",
+            "settings.about.updates": "Обновления",
+            "settings.about.updates.hint": "Проверить наличие новой версии на GitHub. heap ничего не скачивает и не устанавливает без вашего согласия.",
+            "settings.about.checkUpdates": "Проверить обновления",
+            "settings.about.download": "Скачать",
+            "settings.about.autoCheck": "Проверять обновления автоматически",
+            "update.available": "Доступно обновление: %1",
+            "update.download": "Скачать",
 
             // ── Selection action bar ──
             "selection.bar.count": "Выделено: %1",

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -122,6 +122,12 @@ ApplicationWindow {
                 AppController.undoLastDeletion()
             });
         }
+        // A newer release was found — offer a one-click jump to the release page.
+        function onUpdateAvailable(version, url) {
+            toast.showWithAction(I18n.t("update.available").arg(version), I18n.t("update.download"), 10, function () {
+                Qt.openUrlExternally(url)
+            });
+        }
     }
 
     GridLayout {

--- a/qml/SettingsView.qml
+++ b/qml/SettingsView.qml
@@ -175,6 +175,7 @@ Item {
             confluence: ({ connected: false, space: "" })
         },
         data: { autoBackup: true, backupInterval: "daily" },
+        updates: { autoCheck: true },
         git: {
             watchedRepos: [],
             autoMoveToInProgress: true,
@@ -423,7 +424,7 @@ Item {
                 }
 
                 Text {
-                    text: I18n.t("settings.footer.stable").arg(Brand.version)
+                    text: I18n.t("settings.footer.stable").arg(AppController.appVersion)
                     color: Theme.textDim
                     font.family: Theme.fontMono
                     font.pixelSize: 10
@@ -1934,7 +1935,7 @@ Item {
                         Layout.topMargin: 4
                         Layout.fillWidth: true
                         AboutRow {
-                            label: I18n.t("settings.about.version"); value: Brand.version
+                            label: I18n.t("settings.about.version"); value: AppController.appVersion
                         }
                         AboutRow {
                             label: I18n.t("settings.about.channel"); value: "stable"
@@ -1984,6 +1985,57 @@ Item {
                             }
                             MouseArea { id: logsMA; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor; onClicked: AppController.openLogsFolder() }
                         }
+                    }
+                }
+            }
+            SectionCard {
+                ColumnLayout {
+                    id: updatesCol
+                    property bool updateReady: false
+                    spacing: 12
+                    Layout.fillWidth: true
+                    Connections {
+                        target: AppController
+                        function onUpdateAvailable(version, url) { updatesCol.updateReady = true }
+                    }
+                    Sub {
+                        label: I18n.t("settings.about.updates")
+                    }
+                    Text {
+                        text: AppController.updateStatus === "" ? I18n.t("settings.about.updates.hint") : AppController.updateStatus
+                        color: Theme.textMuted
+                        font.pixelSize: 11
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+                    RowLayout {
+                        spacing: 8
+                        Rectangle {
+                            radius: 6
+                            color: checkMA.containsMouse ? Theme.panel3 : Theme.panel2
+                            border.color: Theme.border; border.width: 1
+                            implicitWidth: checkTxt.implicitWidth + 24; implicitHeight: 30
+                            Text {
+                                id: checkTxt; anchors.centerIn: parent; text: I18n.t("settings.about.checkUpdates"); color: Theme.text; font.pixelSize: 12
+                            }
+                            MouseArea { id: checkMA; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor; onClicked: AppController.checkForUpdates() }
+                        }
+                        Rectangle {
+                            visible: updatesCol.updateReady
+                            radius: 6
+                            color: dlMA.containsMouse ? Theme.accent : Theme.panel2
+                            border.color: Theme.border; border.width: 1
+                            implicitWidth: dlTxt.implicitWidth + 24; implicitHeight: 30
+                            Text {
+                                id: dlTxt; anchors.centerIn: parent; text: I18n.t("settings.about.download"); color: Theme.text; font.pixelSize: 12
+                            }
+                            MouseArea { id: dlMA; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor; onClicked: AppController.openLatestRelease() }
+                        }
+                    }
+                    SwitchRow {
+                        label: I18n.t("settings.about.autoCheck")
+                        checked: !!(root.settings.updates && root.settings.updates.autoCheck)
+                        onToggled: (checked) => root.set("updates", "autoCheck", checked)
                     }
                 }
             }

--- a/qml/SplashScreen.qml
+++ b/qml/SplashScreen.qml
@@ -30,7 +30,7 @@ Item {
     // Public knobs
     property real progress: 0.0          // 0..1; bind to your loader's progress
     property string status: "initializing allocator…"
-    property string buildInfo: "v" + Brand.version + " · build 240617"
+    property string buildInfo: "v" + AppController.appVersion + " · build 240617"
     property string channel: "stable · channel"
     property bool autoAnimate: true      // demo: animate the loading bar
     property int autoDuration: 1200

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -8,11 +8,13 @@
 #include "notify/NotificationCenter.h"
 #include "platform/GlobalHotkey.h"
 #include "text/TaskTextUtils.h"
+#include "update/Updater.h"
 
 #include <QApplication>
 #include <QClipboard>
 #include <QCoreApplication>
 #include <QDateTime>
+#include <QDebug>
 #include <QDesktopServices>
 #include <QDir>
 #include <QFile>
@@ -34,6 +36,12 @@
 #include <QUuid>
 
 #include <cmath>
+
+// Version is injected by CMake (PROJECT_VERSION); this fallback keeps standalone
+// test targets that compile AppController.cpp directly building without it.
+#ifndef HEAP_VERSION
+#define HEAP_VERSION "0.0.0-dev"
+#endif
 
 namespace {
 constexpr int kBackupIntervalSeconds = 5 * 60;
@@ -316,6 +324,31 @@ AppController::AppController(QObject* parent) :
   applyGitSettingsFromMap(settingsMap().value("git").toMap());
   connect(this, &AppController::appSettingsJsonChanged, this, [this]() {
     applyGitSettingsFromMap(settingsMap().value("git").toMap());
+  });
+
+  // ---- Auto-update (HEAP-63) ----
+  m_updater = std::make_unique<heap::update::Updater>(appVersion(), this);
+  connect(m_updater.get(), &heap::update::Updater::updateAvailable, this, [this](const QString& version, const QString& url) {
+    m_latestReleaseUrl = url;
+    m_updateStatus = tr("Update available: %1").arg(version);
+    emit updateStatusChanged();
+    emit updateAvailable(version, url);
+  });
+  connect(m_updater.get(), &heap::update::Updater::upToDate, this, [this](const QString&) {
+    m_updateStatus = tr("You're up to date");
+    emit updateStatusChanged();
+  });
+  connect(m_updater.get(), &heap::update::Updater::checkFailed, this, [this](const QString& error) {
+    qWarning() << "update check failed:" << error;
+    m_updateStatus = tr("Update check failed");
+    emit updateStatusChanged();
+  });
+  // Opt-out background check shortly after startup (never auto-downloads). The
+  // delay lets settings load and the QML toast bar come up first.
+  QTimer::singleShot(3000, this, [this]() {
+    if(settingsMap().value("updates").toMap().value("autoCheck", true).toBool()) {
+      checkForUpdates();
+    }
   });
   connect(this, &AppController::activeProfileChanged, this, [this]() {
     if(m_gitWatcher) {
@@ -1597,6 +1630,10 @@ QString AppController::qtVersion() const {
   return QString::fromLatin1(qVersion());
 }
 
+QString AppController::appVersion() const {
+  return QString::fromLatin1(HEAP_VERSION);
+}
+
 void AppController::openLogsFolder() const {
   QDesktopServices::openUrl(QUrl::fromLocalFile(heap::logging::logDirPath()));
 }
@@ -1624,6 +1661,21 @@ void AppController::reportAnIssue() const {
   query.addQueryItem(QStringLiteral("body"), body);
   url.setQuery(query);
   QDesktopServices::openUrl(url);
+}
+
+void AppController::checkForUpdates() {
+  if(!m_updater || m_updater->isChecking()) {
+    return;
+  }
+  m_updateStatus = tr("Checking for updates…");
+  emit updateStatusChanged();
+  m_updater->checkForUpdates();
+}
+
+void AppController::openLatestRelease() const {
+  if(!m_latestReleaseUrl.isEmpty()) {
+    QDesktopServices::openUrl(QUrl(m_latestReleaseUrl));
+  }
 }
 
 void AppController::scheduleSave() {

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -32,6 +32,10 @@ namespace heap::platform {
 class GlobalHotkey;
 }
 
+namespace heap::update {
+class Updater;
+}
+
 class AppController : public QObject {
   Q_OBJECT
   QML_ELEMENT
@@ -85,6 +89,12 @@ class AppController : public QObject {
   // Runtime facts for Settings → About (so nothing is hardcoded / stale).
   Q_PROPERTY(QString dataDir READ dataDir CONSTANT)
   Q_PROPERTY(QString qtVersion READ qtVersion CONSTANT)
+  Q_PROPERTY(QString appVersion READ appVersion CONSTANT)
+
+  // ---- Auto-update (HEAP-63) ----
+  // Human-readable result of the last update check, shown in Settings → About:
+  // "" (idle), a "checking" string, "up to date", or "update available: vX".
+  Q_PROPERTY(QString updateStatus READ updateStatus NOTIFY updateStatusChanged)
 
   // ---- Git focus banner ----
   Q_PROPERTY(QString focusedTaskId READ focusedTaskId NOTIFY focusedGitChanged)
@@ -278,6 +288,11 @@ class AppController : public QObject {
   // Qt runtime version — resolved at runtime for the About panel.
   QString dataDir() const;
   QString qtVersion() const;
+  QString appVersion() const;
+
+  QString updateStatus() const {
+    return m_updateStatus;
+  }
 
   // ---- Diagnostics (HEAP-64) ----
   // Open the rotating-log directory in the system file manager.
@@ -286,6 +301,13 @@ class AppController : public QObject {
   // version / recent-log-tail diagnostics, so a user can file a report in one
   // click.
   Q_INVOKABLE void reportAnIssue() const;
+
+  // ---- Auto-update (HEAP-63) ----
+  // Manually trigger a GitHub-Releases check (Settings → About → "Check for
+  // updates"). Result surfaces via updateStatus + the updateAvailable toast.
+  Q_INVOKABLE void checkForUpdates();
+  // Open the latest release's page in the browser — the "Download" action.
+  Q_INVOKABLE void openLatestRelease() const;
 
   // ---- Notifications & automation ----
   Q_INVOKABLE void notify(const QString& title, const QString& body, const QString& kind = QString());
@@ -457,6 +479,9 @@ class AppController : public QObject {
   void blockedStuckChanged();
   void notification(const QString& title, const QString& body, const QString& kind);
   void toast(const QString& message);
+  void updateStatusChanged();
+  // Emitted when a newer release is found — Main.qml shows an actionable toast.
+  void updateAvailable(const QString& version, const QString& url);
   void undoableToast(const QString& message, int seconds);
   void focusedGitChanged();
   void openTaskRequested(const QString& id);
@@ -589,6 +614,11 @@ class AppController : public QObject {
 
   // ---- Git watcher ----
   std::unique_ptr<heap::git::GitWatcher> m_gitWatcher;
+
+  // ---- Auto-update (HEAP-63) ----
+  std::unique_ptr<heap::update::Updater> m_updater;
+  QString m_updateStatus;
+  QString m_latestReleaseUrl;
   QString m_focusedTaskId, m_focusedBranch, m_focusedRepo;
   QVariantMap m_focusedRepoState;
   QSet<QString> m_dismissedBranches;  // in-memory only; per branch name

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,11 @@
 
 #include <csignal>
 
+// Injected by CMake from project() VERSION; fallback keeps ad-hoc builds sane.
+#ifndef HEAP_VERSION
+#define HEAP_VERSION "0.0.0-dev"
+#endif
+
 namespace {
 void quitOnSignal(int) {
   QCoreApplication::quit();
@@ -21,7 +26,7 @@ int main(int argc, char* argv[]) {
   QApplication::setOrganizationDomain("heap.local");
   QApplication::setApplicationName("heap");
   QApplication::setApplicationDisplayName(QStringLiteral("heap."));
-  QApplication::setApplicationVersion(QStringLiteral("0.4.2"));
+  QApplication::setApplicationVersion(QStringLiteral(HEAP_VERSION));
   QApplication::setWindowIcon(QIcon(QStringLiteral(":/brand/icon/heap-icon.svg")));
 
   // Route qDebug/qWarning/… to a rotating log file (must come after the

--- a/src/update/Updater.cpp
+++ b/src/update/Updater.cpp
@@ -1,0 +1,107 @@
+#include "update/Updater.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QList>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QStringList>
+#include <QUrl>
+
+#include <utility>
+
+namespace heap::update {
+
+namespace {
+
+// GitHub REST endpoint for the newest *published* (non-draft, non-prerelease)
+// release of the repo.
+constexpr auto kLatestReleaseUrl = "https://api.github.com/repos/sectapunterx/heap/releases/latest";
+
+struct ParsedVersion {
+  QList<int> parts;
+  bool preRelease = false;
+};
+
+ParsedVersion parseVersion(QString v) {
+  v = v.trimmed();
+  if(v.startsWith('v') || v.startsWith('V')) {
+    v.remove(0, 1);
+  }
+  const qsizetype dash = v.indexOf('-');
+  ParsedVersion parsed;
+  parsed.preRelease = dash >= 0;
+  const QString core = parsed.preRelease ? v.left(dash) : v;
+  const QStringList comps = core.split('.', Qt::SkipEmptyParts);
+  for(const QString& c : comps) {
+    bool ok = false;
+    const int n = c.toInt(&ok);
+    parsed.parts.append(ok ? n : 0);
+  }
+  return parsed;
+}
+
+}  // namespace
+
+bool isNewerVersion(const QString& current, const QString& latest) {
+  const ParsedVersion a = parseVersion(current);
+  const ParsedVersion b = parseVersion(latest);
+  const qsizetype n = qMax(a.parts.size(), b.parts.size());
+  for(qsizetype i = 0; i < n; ++i) {
+    const int av = i < a.parts.size() ? a.parts.at(i) : 0;
+    const int bv = i < b.parts.size() ? b.parts.at(i) : 0;
+    if(bv != av) {
+      return bv > av;
+    }
+  }
+  // Equal numeric core: a plain release outranks a pre-release of the same core.
+  if(a.preRelease != b.preRelease) {
+    return a.preRelease && !b.preRelease;
+  }
+  return false;
+}
+
+Updater::Updater(QString currentVersion, QObject* parent) :
+    QObject(parent), m_currentVersion(std::move(currentVersion)), m_nam(new QNetworkAccessManager(this)) {
+}
+
+Updater::~Updater() = default;
+
+void Updater::checkForUpdates() {
+  if(m_checking) {
+    return;
+  }
+  m_checking = true;
+
+  QNetworkRequest req{QUrl(QLatin1String(kLatestReleaseUrl))};
+  req.setRawHeader("Accept", "application/vnd.github+json");
+  req.setRawHeader("User-Agent", "heap-updater");
+
+  QNetworkReply* reply = m_nam->get(req);
+  connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+    reply->deleteLater();
+    m_checking = false;
+
+    if(reply->error() != QNetworkReply::NoError) {
+      emit checkFailed(reply->errorString());
+      return;
+    }
+
+    const QJsonObject obj = QJsonDocument::fromJson(reply->readAll()).object();
+    const QString tag = obj.value(QStringLiteral("tag_name")).toString();
+    const QString url = obj.value(QStringLiteral("html_url")).toString();
+    if(tag.isEmpty()) {
+      emit checkFailed(QStringLiteral("no release tag in GitHub response"));
+      return;
+    }
+
+    if(isNewerVersion(m_currentVersion, tag)) {
+      emit updateAvailable(tag, url);
+    } else {
+      emit upToDate(m_currentVersion);
+    }
+  });
+}
+
+}  // namespace heap::update

--- a/src/update/Updater.h
+++ b/src/update/Updater.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+class QNetworkAccessManager;
+
+// GitHub-Releases update checker (HEAP-63). Polls the public releases API for
+// the latest published release and reports whether it is newer than the running
+// build. It never downloads or installs anything — acting on an available
+// update is left to the caller (open the release page). No auth/token needed for
+// public repos.
+namespace heap::update {
+
+// Compare two version strings ("v0.5.0", "0.5.0", "0.5.0-rc1"). Returns true iff
+// `latest` is strictly newer than `current`. A leading 'v'/'V' is ignored;
+// dotted numeric components are compared left-to-right (missing = 0); with an
+// equal numeric core, a pre-release ("-rc1") ranks below the plain release.
+// Non-numeric components degrade to 0. Pure function — unit-tested directly.
+bool isNewerVersion(const QString& current, const QString& latest);
+
+class Updater : public QObject {
+  Q_OBJECT
+
+ public:
+  explicit Updater(QString currentVersion, QObject* parent = nullptr);
+  ~Updater() override;
+
+  // Start an async check. Emits exactly one of updateAvailable / upToDate /
+  // checkFailed. A no-op while a previous check is still in flight.
+  void checkForUpdates();
+
+  bool isChecking() const {
+    return m_checking;
+  }
+
+ signals:
+  void updateAvailable(const QString& latestVersion, const QString& releaseUrl);
+  void upToDate(const QString& currentVersion);
+  void checkFailed(const QString& error);
+
+ private:
+  QString m_currentVersion;
+  QNetworkAccessManager* m_nam = nullptr;
+  bool m_checking = false;
+};
+
+}  // namespace heap::update

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,7 @@ set(HEAP_SELECTION_SOURCES
         test_selection.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -156,6 +157,7 @@ target_include_directories(heap_selection_tests PRIVATE
 target_link_libraries(heap_selection_tests PRIVATE
         Qt6::Core
         Qt6::Gui
+        Qt6::Network
         Qt6::Widgets
         Qt6::Qml
         Qt6::Test
@@ -181,6 +183,7 @@ set(HEAP_NOTES_SOURCES
         test_notes.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -220,6 +223,7 @@ target_include_directories(heap_notes_tests PRIVATE
 target_link_libraries(heap_notes_tests PRIVATE
         Qt6::Core
         Qt6::Gui
+        Qt6::Network
         Qt6::Widgets
         Qt6::Qml
         Qt6::Test
@@ -278,6 +282,7 @@ set(HEAP_PERSISTENCE_SOURCES
         test_persistence.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -317,6 +322,7 @@ target_include_directories(heap_persistence_tests PRIVATE
 target_link_libraries(heap_persistence_tests PRIVATE
         Qt6::Core
         Qt6::Gui
+        Qt6::Network
         Qt6::Widgets
         Qt6::Qml
         Qt6::Test
@@ -340,6 +346,7 @@ set(HEAP_EXPORT_SOURCES
         test_export_markdown.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -379,6 +386,7 @@ target_include_directories(heap_export_tests PRIVATE
 target_link_libraries(heap_export_tests PRIVATE
         Qt6::Core
         Qt6::Gui
+        Qt6::Network
         Qt6::Widgets
         Qt6::Qml
         Qt6::Test
@@ -401,6 +409,7 @@ set(HEAP_PROFILE_IO_SOURCES
         test_profile_io.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -440,6 +449,7 @@ target_include_directories(heap_profile_io_tests PRIVATE
 target_link_libraries(heap_profile_io_tests PRIVATE
         Qt6::Core
         Qt6::Gui
+        Qt6::Network
         Qt6::Widgets
         Qt6::Qml
         Qt6::Test
@@ -461,6 +471,7 @@ set(HEAP_ONBOARDING_SOURCES
         test_onboarding.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -500,6 +511,7 @@ target_include_directories(heap_onboarding_tests PRIVATE
 target_link_libraries(heap_onboarding_tests PRIVATE
         Qt6::Core
         Qt6::Gui
+        Qt6::Network
         Qt6::Widgets
         Qt6::Qml
         Qt6::Test
@@ -540,6 +552,7 @@ set(HEAP_UNDO_SOURCES
         test_undo.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -579,6 +592,7 @@ target_include_directories(heap_undo_tests PRIVATE
 target_link_libraries(heap_undo_tests PRIVATE
         Qt6::Core
         Qt6::Gui
+        Qt6::Network
         Qt6::Widgets
         Qt6::Qml
         Qt6::Test
@@ -602,6 +616,7 @@ set(HEAP_VIEW_SOURCES
         test_view.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -641,6 +656,7 @@ target_include_directories(heap_view_tests PRIVATE
 target_link_libraries(heap_view_tests PRIVATE
         Qt6::Core
         Qt6::Gui
+        Qt6::Network
         Qt6::Widgets
         Qt6::Qml
         Qt6::Test
@@ -725,6 +741,25 @@ target_link_libraries(heap_integrations_tests PRIVATE
 )
 add_test(NAME heap_integrations_tests COMMAND heap_integrations_tests)
 
+# ─── Update (GitHub-Releases version compare) tests ───
+# Covers heap::update::isNewerVersion. Updater.cpp carries a QObject (the QNAM
+# client) so AUTOMOC + Qt6::Network are needed, but the tests exercise only the
+# pure comparison — no network I/O.
+add_executable(heap_update_tests
+        test_update.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.h
+)
+set_target_properties(heap_update_tests PROPERTIES AUTOMOC ON)
+target_include_directories(heap_update_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_link_libraries(heap_update_tests PRIVATE
+        Qt6::Core
+        Qt6::Network
+        GTest::gtest
+        GTest::gtest_main
+)
+add_test(NAME heap_update_tests COMMAND heap_update_tests)
+
 # ─── Sync (BYOS serializer) tests ───
 # Cover heap::sync::SyncSerializer — Profile/CalEvent ↔ git-friendly JSON with
 # stable (id-sorted) ordering and idempotent round-trips. Pure data code; needs
@@ -807,6 +842,7 @@ set(HEAP_APPCTRL_SOURCES
         test_appcontroller.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.h
@@ -846,6 +882,7 @@ target_include_directories(heap_appcontroller_tests PRIVATE
 target_link_libraries(heap_appcontroller_tests PRIVATE
         Qt6::Core
         Qt6::Gui
+        Qt6::Network
         Qt6::Widgets
         Qt6::Qml
         Qt6::Test

--- a/tests/test_update.cpp
+++ b/tests/test_update.cpp
@@ -1,0 +1,36 @@
+// Unit tests for heap::update::isNewerVersion — the semver comparison behind the
+// GitHub-Releases update check (HEAP-63). Pure function, no network.
+
+#include "update/Updater.h"
+
+#include <gtest/gtest.h>
+
+using heap::update::isNewerVersion;
+
+TEST(UpdateVersionCompare, DetectsNewer) {
+  EXPECT_TRUE(isNewerVersion("0.4.2", "0.5.0"));
+  EXPECT_TRUE(isNewerVersion("0.4.2", "v0.4.3"));
+  EXPECT_TRUE(isNewerVersion("v0.4.2", "0.10.0"));  // 10 > 4, not lexicographic
+  EXPECT_TRUE(isNewerVersion("1.0.0", "1.0.1"));
+}
+
+TEST(UpdateVersionCompare, RejectsSameOrOlder) {
+  EXPECT_FALSE(isNewerVersion("0.4.2", "0.4.2"));
+  EXPECT_FALSE(isNewerVersion("0.5.0", "0.4.9"));
+  EXPECT_FALSE(isNewerVersion("v1.2.3", "v1.2.3"));
+  EXPECT_FALSE(isNewerVersion("0.4.2", "v0.4.1"));
+}
+
+TEST(UpdateVersionCompare, HandlesPrerelease) {
+  // Equal numeric core: a plain release outranks its pre-release.
+  EXPECT_TRUE(isNewerVersion("1.0.0-rc1", "1.0.0"));
+  EXPECT_FALSE(isNewerVersion("1.0.0", "1.0.0-rc1"));
+  // A higher numeric core still wins regardless of pre-release suffix.
+  EXPECT_TRUE(isNewerVersion("1.0.0", "1.0.1-rc1"));
+}
+
+TEST(UpdateVersionCompare, HandlesDifferentComponentCounts) {
+  EXPECT_TRUE(isNewerVersion("1.0", "1.0.1"));
+  EXPECT_FALSE(isNewerVersion("1.0.0", "1.0"));
+  EXPECT_FALSE(isNewerVersion("1", "1.0.0"));
+}


### PR DESCRIPTION
## HEAP-63 · Auto-update: check GitHub Releases + self-update

**Why:** no update mechanism existed — every user was stuck on the version they installed and shipped fixes couldn't reach them (release-blocker: maintainability).

### What
- **`src/update/Updater`** — a `QNetworkAccessManager` client that queries the GitHub Releases *latest* endpoint and compares tags with a pure, unit-tested `isNewerVersion()` (handles `v` prefix, differing component counts, and pre-release suffixes). **Never downloads or installs** — acting on an update opens the release page.
- Links **`Qt6::Network`** (new dependency).
- **`AppController`** owns the `Updater`; adds `checkForUpdates()` / `openLatestRelease()` invokables, an `updateStatus` property + `updateAvailable` signal, and an **opt-out** background check ~3s after startup gated on `settings.updates.autoCheck` (never auto-downloads).
- **Settings → About** gains an *Updates* card: *Check for updates*, a conditional *Download* button (opens the release page), a status line, and an auto-check toggle. An **"Update available" toast** (Main.qml) offers a one-click jump — satisfying "update in ≤2 clicks".
- **Single-sources the version** from CMake `PROJECT_VERSION` via a `HEAP_VERSION` compile definition, exposed as `AppController.appVersion`. Drops the hardcoded `0.4.2` literals in `Brand.qml`/`main.cpp` and repoints the About row, settings footer, and splash screen at it.
- **`tests/test_update.cpp`** — unit tests for `isNewerVersion`; wires `Updater.cpp` + `Qt6::Network` into the AppController-based test targets.

### Verification
- Built locally (MSYS2 UCRT64, Qt 6) — **all 22 ctest targets pass** (incl. the new `heap_update_tests`).
- Ran the app: launches clean with the new About *Updates* card, no QML errors; startup log shows the single-sourced version.
- clang-format + clang-tidy applied locally (fixed a `qsizetype→int` narrowing).

### Notes
- The version value is unchanged (`0.4.2`) — this PR only removes the duplication so future bumps happen in one place (`project(... VERSION ...)`).
- Download hand-off is "open the release page" (the ticket's stated minimum); a silent WinSparkle-style in-app installer can be layered on later behind the same `Updater`.