### PR TITLE
feat: git write-actions — branch-from-task, commit↔task, inline PR/CI (HEAP-76)

### DIFF
--- a/qml/ArchiveView.qml
+++ b/qml/ArchiveView.qml
@@ -89,6 +89,7 @@ Item {
                 prUrl: m.data(idx, Qt.UserRole + 13),
                 gitAhead: m.data(idx, Qt.UserRole + 14),
                 gitBehind: m.data(idx, Qt.UserRole + 15),
+                recentCommits: m.data(idx, Qt.UserRole + 16),
             };
             if (!root.passesFilter(t)) continue;
             out.push(t);

--- a/qml/I18n.qml
+++ b/qml/I18n.qml
@@ -150,6 +150,7 @@ QtObject {
             "taskcard.schedule": "Schedule in calendar",
             "taskcard.copyId": "Copy ID",
             "taskcard.copyBranch": "Copy branch",
+            "taskcard.createBranch": "Create branch",
 
             // ── TaskEditor / EventEditor / PersonEditor / ProfileEditor ──
             "editor.new.task": "New task",
@@ -669,6 +670,7 @@ QtObject {
             "taskcard.schedule": "Запланировать в календарь",
             "taskcard.copyId": "Копировать ID",
             "taskcard.copyBranch": "Копировать branch",
+            "taskcard.createBranch": "Создать ветку",
 
             "editor.new.task": "Новая задача",
             "editor.edit.task": "Редактировать задачу",

--- a/qml/KanbanBoard.qml
+++ b/qml/KanbanBoard.qml
@@ -416,6 +416,7 @@ Item {
                                             required property string prUrl
                                             required property int    gitAhead
                                             required property int    gitBehind
+                                            required property var    recentCommits
                                             width: bodyCol.width
 
                                             readonly property var taskData: ({
@@ -424,7 +425,8 @@ Item {
                                                 deadline: tc.deadline, branch: tc.branch,
                                                 archived: tc.archived, blockedStuck: tc.blockedStuck,
                                                 prState: tc.prState, prNumber: tc.prNumber, prUrl: tc.prUrl,
-                                                gitAhead: tc.gitAhead, gitBehind: tc.gitBehind
+                                                gitAhead: tc.gitAhead, gitBehind: tc.gitBehind,
+                                                recentCommits: tc.recentCommits
                                             })
                                             task: taskData
                                             scheduled: root.scheduleMap[tc.id] || ""

--- a/qml/TaskCard.qml
+++ b/qml/TaskCard.qml
@@ -177,6 +177,37 @@ Rectangle {
                     font.weight: Font.DemiBold
                 }
             }
+            // Recent commits mentioning this task id — fed by GitWatcher git-log
+            // parsing. Tooltip shows the most recent subject.
+            Rectangle {
+                id: commitChip
+                visible: card.task && card.task.recentCommits && card.task.recentCommits.length > 0
+                radius: 4
+                color: Theme.withAlpha(Theme.textDim, 0.14)
+                border.color: Theme.border
+                border.width: 1
+                implicitWidth: commitT.implicitWidth + 10
+                implicitHeight: commitT.implicitHeight + 2
+                Text {
+                    id: commitT
+                    anchors.centerIn: parent
+                    text: "◇ " + (card.task && card.task.recentCommits ? card.task.recentCommits.length : 0)
+                    color: Theme.textMuted
+                    font.family: Theme.fontMono
+                    font.pixelSize: 9
+                    font.weight: Font.DemiBold
+                }
+                QQC.ToolTip.visible: commitMA.containsMouse && commitChip.visible
+                QQC.ToolTip.text: (card.task && card.task.recentCommits && card.task.recentCommits.length > 0)
+                    ? (card.task.recentCommits[0].sha + "  " + card.task.recentCommits[0].subject)
+                    : ""
+                MouseArea {
+                    id: commitMA
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    acceptedButtons: Qt.NoButton
+                }
+            }
         }
 
         Text {
@@ -347,6 +378,12 @@ Rectangle {
             enabled: card.task && card.task.branch && String(card.task.branch).length > 0
             onTriggered: {
                 if (card.task && card.task.branch) AppController.copyToClipboard(card.task.branch);
+            }
+        }
+        QQC.MenuItem {
+            text: "⎇+  " + I18n.t("taskcard.createBranch")
+            onTriggered: {
+                if (card.task && card.task.id) AppController.createBranchForTask(card.task.id);
             }
         }
         QQC.MenuSeparator {}

--- a/qml/TopBar.qml
+++ b/qml/TopBar.qml
@@ -196,6 +196,88 @@ Rectangle {
                     font.pixelSize: 12
                     font.weight: Font.DemiBold
                 }
+                // ── Live PR state on the focused repo (HEAP-76) ──
+                Rectangle {
+                    id: prBadge
+                    property var pr: AppController.focusedRepoState
+                                     ? AppController.focusedRepoState.pr : null
+                    visible: pr && String(pr.state || "").length > 0
+                          && Number(pr.number || 0) > 0
+                    radius: 4
+                    implicitWidth: prBadgeT.implicitWidth + 12
+                    implicitHeight: 18
+                    color: {
+                        const s = prBadge.pr ? String(prBadge.pr.state || "") : "";
+                        if (s === "merged") return Theme.withAlpha(Theme.mFocus, 0.20);
+                        if (s === "closed") return Theme.withAlpha(Theme.textDim, 0.20);
+                        return Theme.withAlpha(Theme.p1, 0.20);
+                    }
+                    border.width: 1
+                    border.color: {
+                        const s = prBadge.pr ? String(prBadge.pr.state || "") : "";
+                        if (s === "merged") return Theme.mFocus;
+                        if (s === "closed") return Theme.textDim;
+                        return Theme.p1;
+                    }
+                    Text {
+                        id: prBadgeT
+                        anchors.centerIn: parent
+                        text: {
+                            if (!prBadge.pr) return "";
+                            const n = prBadge.pr.number || 0;
+                            const s = String(prBadge.pr.state || "");
+                            const d = prBadge.pr.draft === true ? " · draft" : "";
+                            return "PR #" + n + " " + s + d;
+                        }
+                        color: Theme.accentStrong
+                        font.family: Theme.fontMono
+                        font.pixelSize: 10
+                        font.weight: Font.DemiBold
+                    }
+                    MouseArea {
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: (prBadge.pr && prBadge.pr.url)
+                                     ? Qt.PointingHandCursor : Qt.ArrowCursor
+                        onClicked: if (prBadge.pr && prBadge.pr.url)
+                                       Qt.openUrlExternally(prBadge.pr.url)
+                    }
+                }
+                // ── CI check rollup on the focused repo (HEAP-76) ──
+                Rectangle {
+                    id: ciBadge
+                    property string ci: (AppController.focusedRepoState
+                                         && AppController.focusedRepoState.pr)
+                        ? String(AppController.focusedRepoState.pr.checks || "") : ""
+                    visible: ci.length > 0
+                    radius: 4
+                    implicitWidth: ciT.implicitWidth + 12
+                    implicitHeight: 18
+                    color: {
+                        if (ciBadge.ci === "passing") return Theme.withAlpha(Theme.mFocus, 0.20);
+                        if (ciBadge.ci === "failing") return Theme.withAlpha(Theme.p0, 0.20);
+                        return Theme.withAlpha(Theme.p2, 0.20);
+                    }
+                    border.width: 1
+                    border.color: {
+                        if (ciBadge.ci === "passing") return Theme.mFocus;
+                        if (ciBadge.ci === "failing") return Theme.p0;
+                        return Theme.p2;
+                    }
+                    Text {
+                        id: ciT
+                        anchors.centerIn: parent
+                        text: {
+                            if (ciBadge.ci === "passing") return "CI ✓";
+                            if (ciBadge.ci === "failing") return "CI ✗";
+                            return "CI …";
+                        }
+                        color: Theme.text
+                        font.family: Theme.fontMono
+                        font.pixelSize: 10
+                        font.weight: Font.DemiBold
+                    }
+                }
                 Rectangle {
                     radius: 4
                     color: openMA.containsMouse ? Theme.accentStrong : "transparent"

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -310,6 +310,7 @@ AppController::AppController(QObject* parent) :
   m_gitWatcher = std::make_unique<heap::git::GitWatcher>(this);
   connect(m_gitWatcher.get(), &heap::git::GitWatcher::branchChanged, this, &AppController::onGitBranchChanged);
   connect(m_gitWatcher.get(), &heap::git::GitWatcher::repoStateUpdated, this, &AppController::onGitRepoState);
+  connect(m_gitWatcher.get(), &heap::git::GitWatcher::commitsUpdated, this, &AppController::onGitCommits);
   connect(
       m_gitWatcher.get(), &heap::git::GitWatcher::prInfoUpdated, this, [this](const QString&, const QString& br, const QVariantMap& pr) {
         const heap::git::BranchTaskMatcher m(collectPrefixes());
@@ -3642,6 +3643,58 @@ void AppController::refreshGitForTaskBranch(const QString& taskId) {
   const QStringList repos = m_gitWatcher->snapshot().keys();
   for(const QString& repo : repos) {
     m_gitWatcher->requestPrFetch(repo, br);
+  }
+}
+
+void AppController::createBranchForTask(const QString& taskId) {
+  if(!m_gitWatcher) {
+    return;
+  }
+  const int row = m_tasks.indexOfId(taskId);
+  if(row < 0) {
+    return;
+  }
+  Task t = m_tasks.items().at(row);  // copy — mutated below on success
+
+  // Prefer the currently focused repo; otherwise the first watched repo.
+  QString repo = m_focusedRepo;
+  const QStringList repos = m_gitWatcher->snapshot().keys();
+  if(repo.isEmpty() && !repos.isEmpty()) {
+    repo = repos.first();
+  }
+  if(repo.isEmpty()) {
+    emit toast(tr("No git repository configured — add one in Settings › Git"));
+    return;
+  }
+
+  const QString templ = settingsMap().value("integrations").toMap().value("github").toMap().value("branchTemplate").toString();
+  const QString branch = heap::git::BranchTaskMatcher::branchNameForTask(t.id, t.title, templ);
+  if(branch.isEmpty()) {
+    emit toast(tr("Could not derive a branch name for %1").arg(t.id));
+    return;
+  }
+
+  QString err;
+  if(!m_gitWatcher->createBranch(repo, branch, &err)) {
+    emit toast(tr("Branch create failed: %1").arg(err));
+    return;
+  }
+  // Record the branch on the task so the card shows it and copy-branch works.
+  t.branch = branch;
+  m_tasks.upsert(t);
+  scheduleSave();
+  emit toast(tr("Created branch %1").arg(branch));
+}
+
+void AppController::onGitCommits(const QString& repo, const QVariantMap& commitsByTask) {
+  Q_UNUSED(repo);
+  for(auto it = commitsByTask.constBegin(); it != commitsByTask.constEnd(); ++it) {
+    if(m_tasks.indexOfId(it.key()) < 0) {
+      continue;
+    }
+    QVariantMap entry;
+    entry["recentCommits"] = it.value();
+    m_tasks.setGitInfoForId(it.key(), entry);
   }
 }
 

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -465,6 +465,9 @@ class AppController : public QObject {
   Q_INVOKABLE void openFocusedTask();
   Q_INVOKABLE QStringList collectPrefixes() const;
   Q_INVOKABLE void refreshGitForTaskBranch(const QString& taskId);
+  // Create (and switch to) the task's branch from a task card. Honors the
+  // configured integrations.github.branchTemplate; toasts the result.
+  Q_INVOKABLE void createBranchForTask(const QString& taskId);
 
  signals:
   void selectedDateChanged();
@@ -639,4 +642,5 @@ class AppController : public QObject {
   void applyGitSettingsFromMap(const QVariantMap& git);
   void onGitBranchChanged(const QString& repo, const QString& branch, const QString& taskId);
   void onGitRepoState(const QString& repo, const QVariantMap& state);
+  void onGitCommits(const QString& repo, const QVariantMap& commitsByTask);
 };

--- a/src/Models.cpp
+++ b/src/Models.cpp
@@ -1,5 +1,7 @@
 #include "Models.h"
 
+#include <algorithm>
+
 QHash<int, QByteArray> TaskModel::roleNames() const {
   return {
       {IdRole, "id"},
@@ -17,6 +19,7 @@ QHash<int, QByteArray> TaskModel::roleNames() const {
       {PrUrlRole, "prUrl"},
       {GitAheadRole, "gitAhead"},
       {GitBehindRole, "gitBehind"},
+      {RecentCommitsRole, "recentCommits"},
   };
 }
 
@@ -56,6 +59,8 @@ QVariant TaskModel::data(const QModelIndex& idx, int role) const {
       return m_git.value(t.id).ahead;
     case GitBehindRole:
       return m_git.value(t.id).behind;
+    case RecentCommitsRole:
+      return m_git.value(t.id).recentCommits;
   }
   return {};
 }
@@ -88,8 +93,11 @@ void TaskModel::setGitInfoForId(const QString& id, const QVariantMap& info) {
   if(info.contains(QStringLiteral("behind"))) {
     g.behind = info.value(QStringLiteral("behind")).toInt();
   }
+  if(info.contains(QStringLiteral("recentCommits"))) {
+    g.recentCommits = info.value(QStringLiteral("recentCommits")).toList();
+  }
   const QModelIndex mi = index(row, 0);
-  emit dataChanged(mi, mi, {PrStateRole, PrNumberRole, PrUrlRole, GitAheadRole, GitBehindRole});
+  emit dataChanged(mi, mi, {PrStateRole, PrNumberRole, PrUrlRole, GitAheadRole, GitBehindRole, RecentCommitsRole});
 }
 
 void TaskModel::clearAllGitInfo() {
@@ -98,7 +106,8 @@ void TaskModel::clearAllGitInfo() {
     return;
   }
   m_git.clear();
-  emit dataChanged(index(0, 0), index(m_items.size() - 1, 0), {PrStateRole, PrNumberRole, PrUrlRole, GitAheadRole, GitBehindRole});
+  emit dataChanged(
+      index(0, 0), index(m_items.size() - 1, 0), {PrStateRole, PrNumberRole, PrUrlRole, GitAheadRole, GitBehindRole, RecentCommitsRole});
 }
 
 int TaskModel::indexOfId(const QString& id) const {
@@ -155,12 +164,8 @@ void TaskModel::setBlockedStuckIds(const QSet<QString>& ids) {
   int hi = -1;
   for(int i = 0; i < m_items.size(); ++i) {
     if(changed.contains(m_items[i].id)) {
-      if(i < lo) {
-        lo = i;
-      }
-      if(i > hi) {
-        hi = i;
-      }
+      lo = std::min(i, lo);
+      hi = std::max(i, hi);
     }
   }
   if(hi < 0) {

--- a/src/Models.h
+++ b/src/Models.h
@@ -89,6 +89,7 @@ class TaskModel : public QAbstractListModel {
     PrUrlRole,
     GitAheadRole,
     GitBehindRole,
+    RecentCommitsRole,
   };
 
   explicit TaskModel(QObject* parent = nullptr) : QAbstractListModel(parent) {
@@ -132,6 +133,7 @@ class TaskModel : public QAbstractListModel {
     int prNumber = 0;
     int ahead = 0;
     int behind = 0;
+    QVariantList recentCommits;  // [ {sha, subject}, … ] mentioning this task
   };
 
   QVector<Task> m_items;

--- a/src/git/BranchTaskMatcher.cpp
+++ b/src/git/BranchTaskMatcher.cpp
@@ -4,100 +4,213 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QTextStream>
+#include <QVariantList>
+#include <QVariantMap>
 
 namespace heap::git {
 
-BranchTaskMatcher::BranchTaskMatcher(QStringList prefixes)
-    : m_prefixes(std::move(prefixes)),
-      m_loneDigitsRx(QStringLiteral("(?:^|[-/_])(\\d{3,7})(?:[-/_]|$)"))
-{
-    rebuildRegexes();
+BranchTaskMatcher::BranchTaskMatcher(QStringList prefixes) :
+    m_prefixes(std::move(prefixes)), m_loneDigitsRx(QStringLiteral("(?:^|[-/_])(\\d{3,7})(?:[-/_]|$)")) {
+  rebuildRegexes();
 }
 
 void BranchTaskMatcher::setPrefixes(QStringList prefixes) {
-    m_prefixes = std::move(prefixes);
-    rebuildRegexes();
+  m_prefixes = std::move(prefixes);
+  rebuildRegexes();
 }
 
 void BranchTaskMatcher::rebuildRegexes() {
-    m_prefixRx.clear();
-    m_prefixRx.reserve(m_prefixes.size());
-    for (const QString &raw : m_prefixes) {
-        const QString p = raw.trimmed();
-        if (p.isEmpty()) continue;
-        // (?:^|[-/_]) <PREFIX>-<digits> (?:[-/_]|$), case-insensitive
-        QRegularExpression rx(
-            QStringLiteral("(?:^|[-/_])(") + QRegularExpression::escape(p)
-                + QStringLiteral(")-(\\d+)(?:[-/_]|$)"),
-            QRegularExpression::CaseInsensitiveOption);
-        m_prefixRx.push_back(rx);
+  m_prefixRx.clear();
+  m_textRx.clear();
+  m_prefixRx.reserve(m_prefixes.size());
+  m_textRx.reserve(m_prefixes.size());
+  for(const QString& raw : m_prefixes) {
+    const QString p = raw.trimmed();
+    if(p.isEmpty()) {
+      continue;
     }
+    // Branch names: (?:^|[-/_]) <PREFIX>-<digits> (?:[-/_]|$).
+    const QRegularExpression rx(QStringLiteral("(?:^|[-/_])(") + QRegularExpression::escape(p) + QStringLiteral(")-(\\d+)(?:[-/_]|$)"),
+                                QRegularExpression::CaseInsensitiveOption);
+    m_prefixRx.push_back(rx);
+    // Free text (commit subjects): word-boundary around the id so it is
+    // caught amid prose ("fix HEAP-76: …") but not inside another token.
+    const QRegularExpression tx(QStringLiteral("(?<![A-Za-z0-9])(") + QRegularExpression::escape(p) + QStringLiteral(")-(\\d+)(?![0-9])"),
+                                QRegularExpression::CaseInsensitiveOption);
+    m_textRx.push_back(tx);
+  }
 }
 
-MatchResult BranchTaskMatcher::extract(const QString &branch) const {
-    MatchResult out;
-    if (branch.isEmpty() || branch == QStringLiteral("(detached HEAD)"))
-        return out;
-    if (m_prefixes.isEmpty()) return out;
-
-    // Rule 1: explicit "<prefix>-<digits>" anywhere (case-insensitive).
-    for (int i = 0; i < m_prefixRx.size(); ++i) {
-        const auto m = m_prefixRx.at(i).match(branch);
-        if (m.hasMatch()) {
-            const QString prefix = m_prefixes.at(i).trimmed().toUpper();
-            const int     n      = m.captured(2).toInt();
-            out.matchedPrefix    = prefix;
-            out.numericPart      = n;
-            out.taskId           = prefix + QChar('-') + QString::number(n);
-            out.matched          = true;
-            return out;
-        }
-    }
-
-    // Rule 2: numeric-only fallback — only if exactly one registered prefix.
-    QStringList nonEmpty;
-    for (const QString &p : m_prefixes)
-        if (!p.trimmed().isEmpty()) nonEmpty << p.trimmed();
-    if (nonEmpty.size() != 1) return out;
-
-    const auto dm = m_loneDigitsRx.match(branch);
-    if (!dm.hasMatch()) return out;
-    const QString prefix = nonEmpty.first().toUpper();
-    const int     n      = dm.captured(1).toInt();
-    out.matchedPrefix    = prefix;
-    out.numericPart      = n;
-    out.taskId           = prefix + QChar('-') + QString::number(n);
-    out.matched          = true;
+MatchResult BranchTaskMatcher::extract(const QString& branch) const {
+  MatchResult out;
+  if(branch.isEmpty() || branch == QStringLiteral("(detached HEAD)")) {
     return out;
+  }
+  if(m_prefixes.isEmpty()) {
+    return out;
+  }
+
+  // Rule 1: explicit "<prefix>-<digits>" anywhere (case-insensitive).
+  for(int i = 0; i < m_prefixRx.size(); ++i) {
+    const auto m = m_prefixRx.at(i).match(branch);
+    if(m.hasMatch()) {
+      const QString prefix = m_prefixes.at(i).trimmed().toUpper();
+      const int n = m.captured(2).toInt();
+      out.matchedPrefix = prefix;
+      out.numericPart = n;
+      out.taskId = prefix + QChar('-') + QString::number(n);
+      out.matched = true;
+      return out;
+    }
+  }
+
+  // Rule 2: numeric-only fallback — only if exactly one registered prefix.
+  QStringList nonEmpty;
+  for(const QString& p : m_prefixes) {
+    if(!p.trimmed().isEmpty()) {
+      nonEmpty << p.trimmed();
+    }
+  }
+  if(nonEmpty.size() != 1) {
+    return out;
+  }
+
+  const auto dm = m_loneDigitsRx.match(branch);
+  if(!dm.hasMatch()) {
+    return out;
+  }
+  const QString prefix = nonEmpty.first().toUpper();
+  const int n = dm.captured(1).toInt();
+  out.matchedPrefix = prefix;
+  out.numericPart = n;
+  out.taskId = prefix + QChar('-') + QString::number(n);
+  out.matched = true;
+  return out;
+}
+
+QVariantMap BranchTaskMatcher::groupCommitsByTask(const QByteArray& gitLogOutput) const {
+  QVariantMap out;
+  const QString text = QString::fromUtf8(gitLogOutput);
+  const auto lines = text.split(QChar('\n'), Qt::SkipEmptyParts);
+  for(const QString& line : lines) {
+    const int sep = line.indexOf(QChar(0x1f));
+    if(sep < 0) {
+      continue;
+    }
+    const QString sha = line.left(sep).trimmed();
+    const QString subject = line.mid(sep + 1).trimmed();
+    if(sha.isEmpty()) {
+      continue;
+    }
+    // Free-text match — the id can sit anywhere in the subject line.
+    QString taskId;
+    for(int i = 0; i < m_textRx.size(); ++i) {
+      const auto m = m_textRx.at(i).match(subject);
+      if(m.hasMatch()) {
+        taskId = m_prefixes.at(i).trimmed().toUpper() + QChar('-') + QString::number(m.captured(2).toInt());
+        break;
+      }
+    }
+    if(taskId.isEmpty()) {
+      continue;
+    }
+    QVariantList list = out.value(taskId).toList();
+    if(list.size() >= 20) {
+      continue;  // cap per task — cards show a few
+    }
+    QVariantMap commit;
+    commit.insert(QStringLiteral("sha"), sha.left(7));
+    commit.insert(QStringLiteral("subject"), subject);
+    list.append(commit);
+    out.insert(taskId, list);
+  }
+  return out;
+}
+
+QString BranchTaskMatcher::slugifyTitle(const QString& title) {
+  QString s;
+  s.reserve(title.size());
+  bool lastDash = false;
+  for(const QChar c : title.toLower()) {
+    if(c.isLetterOrNumber()) {
+      s.append(c);
+      lastDash = false;
+    } else if(!s.isEmpty() && !lastDash) {
+      s.append(QChar('-'));
+      lastDash = true;
+    }
+  }
+  while(s.endsWith(QChar('-'))) {
+    s.chop(1);
+  }
+  constexpr int kMaxSlug = 40;
+  if(s.size() > kMaxSlug) {
+    s = s.left(kMaxSlug);
+    while(s.endsWith(QChar('-'))) {
+      s.chop(1);
+    }
+  }
+  return s;
+}
+
+QString BranchTaskMatcher::branchNameForTask(const QString& taskId, const QString& title, const QString& templ) {
+  QString t = templ.trimmed();
+  if(t.isEmpty()) {
+    t = QStringLiteral("feature/{id}-{slug}");
+  }
+  const QString slug = slugifyTitle(title);
+  t.replace(QStringLiteral("{type}"), QStringLiteral("feature"));
+  t.replace(QStringLiteral("{id}"), taskId.trimmed().toLower());
+  t.replace(QStringLiteral("{slug}"), slug);
+  // A missing slug/id can leave a dangling separator — trim it.
+  while(t.endsWith(QChar('-')) || t.endsWith(QChar('/'))) {
+    t.chop(1);
+  }
+  return t;
 }
 
 QString BranchTaskMatcher::branchFromHeadText(QStringView headFileContents) {
-    QString t = headFileContents.trimmed().toString();
-    static const QString kRef = QStringLiteral("ref: refs/heads/");
-    if (t.startsWith(kRef)) return t.mid(kRef.size());
-    static const QRegularExpression rxSha(QStringLiteral("^[0-9a-fA-F]{40}$"));
-    if (rxSha.match(t).hasMatch())
-        return QStringLiteral("(detached HEAD)");
-    return QString();
+  const QString t = headFileContents.trimmed().toString();
+  static const QString kRef = QStringLiteral("ref: refs/heads/");
+  if(t.startsWith(kRef)) {
+    return t.mid(kRef.size());
+  }
+  static const QRegularExpression rxSha(QStringLiteral("^[0-9a-fA-F]{40}$"));
+  if(rxSha.match(t).hasMatch()) {
+    return QStringLiteral("(detached HEAD)");
+  }
+  return QString();
 }
 
-QString BranchTaskMatcher::resolveGitDir(const QString &repoPath) {
-    if (repoPath.isEmpty()) return QString();
-    QFileInfo gi(QDir(repoPath).filePath(QStringLiteral(".git")));
-    if (gi.isDir()) return gi.absoluteFilePath();
-    if (gi.isFile()) {
-        QFile f(gi.absoluteFilePath());
-        if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) return QString();
-        const QString line = QString::fromUtf8(f.readLine()).trimmed();
-        static const QString kPrefix = QStringLiteral("gitdir:");
-        if (!line.startsWith(kPrefix)) return QString();
-        QString p = line.mid(kPrefix.size()).trimmed();
-        if (p.isEmpty()) return QString();
-        QFileInfo pi(p);
-        if (pi.isAbsolute()) return QDir::cleanPath(pi.absoluteFilePath());
-        return QDir::cleanPath(QDir(repoPath).absoluteFilePath(p));
+QString BranchTaskMatcher::resolveGitDir(const QString& repoPath) {
+  if(repoPath.isEmpty()) {
+    return QString();
+  }
+  const QFileInfo gi(QDir(repoPath).filePath(QStringLiteral(".git")));
+  if(gi.isDir()) {
+    return gi.absoluteFilePath();
+  }
+  if(gi.isFile()) {
+    QFile f(gi.absoluteFilePath());
+    if(!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+      return QString();
     }
-    return QString();
+    const QString line = QString::fromUtf8(f.readLine()).trimmed();
+    static const QString kPrefix = QStringLiteral("gitdir:");
+    if(!line.startsWith(kPrefix)) {
+      return QString();
+    }
+    const QString p = line.mid(kPrefix.size()).trimmed();
+    if(p.isEmpty()) {
+      return QString();
+    }
+    const QFileInfo pi(p);
+    if(pi.isAbsolute()) {
+      return QDir::cleanPath(pi.absoluteFilePath());
+    }
+    return QDir::cleanPath(QDir(repoPath).absoluteFilePath(p));
+  }
+  return QString();
 }
 
-} // namespace heap::git
+}  // namespace heap::git

--- a/src/git/BranchTaskMatcher.h
+++ b/src/git/BranchTaskMatcher.h
@@ -4,35 +4,56 @@
 #include <QString>
 #include <QStringList>
 #include <QStringView>
+#include <QVariantMap>
 #include <QVector>
 
 namespace heap::git {
 
 struct MatchResult {
-    QString taskId;          // e.g. "LTE-2398" (prefix uppercased)
-    QString matchedPrefix;   // e.g. "LTE"
-    int     numericPart = 0;
-    bool    matched = false;
+  QString taskId;         // e.g. "LTE-2398" (prefix uppercased)
+  QString matchedPrefix;  // e.g. "LTE"
+  int numericPart = 0;
+  bool matched = false;
 };
 
 class BranchTaskMatcher {
-public:
-    explicit BranchTaskMatcher(QStringList prefixes = {});
+ public:
+  explicit BranchTaskMatcher(QStringList prefixes = {});
 
-    void setPrefixes(QStringList prefixes);
-    const QStringList &prefixes() const noexcept { return m_prefixes; }
+  void setPrefixes(QStringList prefixes);
 
-    MatchResult extract(const QString &branch) const;
+  const QStringList& prefixes() const noexcept {
+    return m_prefixes;
+  }
 
-    static QString branchFromHeadText(QStringView headFileContents);
-    static QString resolveGitDir(const QString &repoPath);
+  MatchResult extract(const QString& branch) const;
 
-private:
-    QStringList                 m_prefixes;
-    QVector<QRegularExpression> m_prefixRx;
-    QRegularExpression          m_loneDigitsRx;
+  // Group commit subjects by the task id they mention. Input is the raw
+  // output of `git log --pretty=format:%H%x1f%s` (SHA, unit-separator 0x1f,
+  // subject; one commit per line). Returns { taskId → [ {sha, subject}, … ] }
+  // where sha is the abbreviated (7-char) hash. Commits mentioning no known
+  // task prefix are dropped. Pure/testable — no git I/O.
+  QVariantMap groupCommitsByTask(const QByteArray& gitLogOutput) const;
 
-    void rebuildRegexes();
+  static QString branchFromHeadText(QStringView headFileContents);
+  static QString resolveGitDir(const QString& repoPath);
+
+  // Slug for a branch name: lowercased, non-alphanumerics collapsed to single
+  // '-', trimmed of leading/trailing '-', capped to a sane length.
+  static QString slugifyTitle(const QString& title);
+
+  // Compose a branch name for a task from a template. Placeholders {id},
+  // {slug} and {type} are substituted; an empty template falls back to
+  // "feature/{id}-{slug}". {id} is lowercased for filesystem safety.
+  static QString branchNameForTask(const QString& taskId, const QString& title, const QString& templ);
+
+ private:
+  QStringList m_prefixes;
+  QVector<QRegularExpression> m_prefixRx;  // branch-name boundaries ([-/_])
+  QVector<QRegularExpression> m_textRx;    // free-text boundaries (commits)
+  QRegularExpression m_loneDigitsRx;
+
+  void rebuildRegexes();
 };
 
-} // namespace heap::git
+}  // namespace heap::git

--- a/src/git/GitTypes.h
+++ b/src/git/GitTypes.h
@@ -7,48 +7,52 @@
 namespace heap::git {
 
 struct RepoConfig {
-    QString path;            // worktree root (absolute)
-    QString resolvedGitDir;  // <repo>/.git OR worktree gitdir target
+  QString path;            // worktree root (absolute)
+  QString resolvedGitDir;  // <repo>/.git OR worktree gitdir target
 };
 
 struct PrInfo {
-    QString   state;         // "open" | "draft" | "merged" | "closed" | ""
-    int       number = 0;
-    QString   url;
-    QString   title;
-    QDateTime fetchedAt;
+  QString state;  // "open" | "draft" | "merged" | "closed" | ""
+  int number = 0;
+  QString url;
+  QString title;
+  bool draft = false;
+  QString checks;  // CI rollup: "passing" | "failing" | "pending" | ""
+  QDateTime fetchedAt;
 
-    QVariantMap toVariant() const {
-        QVariantMap m;
-        m["state"]     = state;
-        m["number"]    = number;
-        m["url"]       = url;
-        m["title"]     = title;
-        m["fetchedAt"] = fetchedAt;
-        return m;
-    }
+  QVariantMap toVariant() const {
+    QVariantMap m;
+    m["state"] = state;
+    m["number"] = number;
+    m["url"] = url;
+    m["title"] = title;
+    m["draft"] = draft;
+    m["checks"] = checks;
+    m["fetchedAt"] = fetchedAt;
+    return m;
+  }
 };
 
 struct RepoState {
-    QString repoPath;
-    QString branch;          // "" if unset; "(detached HEAD)" if detached
-    QString headSha;
-    QString upstream;        // "origin/main" if known
-    int     ahead  = 0;
-    int     behind = 0;
-    PrInfo  pr;
+  QString repoPath;
+  QString branch;  // "" if unset; "(detached HEAD)" if detached
+  QString headSha;
+  QString upstream;  // "origin/main" if known
+  int ahead = 0;
+  int behind = 0;
+  PrInfo pr;
 
-    QVariantMap toVariant() const {
-        QVariantMap m;
-        m["repoPath"] = repoPath;
-        m["branch"]   = branch;
-        m["headSha"]  = headSha;
-        m["upstream"] = upstream;
-        m["ahead"]    = ahead;
-        m["behind"]   = behind;
-        m["pr"]       = pr.toVariant();
-        return m;
-    }
+  QVariantMap toVariant() const {
+    QVariantMap m;
+    m["repoPath"] = repoPath;
+    m["branch"] = branch;
+    m["headSha"] = headSha;
+    m["upstream"] = upstream;
+    m["ahead"] = ahead;
+    m["behind"] = behind;
+    m["pr"] = pr.toVariant();
+    return m;
+  }
 };
 
-} // namespace heap::git
+}  // namespace heap::git

--- a/src/git/GitWatcher.cpp
+++ b/src/git/GitWatcher.cpp
@@ -12,358 +12,522 @@
 
 namespace heap::git {
 
-GitWatcher::GitWatcher(QObject *parent)
-    : QObject(parent),
-      m_fsw(new QFileSystemWatcher(this)),
-      m_debounce(new QTimer(this))
-{
-    m_debounce->setSingleShot(true);
-    m_debounce->setInterval(250);
-    connect(m_debounce, &QTimer::timeout, this, &GitWatcher::onDebounceFired);
-    connect(m_fsw, &QFileSystemWatcher::fileChanged,
-            this, &GitWatcher::onFsPathChanged);
-    connect(m_fsw, &QFileSystemWatcher::directoryChanged,
-            this, &GitWatcher::onFsPathChanged);
+namespace {
 
-    m_gitPath  = QStandardPaths::findExecutable(QStringLiteral("git"));
-    m_ghPath   = QStandardPaths::findExecutable(QStringLiteral("gh"));
-    m_glabPath = QStandardPaths::findExecutable(QStringLiteral("glab"));
-    if (m_ghPath.isEmpty() && m_glabPath.isEmpty())
-        qInfo("GitWatcher: neither 'gh' nor 'glab' on PATH — PR state disabled");
-    if (m_gitPath.isEmpty())
-        qInfo("GitWatcher: 'git' not on PATH — ahead/behind disabled");
+// Collapse GitHub's statusCheckRollup array into one CI verdict. Handles both
+// CheckRun nodes (status QUEUED/IN_PROGRESS/COMPLETED + conclusion) and legacy
+// StatusContext nodes (state SUCCESS/PENDING/FAILURE/ERROR). Any failure wins,
+// then any pending, else passing; empty when there are no checks.
+QString rollupChecks(const QJsonArray& arr) {
+  if(arr.isEmpty()) {
+    return QString();
+  }
+  bool anyFail = false;
+  bool anyPending = false;
+  bool anySuccess = false;
+  for(const auto& v : arr) {
+    const auto o = v.toObject();
+    const QString status = o.value(QStringLiteral("status")).toString().toUpper();
+    const QString state = o.value(QStringLiteral("state")).toString().toUpper();
+    QString concl = o.value(QStringLiteral("conclusion")).toString().toUpper();
+    if(!state.isEmpty()) {
+      concl = state;  // StatusContext carries no conclusion
+    }
+    if(status == QLatin1String("QUEUED") || status == QLatin1String("IN_PROGRESS") || status == QLatin1String("PENDING") ||
+       state == QLatin1String("PENDING") || state == QLatin1String("EXPECTED")) {
+      anyPending = true;
+    } else if(concl == QLatin1String("FAILURE") || concl == QLatin1String("ERROR") || concl == QLatin1String("CANCELLED") ||
+              concl == QLatin1String("TIMED_OUT") || concl == QLatin1String("ACTION_REQUIRED")) {
+      anyFail = true;
+    } else if(concl == QLatin1String("SUCCESS") || concl == QLatin1String("NEUTRAL") || concl == QLatin1String("SKIPPED")) {
+      anySuccess = true;
+    }
+  }
+  if(anyFail) {
+    return QStringLiteral("failing");
+  }
+  if(anyPending) {
+    return QStringLiteral("pending");
+  }
+  if(anySuccess) {
+    return QStringLiteral("passing");
+  }
+  return QString();
+}
+
+}  // namespace
+
+GitWatcher::GitWatcher(QObject* parent) : QObject(parent), m_fsw(new QFileSystemWatcher(this)), m_debounce(new QTimer(this)) {
+  m_debounce->setSingleShot(true);
+  m_debounce->setInterval(250);
+  connect(m_debounce, &QTimer::timeout, this, &GitWatcher::onDebounceFired);
+  connect(m_fsw, &QFileSystemWatcher::fileChanged, this, &GitWatcher::onFsPathChanged);
+  connect(m_fsw, &QFileSystemWatcher::directoryChanged, this, &GitWatcher::onFsPathChanged);
+
+  m_gitPath = QStandardPaths::findExecutable(QStringLiteral("git"));
+  m_ghPath = QStandardPaths::findExecutable(QStringLiteral("gh"));
+  m_glabPath = QStandardPaths::findExecutable(QStringLiteral("glab"));
+  if(m_ghPath.isEmpty() && m_glabPath.isEmpty()) {
+    qInfo("GitWatcher: neither 'gh' nor 'glab' on PATH — PR state disabled");
+  }
+  if(m_gitPath.isEmpty()) {
+    qInfo("GitWatcher: 'git' not on PATH — ahead/behind disabled");
+  }
 }
 
 GitWatcher::~GitWatcher() = default;
 
 QStringList GitWatcher::watchedRepos() const {
-    return m_configs.keys();
+  return m_configs.keys();
 }
 
 QVariantMap GitWatcher::snapshot() const {
-    QVariantMap out;
-    for (auto it = m_state.constBegin(); it != m_state.constEnd(); ++it)
-        out.insert(it.key(), it.value().toVariant());
-    return out;
+  QVariantMap out;
+  for(auto it = m_state.constBegin(); it != m_state.constEnd(); ++it) {
+    out.insert(it.key(), it.value().toVariant());
+  }
+  return out;
 }
 
-QString GitWatcher::cacheKey(const QString &repo, const QString &branch) {
-    return repo + QChar('\n') + branch;
+QString GitWatcher::cacheKey(const QString& repo, const QString& branch) {
+  return repo + QChar('\n') + branch;
 }
 
-void GitWatcher::setWatchedRepos(const QStringList &paths) {
-    QSet<QString> wanted;
-    for (const QString &p : paths) {
-        const QString abs = QDir(p).absolutePath();
-        if (!abs.isEmpty()) wanted.insert(abs);
+void GitWatcher::setWatchedRepos(const QStringList& paths) {
+  QSet<QString> wanted;
+  for(const QString& p : paths) {
+    const QString abs = QDir(p).absolutePath();
+    if(!abs.isEmpty()) {
+      wanted.insert(abs);
     }
-    const auto current = QSet<QString>(m_configs.keyBegin(), m_configs.keyEnd());
-    for (const QString &p : current)
-        if (!wanted.contains(p)) removeRepo(p);
-    for (const QString &p : wanted)
-        if (!m_configs.contains(p)) addRepo(p);
+  }
+  const auto current = QSet<QString>(m_configs.keyBegin(), m_configs.keyEnd());
+  for(const QString& p : current) {
+    if(!wanted.contains(p)) {
+      removeRepo(p);
+    }
+  }
+  for(const QString& p : wanted) {
+    if(!m_configs.contains(p)) {
+      addRepo(p);
+    }
+  }
 }
 
-void GitWatcher::setPrefixes(const QStringList &prefixes) {
-    m_matcher.setPrefixes(prefixes);
+void GitWatcher::setPrefixes(const QStringList& prefixes) {
+  m_matcher.setPrefixes(prefixes);
 }
 
 void GitWatcher::setPrFetchEnabled(bool on) {
-    m_prEnabled = on;
+  m_prEnabled = on;
 }
 
-void GitWatcher::addRepo(const QString &path) {
-    const QString gitDir = BranchTaskMatcher::resolveGitDir(path);
-    if (gitDir.isEmpty()) {
-        qInfo("GitWatcher: skipping '%s' — no .git found",
-              qUtf8Printable(path));
-        return;
-    }
-    RepoConfig cfg{ path, gitDir };
-    m_configs.insert(path, cfg);
-    RepoState st;
-    st.repoPath = path;
-    m_state.insert(path, st);
-    rewatchFiles(cfg);
-    recomputeForRepo(path);
+void GitWatcher::addRepo(const QString& path) {
+  const QString gitDir = BranchTaskMatcher::resolveGitDir(path);
+  if(gitDir.isEmpty()) {
+    qInfo("GitWatcher: skipping '%s' — no .git found", qUtf8Printable(path));
+    return;
+  }
+  const RepoConfig cfg{.path = path, .resolvedGitDir = gitDir};
+  m_configs.insert(path, cfg);
+  RepoState st;
+  st.repoPath = path;
+  m_state.insert(path, st);
+  rewatchFiles(cfg);
+  recomputeForRepo(path);
 }
 
-void GitWatcher::removeRepo(const QString &path) {
-    auto it = m_configs.find(path);
-    if (it == m_configs.end()) return;
-    const QString gitDir = it->resolvedGitDir;
-    for (const QString &f : { QStringLiteral("HEAD"),
-                              QStringLiteral("packed-refs"),
-                              QStringLiteral("index") }) {
-        const QString fp = gitDir + QChar('/') + f;
-        m_fsw->removePath(fp);
-        m_watchedFileOwner.remove(fp);
-    }
-    m_configs.erase(it);
-    m_state.remove(path);
+void GitWatcher::removeRepo(const QString& path) {
+  auto it = m_configs.find(path);
+  if(it == m_configs.end()) {
+    return;
+  }
+  const QString gitDir = it->resolvedGitDir;
+  for(const QString& f : {QStringLiteral("HEAD"), QStringLiteral("packed-refs"), QStringLiteral("index")}) {
+    const QString fp = gitDir + QChar('/') + f;
+    m_fsw->removePath(fp);
+    m_watchedFileOwner.remove(fp);
+  }
+  m_configs.erase(it);
+  m_state.remove(path);
 }
 
-void GitWatcher::rewatchFiles(const RepoConfig &cfg) {
-    for (const QString &f : { QStringLiteral("HEAD"),
-                              QStringLiteral("packed-refs"),
-                              QStringLiteral("index") }) {
-        const QString fp = cfg.resolvedGitDir + QChar('/') + f;
-        if (!QFile::exists(fp)) continue;
-        if (!m_fsw->files().contains(fp)) m_fsw->addPath(fp);
-        m_watchedFileOwner.insert(fp, cfg.path);
+void GitWatcher::rewatchFiles(const RepoConfig& cfg) {
+  for(const QString& f : {QStringLiteral("HEAD"), QStringLiteral("packed-refs"), QStringLiteral("index")}) {
+    const QString fp = cfg.resolvedGitDir + QChar('/') + f;
+    if(!QFile::exists(fp)) {
+      continue;
     }
-    // Also watch the refs/heads directory: branch SHA file is created on
-    // first checkout and may not exist yet.
-    const QString refsHeads = cfg.resolvedGitDir + QStringLiteral("/refs/heads");
-    if (QFileInfo(refsHeads).isDir()
-        && !m_fsw->directories().contains(refsHeads)) {
-        m_fsw->addPath(refsHeads);
-        m_watchedFileOwner.insert(refsHeads, cfg.path);
+    if(!m_fsw->files().contains(fp)) {
+      m_fsw->addPath(fp);
     }
+    m_watchedFileOwner.insert(fp, cfg.path);
+  }
+  // Also watch the refs/heads directory: branch SHA file is created on
+  // first checkout and may not exist yet.
+  const QString refsHeads = cfg.resolvedGitDir + QStringLiteral("/refs/heads");
+  if(QFileInfo(refsHeads).isDir() && !m_fsw->directories().contains(refsHeads)) {
+    m_fsw->addPath(refsHeads);
+    m_watchedFileOwner.insert(refsHeads, cfg.path);
+  }
 }
 
-void GitWatcher::onFsPathChanged(const QString &path) {
-    const QString repo = m_watchedFileOwner.value(path);
-    if (!repo.isEmpty()) m_pendingRepos.insert(repo);
+void GitWatcher::onFsPathChanged(const QString& path) {
+  const QString repo = m_watchedFileOwner.value(path);
+  if(!repo.isEmpty()) {
+    m_pendingRepos.insert(repo);
+  }
 
-    // Re-arm watch in case of atomic-rename replacement (Windows).
-    if (QFile::exists(path) && !m_fsw->files().contains(path)
-        && !m_fsw->directories().contains(path)) {
-        m_fsw->addPath(path);
-    }
-    m_debounce->start();
+  // Re-arm watch in case of atomic-rename replacement (Windows).
+  if(QFile::exists(path) && !m_fsw->files().contains(path) && !m_fsw->directories().contains(path)) {
+    m_fsw->addPath(path);
+  }
+  m_debounce->start();
 }
 
 void GitWatcher::onDebounceFired() {
-    const auto repos = m_pendingRepos;
-    m_pendingRepos.clear();
-    for (const QString &r : repos) {
-        if (m_configs.contains(r)) {
-            // Re-arm files for the repo before recomputing.
-            rewatchFiles(m_configs.value(r));
-            recomputeForRepo(r);
-        }
+  const auto repos = m_pendingRepos;
+  m_pendingRepos.clear();
+  for(const QString& r : repos) {
+    if(m_configs.contains(r)) {
+      // Re-arm files for the repo before recomputing.
+      rewatchFiles(m_configs.value(r));
+      recomputeForRepo(r);
     }
+  }
 }
 
-QString GitWatcher::readHeadText(const QString &gitDir) {
-    QFile f(gitDir + QStringLiteral("/HEAD"));
-    if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) return QString();
-    return QString::fromUtf8(f.readAll());
-}
-
-QString GitWatcher::readShaForBranch(const QString &gitDir,
-                                     const QString &branch) {
-    if (branch.isEmpty() || branch == QStringLiteral("(detached HEAD)"))
-        return QString();
-    {
-        QFile f(gitDir + QStringLiteral("/refs/heads/") + branch);
-        if (f.open(QIODevice::ReadOnly | QIODevice::Text))
-            return QString::fromUtf8(f.readAll()).trimmed();
-    }
-    QFile pr(gitDir + QStringLiteral("/packed-refs"));
-    if (!pr.open(QIODevice::ReadOnly | QIODevice::Text)) return QString();
-    QTextStream ts(&pr);
-    const QString needle = QStringLiteral(" refs/heads/") + branch;
-    while (!ts.atEnd()) {
-        const QString line = ts.readLine();
-        if (line.startsWith('#') || line.startsWith('^')) continue;
-        if (line.endsWith(needle))
-            return line.left(line.indexOf(' '));
-    }
+QString GitWatcher::readHeadText(const QString& gitDir) {
+  QFile f(gitDir + QStringLiteral("/HEAD"));
+  if(!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
     return QString();
+  }
+  return QString::fromUtf8(f.readAll());
 }
 
-QString GitWatcher::upstreamForBranch(const QString &gitDir,
-                                      const QString &branch) {
-    if (branch.isEmpty() || branch == QStringLiteral("(detached HEAD)"))
-        return QString();
-    QFile f(gitDir + QStringLiteral("/config"));
-    if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) return QString();
-    QTextStream ts(&f);
-    const QString header = QStringLiteral("[branch \"") + branch + QChar('"');
-    bool inSection = false;
-    QString remote, merge;
-    while (!ts.atEnd()) {
-        const QString line = ts.readLine().trimmed();
-        if (line.startsWith('[')) {
-            inSection = line.startsWith(header);
-            continue;
-        }
-        if (!inSection) continue;
-        if (line.startsWith(QStringLiteral("remote"))) {
-            const int eq = line.indexOf('=');
-            if (eq > 0) remote = line.mid(eq + 1).trimmed();
-        } else if (line.startsWith(QStringLiteral("merge"))) {
-            const int eq = line.indexOf('=');
-            if (eq > 0) merge = line.mid(eq + 1).trimmed();
-        }
+QString GitWatcher::readShaForBranch(const QString& gitDir, const QString& branch) {
+  if(branch.isEmpty() || branch == QStringLiteral("(detached HEAD)")) {
+    return QString();
+  }
+  {
+    QFile f(gitDir + QStringLiteral("/refs/heads/") + branch);
+    if(f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+      return QString::fromUtf8(f.readAll()).trimmed();
     }
-    if (remote.isEmpty() || merge.isEmpty()) return QString();
-    QString mergeBranch = merge;
-    const QString p = QStringLiteral("refs/heads/");
-    if (mergeBranch.startsWith(p)) mergeBranch = mergeBranch.mid(p.size());
-    return remote + QChar('/') + mergeBranch;
-}
-
-void GitWatcher::recomputeForRepo(const QString &path) {
-    auto cit = m_configs.constFind(path);
-    if (cit == m_configs.constEnd()) return;
-    const RepoConfig &cfg = *cit;
-
-    const QString headText = readHeadText(cfg.resolvedGitDir);
-    const QString branch   = BranchTaskMatcher::branchFromHeadText(headText);
-    const QString sha      = readShaForBranch(cfg.resolvedGitDir, branch);
-
-    RepoState &st = m_state[path];
-    const QString oldBranch = st.branch;
-    const QString oldSha    = st.headSha;
-    if (oldBranch == branch && oldSha == sha) return;
-
-    st.branch  = branch;
-    st.headSha = sha;
-    st.upstream = upstreamForBranch(cfg.resolvedGitDir, branch);
-
-    const bool branchActuallyChanged = (oldBranch != branch);
-    if (branchActuallyChanged) {
-        // Reset ahead/behind until rev-list returns.
-        st.ahead = 0;
-        st.behind = 0;
-
-        const auto mr = m_matcher.extract(branch);
-        const QString taskId = mr.matched ? mr.taskId : QString();
-        m_lastRepo   = path;
-        m_lastBranch = branch;
-        m_lastTaskId = taskId;
-        emit branchChanged(path, branch, taskId);
+  }
+  QFile pr(gitDir + QStringLiteral("/packed-refs"));
+  if(!pr.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    return QString();
+  }
+  QTextStream ts(&pr);
+  const QString needle = QStringLiteral(" refs/heads/") + branch;
+  while(!ts.atEnd()) {
+    const QString line = ts.readLine();
+    if(line.startsWith('#') || line.startsWith('^')) {
+      continue;
     }
-
-    emit repoStateUpdated(path, st.toVariant());
-
-    if (branchActuallyChanged) {
-        if (!m_gitPath.isEmpty())
-            fetchAheadBehindAsync(path, branch);
-        if (m_prEnabled && (!m_ghPath.isEmpty() || !m_glabPath.isEmpty()))
-            fetchPrAsync(path, branch, /*emitOneShot=*/false);
+    if(line.endsWith(needle)) {
+      return line.left(line.indexOf(' '));
     }
+  }
+  return QString();
 }
 
-void GitWatcher::fetchAheadBehindAsync(const QString &repoPath,
-                                       const QString &branch) {
-    if (branch.isEmpty() || branch == QStringLiteral("(detached HEAD)")) return;
-    const RepoState &st = m_state.value(repoPath);
-    if (st.upstream.isEmpty()) return;
-
-    const QString key = QStringLiteral("ab:") + cacheKey(repoPath, branch);
-    if (m_inflight.contains(key) && m_inflight.value(key)) return;
-
-    auto *p = new QProcess(this);
-    m_inflight.insert(key, p);
-    p->setWorkingDirectory(repoPath);
-    p->setProgram(m_gitPath);
-    p->setArguments({QStringLiteral("rev-list"),
-                     QStringLiteral("--left-right"),
-                     QStringLiteral("--count"),
-                     branch + QStringLiteral("...") + st.upstream});
-    connect(p, &QProcess::finished, this,
-            [this, p, key, repoPath, branch](int code, QProcess::ExitStatus) {
-        m_inflight.remove(key);
-        const auto sit = m_state.find(repoPath);
-        if (sit == m_state.end() || sit->branch != branch) {
-            p->deleteLater();
-            return;
-        }
-        if (code == 0) {
-            const QString out = QString::fromUtf8(p->readAllStandardOutput())
-                                    .trimmed();
-            const QStringList parts = out.split(QRegularExpression("\\s+"),
-                                                Qt::SkipEmptyParts);
-            if (parts.size() == 2) {
-                sit->ahead  = parts[0].toInt();
-                sit->behind = parts[1].toInt();
-            }
-        }
-        emit repoStateUpdated(repoPath, sit->toVariant());
-        p->deleteLater();
-    });
-    p->start();
-}
-
-void GitWatcher::fetchPrAsync(const QString &repoPath,
-                              const QString &branch,
-                              bool emitOneShot) {
-    if (branch.isEmpty() || branch == QStringLiteral("(detached HEAD)")) return;
-
-    const QString key = QStringLiteral("pr:") + cacheKey(repoPath, branch);
-    if (m_inflight.contains(key) && m_inflight.value(key)) return;
-
-    QString tool = m_ghPath;
-    QStringList args;
-    if (!tool.isEmpty()) {
-        args = {QStringLiteral("pr"), QStringLiteral("view"),
-                QStringLiteral("--json"),
-                QStringLiteral("state,number,url,title"),
-                branch};
-    } else if (!m_glabPath.isEmpty()) {
-        tool = m_glabPath;
-        args = {QStringLiteral("mr"), QStringLiteral("view"),
-                QStringLiteral("--output"), QStringLiteral("json"),
-                branch};
-    } else {
-        return;
+QString GitWatcher::upstreamForBranch(const QString& gitDir, const QString& branch) {
+  if(branch.isEmpty() || branch == QStringLiteral("(detached HEAD)")) {
+    return QString();
+  }
+  QFile f(gitDir + QStringLiteral("/config"));
+  if(!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    return QString();
+  }
+  QTextStream ts(&f);
+  const QString header = QStringLiteral("[branch \"") + branch + QChar('"');
+  bool inSection = false;
+  QString remote;
+  QString merge;
+  while(!ts.atEnd()) {
+    const QString line = ts.readLine().trimmed();
+    if(line.startsWith('[')) {
+      inSection = line.startsWith(header);
+      continue;
     }
-
-    auto *p = new QProcess(this);
-    m_inflight.insert(key, p);
-    p->setWorkingDirectory(repoPath);
-    p->setProgram(tool);
-    p->setArguments(args);
-    connect(p, &QProcess::finished, this,
-            [this, p, key, repoPath, branch, emitOneShot]
-            (int code, QProcess::ExitStatus) {
-        m_inflight.remove(key);
-        PrInfo info;
-        info.fetchedAt = QDateTime::currentDateTime();
-        if (code == 0) {
-            const QByteArray raw = p->readAllStandardOutput();
-            QJsonParseError err{};
-            const auto doc = QJsonDocument::fromJson(raw, &err);
-            if (err.error == QJsonParseError::NoError && doc.isObject()) {
-                const auto o = doc.object();
-                info.state  = o.value(QStringLiteral("state")).toString()
-                                .toLower();
-                info.number = o.value(QStringLiteral("number")).toInt();
-                info.url    = o.value(QStringLiteral("url")).toString();
-                info.title  = o.value(QStringLiteral("title")).toString();
-            }
-        }
-        CacheEntry &ce = m_prCache[cacheKey(repoPath, branch)];
-        ce.info = info;
-        ce.age.start();
-
-        const auto sit = m_state.find(repoPath);
-        if (sit != m_state.end() && sit->branch == branch) {
-            sit->pr = info;
-            emit repoStateUpdated(repoPath, sit->toVariant());
-        }
-        if (emitOneShot)
-            emit prInfoUpdated(repoPath, branch, info.toVariant());
-        p->deleteLater();
-    });
-    p->start();
-}
-
-void GitWatcher::requestPrFetch(const QString &repoPath, const QString &branch) {
-    if (repoPath.isEmpty() || branch.isEmpty()) return;
-    const QString key = cacheKey(repoPath, branch);
-    auto it = m_prCache.constFind(key);
-    if (it != m_prCache.constEnd() && it->age.isValid()
-        && it->age.elapsed() < kPrTtlMs) {
-        emit prInfoUpdated(repoPath, branch, it->info.toVariant());
-        return;
+    if(!inSection) {
+      continue;
     }
-    if (m_ghPath.isEmpty() && m_glabPath.isEmpty()) return;
-    fetchPrAsync(repoPath, branch, /*emitOneShot=*/true);
+    if(line.startsWith(QStringLiteral("remote"))) {
+      const int eq = line.indexOf('=');
+      if(eq > 0) {
+        remote = line.mid(eq + 1).trimmed();
+      }
+    } else if(line.startsWith(QStringLiteral("merge"))) {
+      const int eq = line.indexOf('=');
+      if(eq > 0) {
+        merge = line.mid(eq + 1).trimmed();
+      }
+    }
+  }
+  if(remote.isEmpty() || merge.isEmpty()) {
+    return QString();
+  }
+  QString mergeBranch = merge;
+  const QString p = QStringLiteral("refs/heads/");
+  if(mergeBranch.startsWith(p)) {
+    mergeBranch = mergeBranch.mid(p.size());
+  }
+  return remote + QChar('/') + mergeBranch;
 }
 
-} // namespace heap::git
+void GitWatcher::recomputeForRepo(const QString& path) {
+  auto cit = m_configs.constFind(path);
+  if(cit == m_configs.constEnd()) {
+    return;
+  }
+  const RepoConfig& cfg = *cit;
+
+  const QString headText = readHeadText(cfg.resolvedGitDir);
+  const QString branch = BranchTaskMatcher::branchFromHeadText(headText);
+  const QString sha = readShaForBranch(cfg.resolvedGitDir, branch);
+
+  RepoState& st = m_state[path];
+  const QString oldBranch = st.branch;
+  const QString oldSha = st.headSha;
+  if(oldBranch == branch && oldSha == sha) {
+    return;
+  }
+
+  st.branch = branch;
+  st.headSha = sha;
+  st.upstream = upstreamForBranch(cfg.resolvedGitDir, branch);
+
+  const bool branchActuallyChanged = (oldBranch != branch);
+  if(branchActuallyChanged) {
+    // Reset ahead/behind until rev-list returns.
+    st.ahead = 0;
+    st.behind = 0;
+
+    const auto mr = m_matcher.extract(branch);
+    const QString taskId = mr.matched ? mr.taskId : QString();
+    m_lastRepo = path;
+    m_lastBranch = branch;
+    m_lastTaskId = taskId;
+    emit branchChanged(path, branch, taskId);
+  }
+
+  emit repoStateUpdated(path, st.toVariant());
+
+  if(branchActuallyChanged) {
+    if(!m_gitPath.isEmpty()) {
+      fetchAheadBehindAsync(path, branch);
+    }
+    if(m_prEnabled && (!m_ghPath.isEmpty() || !m_glabPath.isEmpty())) {
+      fetchPrAsync(path, branch, /*emitOneShot=*/false);
+    }
+  }
+  // HEAD moved (branch and/or SHA) → recent commit↔task links may have
+  // changed. Refresh them regardless of whether the branch name changed.
+  if(!m_gitPath.isEmpty()) {
+    fetchCommitsAsync(path);
+  }
+}
+
+void GitWatcher::fetchCommitsAsync(const QString& repoPath) {
+  if(m_gitPath.isEmpty()) {
+    return;
+  }
+  const QString key = QStringLiteral("log:") + repoPath;
+  if(m_inflight.contains(key) && m_inflight.value(key)) {
+    return;
+  }
+
+  auto* p = new QProcess(this);
+  m_inflight.insert(key, p);
+  p->setWorkingDirectory(repoPath);
+  p->setProgram(m_gitPath);
+  p->setArguments({QStringLiteral("log"),
+                   QStringLiteral("--all"),
+                   QStringLiteral("--no-color"),
+                   QStringLiteral("--max-count=200"),
+                   QStringLiteral("--pretty=format:%H%x1f%s")});
+  connect(p, &QProcess::finished, this, [this, p, key, repoPath](int code, QProcess::ExitStatus) {
+    m_inflight.remove(key);
+    if(code == 0) {
+      const QVariantMap byTask = m_matcher.groupCommitsByTask(p->readAllStandardOutput());
+      emit commitsUpdated(repoPath, byTask);
+    }
+    p->deleteLater();
+  });
+  p->start();
+}
+
+bool GitWatcher::createBranch(const QString& repoPath, const QString& branchName, QString* errorOut) {
+  const auto fail = [errorOut](const QString& e) {
+    if(errorOut) {
+      *errorOut = e;
+    }
+    return false;
+  };
+  if(m_gitPath.isEmpty()) {
+    return fail(QStringLiteral("git not found on PATH"));
+  }
+  if(repoPath.isEmpty()) {
+    return fail(QStringLiteral("no repository selected"));
+  }
+  if(branchName.isEmpty()) {
+    return fail(QStringLiteral("empty branch name"));
+  }
+
+  QProcess p;
+  p.setWorkingDirectory(repoPath);
+  p.setProgram(m_gitPath);
+  p.setArguments({QStringLiteral("checkout"), QStringLiteral("-b"), branchName});
+  p.start();
+  if(!p.waitForStarted(5000)) {
+    return fail(QStringLiteral("failed to start git"));
+  }
+  if(!p.waitForFinished(15000)) {
+    p.kill();
+    return fail(QStringLiteral("git checkout timed out"));
+  }
+  if(p.exitStatus() != QProcess::NormalExit || p.exitCode() != 0) {
+    QString err = QString::fromUtf8(p.readAllStandardError()).trimmed();
+    if(err.isEmpty()) {
+      err = QStringLiteral("git checkout -b failed");
+    }
+    return fail(err);
+  }
+  // Reflect the new checkout immediately (the FS watcher would catch up too,
+  // but an explicit recompute makes the banner/card update deterministic).
+  const QString abs = QDir(repoPath).absolutePath();
+  if(m_configs.contains(abs)) {
+    rewatchFiles(m_configs.value(abs));
+    recomputeForRepo(abs);
+  }
+  return true;
+}
+
+void GitWatcher::fetchAheadBehindAsync(const QString& repoPath, const QString& branch) {
+  if(branch.isEmpty() || branch == QStringLiteral("(detached HEAD)")) {
+    return;
+  }
+  const RepoState& st = m_state.value(repoPath);
+  if(st.upstream.isEmpty()) {
+    return;
+  }
+
+  const QString key = QStringLiteral("ab:") + cacheKey(repoPath, branch);
+  if(m_inflight.contains(key) && m_inflight.value(key)) {
+    return;
+  }
+
+  auto* p = new QProcess(this);
+  m_inflight.insert(key, p);
+  p->setWorkingDirectory(repoPath);
+  p->setProgram(m_gitPath);
+  p->setArguments({QStringLiteral("rev-list"),
+                   QStringLiteral("--left-right"),
+                   QStringLiteral("--count"),
+                   branch + QStringLiteral("...") + st.upstream});
+  connect(p, &QProcess::finished, this, [this, p, key, repoPath, branch](int code, QProcess::ExitStatus) {
+    m_inflight.remove(key);
+    const auto sit = m_state.find(repoPath);
+    if(sit == m_state.end() || sit->branch != branch) {
+      p->deleteLater();
+      return;
+    }
+    if(code == 0) {
+      const QString out = QString::fromUtf8(p->readAllStandardOutput()).trimmed();
+      const QStringList parts = out.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+      if(parts.size() == 2) {
+        sit->ahead = parts[0].toInt();
+        sit->behind = parts[1].toInt();
+      }
+    }
+    emit repoStateUpdated(repoPath, sit->toVariant());
+    p->deleteLater();
+  });
+  p->start();
+}
+
+void GitWatcher::fetchPrAsync(const QString& repoPath, const QString& branch, bool emitOneShot) {
+  if(branch.isEmpty() || branch == QStringLiteral("(detached HEAD)")) {
+    return;
+  }
+
+  const QString key = QStringLiteral("pr:") + cacheKey(repoPath, branch);
+  if(m_inflight.contains(key) && m_inflight.value(key)) {
+    return;
+  }
+
+  QString tool = m_ghPath;
+  QStringList args;
+  if(!tool.isEmpty()) {
+    args = {QStringLiteral("pr"),
+            QStringLiteral("view"),
+            QStringLiteral("--json"),
+            QStringLiteral("state,number,url,title,isDraft,statusCheckRollup"),
+            branch};
+  } else if(!m_glabPath.isEmpty()) {
+    tool = m_glabPath;
+    args = {QStringLiteral("mr"), QStringLiteral("view"), QStringLiteral("--output"), QStringLiteral("json"), branch};
+  } else {
+    return;
+  }
+
+  auto* p = new QProcess(this);
+  m_inflight.insert(key, p);
+  p->setWorkingDirectory(repoPath);
+  p->setProgram(tool);
+  p->setArguments(args);
+  connect(p, &QProcess::finished, this, [this, p, key, repoPath, branch, emitOneShot](int code, QProcess::ExitStatus) {
+    m_inflight.remove(key);
+    PrInfo info;
+    info.fetchedAt = QDateTime::currentDateTime();
+    if(code == 0) {
+      const QByteArray raw = p->readAllStandardOutput();
+      QJsonParseError err{};
+      const auto doc = QJsonDocument::fromJson(raw, &err);
+      if(err.error == QJsonParseError::NoError && doc.isObject()) {
+        const auto o = doc.object();
+        info.state = o.value(QStringLiteral("state")).toString().toLower();
+        info.number = o.value(QStringLiteral("number")).toInt();
+        info.url = o.value(QStringLiteral("url")).toString();
+        info.title = o.value(QStringLiteral("title")).toString();
+        info.draft = o.value(QStringLiteral("isDraft")).toBool();
+        info.checks = rollupChecks(o.value(QStringLiteral("statusCheckRollup")).toArray());
+      }
+    }
+    CacheEntry& ce = m_prCache[cacheKey(repoPath, branch)];
+    ce.info = info;
+    ce.age.start();
+
+    const auto sit = m_state.find(repoPath);
+    if(sit != m_state.end() && sit->branch == branch) {
+      sit->pr = info;
+      emit repoStateUpdated(repoPath, sit->toVariant());
+    }
+    if(emitOneShot) {
+      emit prInfoUpdated(repoPath, branch, info.toVariant());
+    }
+    p->deleteLater();
+  });
+  p->start();
+}
+
+void GitWatcher::requestPrFetch(const QString& repoPath, const QString& branch) {
+  if(repoPath.isEmpty() || branch.isEmpty()) {
+    return;
+  }
+  const QString key = cacheKey(repoPath, branch);
+  auto it = m_prCache.constFind(key);
+  if(it != m_prCache.constEnd() && it->age.isValid() && it->age.elapsed() < kPrTtlMs) {
+    emit prInfoUpdated(repoPath, branch, it->info.toVariant());
+    return;
+  }
+  if(m_ghPath.isEmpty() && m_glabPath.isEmpty()) {
+    return;
+  }
+  fetchPrAsync(repoPath, branch, /*emitOneShot=*/true);
+}
+
+}  // namespace heap::git

--- a/src/git/GitWatcher.h
+++ b/src/git/GitWatcher.h
@@ -18,74 +18,87 @@
 namespace heap::git {
 
 class GitWatcher : public QObject {
-    Q_OBJECT
-public:
-    explicit GitWatcher(QObject *parent = nullptr);
-    ~GitWatcher() override;
+  Q_OBJECT
+ public:
+  explicit GitWatcher(QObject* parent = nullptr);
+  ~GitWatcher() override;
 
-    void setWatchedRepos(const QStringList &paths);
-    void setPrefixes(const QStringList &prefixes);
-    void setPrFetchEnabled(bool on);
+  void setWatchedRepos(const QStringList& paths);
+  void setPrefixes(const QStringList& prefixes);
+  void setPrFetchEnabled(bool on);
 
-    QStringList watchedRepos() const;
-    QVariantMap snapshot() const;
+  QStringList watchedRepos() const;
+  QVariantMap snapshot() const;
 
-    QString lastTaskId() const { return m_lastTaskId; }
-    QString lastBranch() const { return m_lastBranch; }
-    QString lastRepo()   const { return m_lastRepo;   }
+  QString lastTaskId() const {
+    return m_lastTaskId;
+  }
 
-    void requestPrFetch(const QString &repoPath, const QString &branch);
+  QString lastBranch() const {
+    return m_lastBranch;
+  }
 
-signals:
-    void branchChanged(const QString &repoPath,
-                       const QString &branch,
-                       const QString &taskId);
-    void repoStateUpdated(const QString &repoPath, const QVariantMap &state);
-    void prInfoUpdated(const QString &repoPath,
-                       const QString &branch,
-                       const QVariantMap &pr);
+  QString lastRepo() const {
+    return m_lastRepo;
+  }
 
-private slots:
-    void onFsPathChanged(const QString &path);
-    void onDebounceFired();
+  void requestPrFetch(const QString& repoPath, const QString& branch);
 
-private:
-    QFileSystemWatcher *m_fsw{};
-    QTimer             *m_debounce{};
-    QSet<QString>       m_pendingRepos;
+  // Create and switch to a new branch (`git checkout -b`). Synchronous —
+  // the caller drives it from a one-click UI action. Returns false and sets
+  // *errorOut (if non-null) on failure (git missing, dirty tree, name clash).
+  bool createBranch(const QString& repoPath, const QString& branchName, QString* errorOut);
 
-    QHash<QString, RepoConfig> m_configs;        // repoPath → config
-    QHash<QString, RepoState>  m_state;          // repoPath → state
-    QHash<QString, QString>    m_watchedFileOwner; // file path → repoPath
+ signals:
+  void branchChanged(const QString& repoPath, const QString& branch, const QString& taskId);
+  void repoStateUpdated(const QString& repoPath, const QVariantMap& state);
+  void prInfoUpdated(const QString& repoPath, const QString& branch, const QVariantMap& pr);
+  // Recent commits mentioning a task id, grouped by task:
+  // { taskId → [ {sha, subject}, … ] }. Refreshed whenever HEAD moves.
+  void commitsUpdated(const QString& repoPath, const QVariantMap& commitsByTask);
 
-    QString m_lastRepo, m_lastBranch, m_lastTaskId;
+ private slots:
+  void onFsPathChanged(const QString& path);
+  void onDebounceFired();
 
-    struct CacheEntry { PrInfo info; QElapsedTimer age; };
-    QHash<QString, CacheEntry> m_prCache;        // key = repo + '\n' + branch
-    static constexpr qint64 kPrTtlMs = 60'000;
+ private:
+  QFileSystemWatcher* m_fsw{};
+  QTimer* m_debounce{};
+  QSet<QString> m_pendingRepos;
 
-    QHash<QString, QPointer<QProcess>> m_inflight; // dedup spawns by key
+  QHash<QString, RepoConfig> m_configs;        // repoPath → config
+  QHash<QString, RepoState> m_state;           // repoPath → state
+  QHash<QString, QString> m_watchedFileOwner;  // file path → repoPath
 
-    QString m_ghPath, m_glabPath, m_gitPath;
-    bool    m_prEnabled = true;
+  QString m_lastRepo, m_lastBranch, m_lastTaskId;
 
-    BranchTaskMatcher m_matcher;
+  struct CacheEntry {
+    PrInfo info;
+    QElapsedTimer age;
+  };
 
-    void addRepo(const QString &path);
-    void removeRepo(const QString &path);
-    void rewatchFiles(const RepoConfig &cfg);
-    void recomputeForRepo(const QString &path);
-    void fetchAheadBehindAsync(const QString &repoPath, const QString &branch);
-    void fetchPrAsync(const QString &repoPath,
-                      const QString &branch,
-                      bool emitOneShot);
+  QHash<QString, CacheEntry> m_prCache;  // key = repo + '\n' + branch
+  static constexpr qint64 kPrTtlMs = 60'000;
 
-    static QString cacheKey(const QString &repo, const QString &branch);
-    static QString upstreamForBranch(const QString &gitDir,
-                                     const QString &branch);
-    static QString readHeadText(const QString &gitDir);
-    static QString readShaForBranch(const QString &gitDir,
-                                    const QString &branch);
+  QHash<QString, QPointer<QProcess>> m_inflight;  // dedup spawns by key
+
+  QString m_ghPath, m_glabPath, m_gitPath;
+  bool m_prEnabled = true;
+
+  BranchTaskMatcher m_matcher;
+
+  void addRepo(const QString& path);
+  void removeRepo(const QString& path);
+  void rewatchFiles(const RepoConfig& cfg);
+  void recomputeForRepo(const QString& path);
+  void fetchAheadBehindAsync(const QString& repoPath, const QString& branch);
+  void fetchCommitsAsync(const QString& repoPath);
+  void fetchPrAsync(const QString& repoPath, const QString& branch, bool emitOneShot);
+
+  static QString cacheKey(const QString& repo, const QString& branch);
+  static QString upstreamForBranch(const QString& gitDir, const QString& branch);
+  static QString readHeadText(const QString& gitDir);
+  static QString readShaForBranch(const QString& gitDir, const QString& branch);
 };
 
-} // namespace heap::git
+}  // namespace heap::git

--- a/tests/test_git_watcher_parse.cpp
+++ b/tests/test_git_watcher_parse.cpp
@@ -1,5 +1,3 @@
-#include <gtest/gtest.h>
-
 #include "git/BranchTaskMatcher.h"
 
 #include <QDir>
@@ -7,63 +5,126 @@
 #include <QFileInfo>
 #include <QTemporaryDir>
 
+#include <gtest/gtest.h>
+
 using heap::git::BranchTaskMatcher;
 
 TEST(Parse, BranchFromRefHeadText) {
-    auto b = BranchTaskMatcher::branchFromHeadText(
-        QStringLiteral("ref: refs/heads/feature/x\n"));
-    EXPECT_EQ(b, QString("feature/x"));
+  auto b = BranchTaskMatcher::branchFromHeadText(QStringLiteral("ref: refs/heads/feature/x\n"));
+  EXPECT_EQ(b, QString("feature/x"));
 }
 
 TEST(Parse, BranchFromDetachedSha) {
-    auto b = BranchTaskMatcher::branchFromHeadText(
-        QStringLiteral("a3f9b1c8d2e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8\n"));
-    EXPECT_EQ(b, QString("(detached HEAD)"));
+  auto b = BranchTaskMatcher::branchFromHeadText(QStringLiteral("a3f9b1c8d2e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8\n"));
+  EXPECT_EQ(b, QString("(detached HEAD)"));
 }
 
 TEST(Parse, BranchFromGarbageEmpty) {
-    EXPECT_TRUE(BranchTaskMatcher::branchFromHeadText(
-        QStringLiteral("garbage")).isEmpty());
+  EXPECT_TRUE(BranchTaskMatcher::branchFromHeadText(QStringLiteral("garbage")).isEmpty());
 }
 
 TEST(Parse, ResolveGitDirNormal) {
-    QTemporaryDir td;
-    ASSERT_TRUE(td.isValid());
-    ASSERT_TRUE(QDir(td.path()).mkdir(".git"));
-    const QString gd = BranchTaskMatcher::resolveGitDir(td.path());
-    EXPECT_TRUE(gd.endsWith("/.git"));
-    EXPECT_TRUE(QFileInfo(gd).isDir());
+  const QTemporaryDir td;
+  ASSERT_TRUE(td.isValid());
+  ASSERT_TRUE(QDir(td.path()).mkdir(".git"));
+  const QString gd = BranchTaskMatcher::resolveGitDir(td.path());
+  EXPECT_TRUE(gd.endsWith("/.git"));
+  EXPECT_TRUE(QFileInfo(gd).isDir());
 }
 
 TEST(Parse, ResolveGitDirWorktreeFile) {
-    QTemporaryDir td;
-    ASSERT_TRUE(td.isValid());
-    const QString realGit = td.path() + "/realgit";
-    ASSERT_TRUE(QDir().mkpath(realGit));
-    QFile f(td.path() + "/.git");
-    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
-    f.write(("gitdir: " + realGit + "\n").toUtf8());
-    f.close();
-    const QString gd = BranchTaskMatcher::resolveGitDir(td.path());
-    EXPECT_EQ(QDir::cleanPath(gd), QDir::cleanPath(realGit));
+  const QTemporaryDir td;
+  ASSERT_TRUE(td.isValid());
+  const QString realGit = td.path() + "/realgit";
+  ASSERT_TRUE(QDir().mkpath(realGit));
+  QFile f(td.path() + "/.git");
+  ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+  f.write(("gitdir: " + realGit + "\n").toUtf8());
+  f.close();
+  const QString gd = BranchTaskMatcher::resolveGitDir(td.path());
+  EXPECT_EQ(QDir::cleanPath(gd), QDir::cleanPath(realGit));
 }
 
 TEST(Parse, ResolveGitDirWorktreeFileRelative) {
-    QTemporaryDir td;
-    ASSERT_TRUE(td.isValid());
-    const QString rel = "subdir/realgit";
-    ASSERT_TRUE(QDir(td.path()).mkpath(rel));
-    QFile f(td.path() + "/.git");
-    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
-    f.write(("gitdir: " + rel + "\n").toUtf8());
-    f.close();
-    const QString gd = BranchTaskMatcher::resolveGitDir(td.path());
-    EXPECT_EQ(QDir::cleanPath(gd),
-              QDir::cleanPath(td.path() + "/" + rel));
+  const QTemporaryDir td;
+  ASSERT_TRUE(td.isValid());
+  const QString rel = "subdir/realgit";
+  ASSERT_TRUE(QDir(td.path()).mkpath(rel));
+  QFile f(td.path() + "/.git");
+  ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+  f.write(("gitdir: " + rel + "\n").toUtf8());
+  f.close();
+  const QString gd = BranchTaskMatcher::resolveGitDir(td.path());
+  EXPECT_EQ(QDir::cleanPath(gd), QDir::cleanPath(td.path() + "/" + rel));
 }
 
 TEST(Parse, ResolveGitDirMissing) {
-    QTemporaryDir td;
-    ASSERT_TRUE(td.isValid());
-    EXPECT_TRUE(BranchTaskMatcher::resolveGitDir(td.path()).isEmpty());
+  const QTemporaryDir td;
+  ASSERT_TRUE(td.isValid());
+  EXPECT_TRUE(BranchTaskMatcher::resolveGitDir(td.path()).isEmpty());
+}
+
+// ── HEAP-76: branch-name derivation ──
+
+TEST(Slug, LowercasesAndHyphenates) {
+  EXPECT_EQ(BranchTaskMatcher::slugifyTitle("Fix the Login Bug"), QString("fix-the-login-bug"));
+}
+
+TEST(Slug, CollapsesAndTrimsSeparators) {
+  EXPECT_EQ(BranchTaskMatcher::slugifyTitle("  Hello,   World!!  "), QString("hello-world"));
+}
+
+TEST(Slug, EmptyForPunctuationOnly) {
+  EXPECT_EQ(BranchTaskMatcher::slugifyTitle("!!! ??? ..."), QString());
+}
+
+TEST(Slug, CapsLength) {
+  const QString slug = BranchTaskMatcher::slugifyTitle(QString("word ").repeated(30).trimmed());
+  EXPECT_LE(slug.size(), 40);
+  EXPECT_FALSE(slug.endsWith('-'));
+}
+
+TEST(BranchName, DefaultTemplate) {
+  EXPECT_EQ(BranchTaskMatcher::branchNameForTask("HEAP-76", "Git write actions", QString()), QString("feature/heap-76-git-write-actions"));
+}
+
+TEST(BranchName, CustomTemplatePlaceholders) {
+  EXPECT_EQ(BranchTaskMatcher::branchNameForTask("HEAP-76", "Do Thing", "{type}/{id}/{slug}"), QString("feature/heap-76/do-thing"));
+}
+
+TEST(BranchName, EmptyTitleDropsDanglingSeparator) {
+  EXPECT_EQ(BranchTaskMatcher::branchNameForTask("HEAP-76", "  ", QString()), QString("feature/heap-76"));
+}
+
+// ── HEAP-76: commit ↔ task grouping ──
+
+TEST(Commits, GroupsBySubjectTaskId) {
+  BranchTaskMatcher m({"HEAP"});
+  QByteArray log;
+  log +=
+      "aaaaaaa1111111111111111111111111111bbbb\x1f"
+      "HEAP-76 add branch action\n";
+  log +=
+      "bbbbbbb2222222222222222222222222222cccc\x1f"
+      "HEAP-76: linking commits\n";
+  log +=
+      "ccccccc3333333333333333333333333333dddd\x1f"
+      "HEAP-40 unrelated older work\n";
+  log +=
+      "ddddddd4444444444444444444444444444eeee\x1f"
+      "chore: no task id here\n";
+  const QVariantMap byTask = m.groupCommitsByTask(log);
+  ASSERT_TRUE(byTask.contains("HEAP-76"));
+  ASSERT_TRUE(byTask.contains("HEAP-40"));
+  EXPECT_FALSE(byTask.contains(""));  // subjects without an id are dropped
+  const QVariantList h76 = byTask.value("HEAP-76").toList();
+  EXPECT_EQ(h76.size(), 2);
+  // sha is abbreviated to 7 chars; subject preserved verbatim.
+  EXPECT_EQ(h76.first().toMap().value("sha").toString(), QString("aaaaaaa"));
+  EXPECT_EQ(h76.first().toMap().value("subject").toString(), QString("HEAP-76 add branch action"));
+}
+
+TEST(Commits, EmptyLogYieldsEmptyMap) {
+  BranchTaskMatcher m({"HEAP"});
+  EXPECT_TRUE(m.groupCommitsByTask(QByteArray()).isEmpty());
 }


### PR DESCRIPTION
Makes the git-aware board **git-active** — the developer's git chores are driven from the task card.

### (a) Create branch from task
- Pure `BranchTaskMatcher::slugifyTitle()` + `branchNameForTask()` (placeholders `{type}`/`{id}`/`{slug}`, default `feature/{id}-{slug}`, honors `integrations.github.branchTemplate`).
- `GitWatcher::createBranch()` → `git checkout -b` (synchronous), then refreshes repo state.
- `AppController::createBranchForTask()` invokable + **Create branch** item on the card context menu; records the branch on the task.

### (b) Commit ↔ task linking
- `git log --all --pretty=%H%x1f%s` on every HEAD move → `groupCommitsByTask()` (free-text word-boundary matcher, so `fix HEAP-76: …` is caught).
- New `TaskModel::RecentCommitsRole`; a `◇ N` card chip (tooltip = latest subject), threaded through KanbanBoard + ArchiveView.

### (c) Inline PR + CI
- `PrInfo` gains `draft` + `checks`; `gh` query extends to `isDraft,statusCheckRollup`; `rollupChecks()` collapses to passing/failing/pending.
- Focus banner shows a PR `#N state (· draft)` badge (click → open) + colored CI chip.

### Notes
- Also normalizes `src/git` to the repo clang-format/clang-tidy (the subdir predates the format bots and had never been re-touched).

### Tests
- Added slugify / branch-name / commit-grouping cases to `test_git_watcher_parse`.
- Full suite green locally (23/23).

Closes HEAP-76.