### PR TITLE
feat: Jira + GitLab tracker-sync providers (HEAP-75)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,8 @@ qt_add_library(heap_core STATIC
     src/platform/GlobalHotkey.cpp
     src/integrations/StatusMap.cpp
     src/integrations/GithubProvider.cpp
+    src/integrations/JiraProvider.cpp
+    src/integrations/GitlabProvider.cpp
     src/sync/SyncSerializer.cpp
     src/sync/JsonMerger.cpp
     src/update/Updater.cpp
@@ -150,6 +152,8 @@ qt_add_qml_module(heap_core
         src/integrations/IntegrationTypes.h
         src/integrations/StatusMap.h
         src/integrations/GithubProvider.h
+        src/integrations/JiraProvider.h
+        src/integrations/GitlabProvider.h
         src/integrations/IntegrationProvider.h
         src/sync/SyncSerializer.h
         src/sync/JsonMerger.h

--- a/qml/I18n.qml
+++ b/qml/I18n.qml
@@ -477,6 +477,7 @@ QtObject {
             // Integrations section
             "settings.int.jira.desc": "Sync tasks, ID prefix, statuses",
             "settings.int.github.desc": "PR status, branch template, code-review pings",
+            "settings.int.gitlab.desc": "Sync issues, statuses, close on Done",
             "settings.int.mattermost.desc": "Notification routing, follow-ups",
             "settings.int.pagerduty.desc": "On-call schedule, incident escalation",
             "settings.int.confluence.desc": "Wiki + runbooks, link previews",
@@ -979,6 +980,7 @@ QtObject {
 
             "settings.int.jira.desc": "Sync задач, ID prefix, статусов",
             "settings.int.github.desc": "PR статус, branch template, code-review pings",
+            "settings.int.gitlab.desc": "Sync issues, статусов, close on Done",
             "settings.int.mattermost.desc": "Notification routing, follow-ups",
             "settings.int.pagerduty.desc": "On-call schedule, incident escalation",
             "settings.int.confluence.desc": "Wiki + runbooks, link previews",

--- a/qml/SettingsView.qml
+++ b/qml/SettingsView.qml
@@ -168,8 +168,9 @@ Item {
             showAsmInline: false
         },
         integrations: {
-            jira:       ({ connected: false, url: "", project: "" }),
-            github:     ({ connected: false, org: "", branchTemplate: "{type}/{id}-{slug}" }),
+            jira:       ({ connected: false, baseUrl: "", email: "", token: "", jql: "" }),
+            github:     ({ connected: false, repo: "", token: "", branchTemplate: "{type}/{id}-{slug}" }),
+            gitlab:     ({ connected: false, host: "", projectId: "", token: "" }),
             mattermost: ({ connected: false, workspace: "", channel: "" }),
             pagerduty:  ({ connected: false, schedule: "" }),
             confluence: ({ connected: false, space: "" })
@@ -1467,6 +1468,13 @@ Item {
                         desc: I18n.t("settings.int.github.desc")
                     },
                     {
+                        key: "gitlab",
+                        name: "GitLab",
+                        icon: "▲",
+                        color: "#e2683c",
+                        desc: I18n.t("settings.int.gitlab.desc")
+                    },
+                    {
                         key: "mattermost",
                         name: "Mattermost",
                         icon: "#",
@@ -1498,14 +1506,20 @@ Item {
                         readonly property var conf: (root.settings.integrations && root.settings.integrations[intKey]) || ({})
                         readonly property var fieldsByKey: ({
                             "jira": [
-                                { key: "baseUrl",      label: "Base URL",        placeholder: "https://jira.company.com" },
-                                { key: "projectKey",   label: "Project key",     placeholder: "LTE",                        mono: true },
-                                { key: "token",        label: "API token",       placeholder: "***",                        mono: true }
+                                { key: "baseUrl",      label: "Base URL",        placeholder: "https://acme.atlassian.net" },
+                                { key: "email",        label: "Email",           placeholder: "you@company.com" },
+                                { key: "token",        label: "API token",       placeholder: "***",                        mono: true },
+                                { key: "jql",          label: "JQL",             placeholder: "project = LTE ORDER BY updated DESC", mono: true }
                             ],
                             "github": [
                                 { key: "repo",            label: "Repo",            placeholder: "org/name",                mono: true },
                                 { key: "token",           label: "Access token",    placeholder: "***",                     mono: true },
                                 { key: "branchTemplate",  label: "Branch template", placeholder: "feature/{id}-{slug}",     mono: true }
+                            ],
+                            "gitlab": [
+                                { key: "host",       label: "Host",         placeholder: "https://gitlab.com" },
+                                { key: "projectId",  label: "Project",      placeholder: "12345 or group/name",   mono: true },
+                                { key: "token",      label: "Access token", placeholder: "***",                   mono: true }
                             ],
                             "mattermost": [
                                 { key: "serverUrl", label: "Server URL", placeholder: "https://chat.company.com" },
@@ -1584,9 +1598,9 @@ Item {
                                     onCommitted: (txt) => root.setNested("integrations", intCard.intKey, modelData.key, txt)
                                 }
                             }
-                            // GitHub 2-way sync (HEAP-74): pull issues as tasks.
+                            // 2-way tracker sync (HEAP-74 GitHub, HEAP-75 Jira/GitLab): pull issues as tasks.
                             Rectangle {
-                                visible: intCard.intKey === "github"
+                                visible: ["github", "jira", "gitlab"].indexOf(intCard.intKey) >= 0
                                 Layout.topMargin: 4
                                 radius: 6
                                 color: syncMA.containsMouse ? Theme.panel3 : Theme.panel2

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -6,6 +6,8 @@
 #include "git/BranchTaskMatcher.h"
 #include "git/GitWatcher.h"
 #include "integrations/GithubProvider.h"
+#include "integrations/GitlabProvider.h"
+#include "integrations/JiraProvider.h"
 #include "integrations/StatusMap.h"
 #include "notify/NotificationCenter.h"
 #include "platform/GlobalHotkey.h"
@@ -642,9 +644,15 @@ void AppController::moveTask(const QString& id, const QString& newStatus) {
   m_tasks.setStatus(id, newStatus);
 
   // Mirror the change back to the linked tracker issue (e.g. moving to Done
-  // closes the GitHub issue). No-op for locally-created, unlinked tasks.
-  if(m_syncProvider && !t.externalId.isEmpty() && t.externalProvider == QStringLiteral("github")) {
-    m_syncProvider->pushStatusChange(t.externalId, newStatus);
+  // closes the GitHub issue / transitions the Jira issue). Routed to whichever
+  // provider owns the task. No-op for locally-created, unlinked tasks.
+  if(!t.externalId.isEmpty() && !t.externalProvider.isEmpty()) {
+    for(const auto& provider : m_syncProviders) {
+      if(provider->id() == t.externalProvider) {
+        provider->pushStatusChange(t.externalId, newStatus);
+        break;
+      }
+    }
   }
 
   // Arm undo so a mis-drag to the wrong column is reversible (previously
@@ -1698,83 +1706,123 @@ void AppController::openLatestRelease() const {
 }
 
 void AppController::syncNow() {
-  if(!m_syncProvider) {
-    emit toast(tr("Connect a GitHub repo in Settings → Integrations first"));
+  if(m_syncProviders.empty()) {
+    emit toast(tr("Connect a tracker in Settings → Integrations first"));
     return;
   }
-  emit toast(tr("Syncing with GitHub…"));
-  m_syncProvider->pullTasks();
+  emit toast(tr("Syncing…"));
+  for(const auto& provider : m_syncProviders) {
+    provider->pullTasks();
+  }
+}
+
+void AppController::mergeExternalTasks(const QString& providerId,
+                                       const QString& idPrefix,
+                                       const QVector<heap::integrations::ExternalTask>& issues) {
+  using heap::integrations::StatusMap;
+  for(const heap::integrations::ExternalTask& ext : issues) {
+    // Match an existing task by its stored external id; else create one.
+    QString existingId;
+    for(const Task& cur : m_tasks.items()) {
+      if(cur.externalProvider == providerId && cur.externalId == ext.externalId) {
+        existingId = cur.id;
+        break;
+      }
+    }
+    const int row = existingId.isEmpty() ? -1 : m_tasks.indexOfId(existingId);
+    Task t;
+    if(row >= 0) {
+      t = m_tasks.items().at(row);
+    } else {
+      t.id = idPrefix + ext.externalId;
+      t.statusChangedAt = QDateTime::currentDateTime();
+    }
+    t.title = ext.title;
+    t.desc = ext.body;
+    t.status = StatusMap::column(ext.status, {}, QStringLiteral("todo"));
+    if(!ext.priority.isEmpty()) {
+      t.priority = StatusMap::priority(ext.priority);
+    } else if(t.priority.isEmpty()) {
+      t.priority = QStringLiteral("P2");
+    }
+    t.externalId = ext.externalId;
+    t.externalUrl = ext.url;
+    t.externalProvider = providerId;
+    m_tasks.upsert(t);
+  }
+  if(!issues.isEmpty()) {
+    scheduleSave();
+  }
 }
 
 void AppController::applyIntegrationSettings() {
-  const QVariantMap gh = settingsMap().value("integrations").toMap().value("github").toMap();
-  const bool connected = gh.value("connected", false).toBool();
-  const QString repo = gh.value("repo").toString().trimmed();
-  const QString token = gh.value("token").toString().trimmed();
+  m_syncProviders.clear();
+  const QVariantMap integrations = settingsMap().value("integrations").toMap();
 
-  if(!connected || repo.isEmpty() || token.isEmpty()) {
-    m_syncProvider.reset();
-    return;
+  // Wire one provider's signals into the shared merge/push/toast handlers.
+  const auto wire = [this](heap::integrations::IntegrationProvider* provider, const QString& idPrefix, const QString& label) {
+    const QString providerId = provider->id();
+    connect(provider,
+            &heap::integrations::IntegrationProvider::tasksFetched,
+            this,
+            [this, providerId, idPrefix, label](const QVector<heap::integrations::ExternalTask>& issues) {
+              mergeExternalTasks(providerId, idPrefix, issues);
+              emit toast(tr("Synced %1 issue(s) from %2").arg(issues.size()).arg(label));
+            });
+    connect(provider,
+            &heap::integrations::IntegrationProvider::taskPushed,
+            this,
+            [providerId](const QString& externalId, bool ok, const QString& error) {
+              if(!ok) {
+                qWarning() << providerId << "push failed for" << externalId << ":" << error;
+              }
+            });
+    connect(provider, &heap::integrations::IntegrationProvider::connectionTested, this, [this, label](bool ok, const QString& error) {
+      emit toast(ok ? tr("%1 connected").arg(label) : tr("%1 connection failed: %2").arg(label, error));
+    });
+  };
+
+  // GitHub (HEAP-74).
+  const QVariantMap gh = integrations.value("github").toMap();
+  if(gh.value("connected", false).toBool()) {
+    const QString repo = gh.value("repo").toString().trimmed();
+    const QString token = gh.value("token").toString().trimmed();
+    if(!repo.isEmpty() && !token.isEmpty()) {
+      auto provider = std::make_unique<heap::integrations::GithubProvider>(this);
+      provider->setConfig(repo, token);
+      wire(provider.get(), QStringLiteral("gh-"), QStringLiteral("GitHub"));
+      m_syncProviders.push_back(std::move(provider));
+    }
   }
 
-  auto provider = std::make_unique<heap::integrations::GithubProvider>(this);
-  provider->setConfig(repo, token);
+  // Jira (HEAP-75).
+  const QVariantMap jira = integrations.value("jira").toMap();
+  if(jira.value("connected", false).toBool()) {
+    const QString baseUrl = jira.value("baseUrl").toString().trimmed();
+    const QString email = jira.value("email").toString().trimmed();
+    const QString token = jira.value("token").toString().trimmed();
+    const QString jql = jira.value("jql").toString().trimmed();
+    if(!baseUrl.isEmpty() && !email.isEmpty() && !token.isEmpty()) {
+      auto provider = std::make_unique<heap::integrations::JiraProvider>(this);
+      provider->setConfig(baseUrl, email, token, jql);
+      wire(provider.get(), QStringLiteral("jira-"), QStringLiteral("Jira"));
+      m_syncProviders.push_back(std::move(provider));
+    }
+  }
 
-  connect(provider.get(),
-          &heap::integrations::IntegrationProvider::tasksFetched,
-          this,
-          [this](const QVector<heap::integrations::ExternalTask>& issues) {
-            using heap::integrations::StatusMap;
-            for(const heap::integrations::ExternalTask& ext : issues) {
-              // Match an existing task by its stored external id; else create one.
-              QString existingId;
-              for(const Task& cur : m_tasks.items()) {
-                if(cur.externalProvider == QStringLiteral("github") && cur.externalId == ext.externalId) {
-                  existingId = cur.id;
-                  break;
-                }
-              }
-              const int row = existingId.isEmpty() ? -1 : m_tasks.indexOfId(existingId);
-              Task t;
-              if(row >= 0) {
-                t = m_tasks.items().at(row);
-              } else {
-                t.id = QStringLiteral("gh-") + ext.externalId;
-                t.statusChangedAt = QDateTime::currentDateTime();
-              }
-              t.title = ext.title;
-              t.desc = ext.body;
-              t.status = StatusMap::column(ext.status, {}, QStringLiteral("todo"));
-              if(!ext.priority.isEmpty()) {
-                t.priority = StatusMap::priority(ext.priority);
-              } else if(t.priority.isEmpty()) {
-                t.priority = QStringLiteral("P2");
-              }
-              t.externalId = ext.externalId;
-              t.externalUrl = ext.url;
-              t.externalProvider = QStringLiteral("github");
-              m_tasks.upsert(t);
-            }
-            if(!issues.isEmpty()) {
-              scheduleSave();
-            }
-            emit toast(tr("Synced %1 issue(s) from GitHub").arg(issues.size()));
-          });
-
-  connect(provider.get(),
-          &heap::integrations::IntegrationProvider::taskPushed,
-          this,
-          [](const QString& externalId, bool ok, const QString& error) {
-            if(!ok) {
-              qWarning() << "github push failed for issue" << externalId << ":" << error;
-            }
-          });
-
-  connect(provider.get(), &heap::integrations::IntegrationProvider::connectionTested, this, [this](bool ok, const QString& error) {
-    emit toast(ok ? tr("GitHub connected") : tr("GitHub connection failed: %1").arg(error));
-  });
-
-  m_syncProvider = std::move(provider);
+  // GitLab (HEAP-75).
+  const QVariantMap gitlab = integrations.value("gitlab").toMap();
+  if(gitlab.value("connected", false).toBool()) {
+    const QString host = gitlab.value("host").toString().trimmed();
+    const QString project = gitlab.value("projectId").toString().trimmed();
+    const QString token = gitlab.value("token").toString().trimmed();
+    if(!host.isEmpty() && !project.isEmpty() && !token.isEmpty()) {
+      auto provider = std::make_unique<heap::integrations::GitlabProvider>(this);
+      provider->setConfig(host, project, token);
+      wire(provider.get(), QStringLiteral("gl-"), QStringLiteral("GitLab"));
+      m_syncProviders.push_back(std::move(provider));
+    }
+  }
 }
 
 void AppController::scheduleSave() {

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -13,6 +13,7 @@
 #include <QVariantMap>
 
 #include <memory>
+#include <vector>
 
 class QJsonObject;
 
@@ -38,7 +39,8 @@ class Updater;
 
 namespace heap::integrations {
 class IntegrationProvider;
-}
+struct ExternalTask;
+}  // namespace heap::integrations
 
 class AppController : public QObject {
   Q_OBJECT
@@ -632,10 +634,15 @@ class AppController : public QObject {
   QString m_updateStatus;
   QString m_latestReleaseUrl;
 
-  // ---- Tracker sync (HEAP-74) ----
-  std::unique_ptr<heap::integrations::IntegrationProvider> m_syncProvider;
-  // Reconcile the GitHub provider with the current integrations settings.
+  // ---- Tracker sync (HEAP-74 GitHub, HEAP-75 Jira + GitLab) ----
+  // Every connected + configured provider runs concurrently; a task's
+  // externalProvider routes status pushes to the matching one.
+  std::vector<std::unique_ptr<heap::integrations::IntegrationProvider>> m_syncProviders;
+  // Reconcile the active providers with the current integrations settings.
   void applyIntegrationSettings();
+  // Fold a batch of pulled external tasks into the model. providerId tags the
+  // task's externalProvider; idPrefix seeds ids for newly-created local tasks.
+  void mergeExternalTasks(const QString& providerId, const QString& idPrefix, const QVector<heap::integrations::ExternalTask>& issues);
   QString m_focusedTaskId, m_focusedBranch, m_focusedRepo;
   QVariantMap m_focusedRepoState;
   QSet<QString> m_dismissedBranches;  // in-memory only; per branch name

--- a/src/integrations/GitlabProvider.cpp
+++ b/src/integrations/GitlabProvider.cpp
@@ -1,0 +1,138 @@
+#include "integrations/GitlabProvider.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrl>
+
+namespace heap::integrations {
+
+QString gitlabStateEventForColumn(const QString& column) {
+  return column == QStringLiteral("done") ? QStringLiteral("close") : QStringLiteral("reopen");
+}
+
+QVector<ExternalTask> parseGitlabIssues(const QByteArray& json) {
+  QVector<ExternalTask> out;
+  const QJsonDocument doc = QJsonDocument::fromJson(json);
+  if(!doc.isArray()) {
+    return out;
+  }
+  const QJsonArray arr = doc.array();
+  out.reserve(arr.size());
+  for(const auto& v : arr) {
+    const QJsonObject o = v.toObject();
+    ExternalTask t;
+    t.providerId = QStringLiteral("gitlab");
+    t.externalId = QString::number(static_cast<qlonglong>(o.value(QStringLiteral("iid")).toDouble()));
+    t.url = o.value(QStringLiteral("web_url")).toString();
+    t.title = o.value(QStringLiteral("title")).toString();
+    t.body = o.value(QStringLiteral("description")).toString();
+    // GitLab state is "opened" | "closed"; StatusMap folds both onto columns.
+    t.status = o.value(QStringLiteral("state")).toString();
+    t.updatedAt = QDateTime::fromString(o.value(QStringLiteral("updated_at")).toString(), Qt::ISODate);
+    // GitLab labels are plain strings. A "priority::high" (scoped) or
+    // "priority: high" label feeds the priority column via StatusMap.
+    for(const auto& lv : o.value(QStringLiteral("labels")).toArray()) {
+      const QString name = lv.toString();
+      if(name.isEmpty()) {
+        continue;
+      }
+      t.labels.append(name);
+      if(name.startsWith(QStringLiteral("priority"), Qt::CaseInsensitive)) {
+        const int sep = name.lastIndexOf(':');
+        if(sep >= 0) {
+          t.priority = name.mid(sep + 1).trimmed();
+        }
+      }
+    }
+    out.append(t);
+  }
+  return out;
+}
+
+GitlabProvider::GitlabProvider(QObject* parent) : IntegrationProvider(parent), m_nam(new QNetworkAccessManager(this)) {
+}
+
+GitlabProvider::~GitlabProvider() = default;
+
+void GitlabProvider::setConfig(const QString& host, const QString& project, const QString& token) {
+  m_host = host.trimmed();
+  while(m_host.endsWith('/')) {
+    m_host.chop(1);
+  }
+  m_project = project.trimmed();
+  m_token = token.trimmed();
+}
+
+bool GitlabProvider::isConfigured() const {
+  return !m_host.isEmpty() && !m_project.isEmpty() && !m_token.isEmpty();
+}
+
+namespace {
+
+// A GitLab project path ("group/name") must be URL-encoded to sit in the path;
+// a numeric id passes through untouched.
+QString encodedProject(const QString& project) {
+  if(!project.contains('/')) {
+    return project;
+  }
+  return QString::fromUtf8(QUrl::toPercentEncoding(project));
+}
+
+// Build an authenticated GitLab API request for `path` under the project.
+QNetworkRequest apiRequest(const QString& host, const QString& project, const QString& token, const QString& path) {
+  QNetworkRequest req{QUrl(host + QStringLiteral("/api/v4/projects/") + encodedProject(project) + path)};
+  req.setRawHeader("Accept", "application/json");
+  req.setRawHeader("User-Agent", "heap-sync");
+  req.setRawHeader("PRIVATE-TOKEN", token.toUtf8());
+  return req;
+}
+
+}  // namespace
+
+void GitlabProvider::testConnection() {
+  if(!isConfigured()) {
+    emit connectionTested(false, QStringLiteral("GitLab host/project/token not configured"));
+    return;
+  }
+  QNetworkReply* reply = m_nam->get(apiRequest(m_host, m_project, m_token, QString()));
+  connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+    reply->deleteLater();
+    emit connectionTested(reply->error() == QNetworkReply::NoError, reply->errorString());
+  });
+}
+
+void GitlabProvider::pullTasks() {
+  if(!isConfigured()) {
+    emit tasksFetched({});
+    return;
+  }
+  QNetworkReply* reply = m_nam->get(apiRequest(m_host, m_project, m_token, QStringLiteral("/issues?per_page=100&scope=all")));
+  connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+    reply->deleteLater();
+    if(reply->error() != QNetworkReply::NoError) {
+      emit tasksFetched({});
+      return;
+    }
+    emit tasksFetched(parseGitlabIssues(reply->readAll()));
+  });
+}
+
+void GitlabProvider::pushStatusChange(const QString& externalId, const QString& newStatus) {
+  if(!isConfigured() || externalId.isEmpty()) {
+    emit taskPushed(externalId, false, QStringLiteral("not configured"));
+    return;
+  }
+  const QString path = QStringLiteral("/issues/") + externalId + QStringLiteral("?state_event=") + gitlabStateEventForColumn(newStatus);
+  const QNetworkRequest req = apiRequest(m_host, m_project, m_token, path);
+  QNetworkReply* reply = m_nam->sendCustomRequest(req, QByteArrayLiteral("PUT"));
+  connect(reply, &QNetworkReply::finished, this, [this, reply, externalId]() {
+    reply->deleteLater();
+    emit taskPushed(externalId, reply->error() == QNetworkReply::NoError, reply->errorString());
+  });
+}
+
+}  // namespace heap::integrations

--- a/src/integrations/GitlabProvider.h
+++ b/src/integrations/GitlabProvider.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "integrations/IntegrationProvider.h"
+#include "integrations/IntegrationTypes.h"
+
+#include <QByteArray>
+#include <QString>
+#include <QVector>
+
+class QNetworkAccessManager;
+
+namespace heap::integrations {
+
+// Parse a GitLab "list project issues" JSON array into ExternalTasks. Pure, no
+// network — unit-tested with canned JSON. externalId is the issue `iid` (the
+// per-project number), which is what the issues/{iid} endpoints expect.
+QVector<ExternalTask> parseGitlabIssues(const QByteArray& json);
+
+// Push-direction map: a heap column → the GitLab `state_event` used to move the
+// issue. "done" closes it; every other column reopens it.
+QString gitlabStateEventForColumn(const QString& column);
+
+// Concrete IntegrationProvider backed by the GitLab REST API v4 (HEAP-75).
+// Auth is a personal-access token sent in the PRIVATE-TOKEN header. Mirrors the
+// QNetworkAccessManager pattern of GithubProvider.
+class GitlabProvider : public IntegrationProvider {
+  Q_OBJECT
+
+ public:
+  explicit GitlabProvider(QObject* parent = nullptr);
+  ~GitlabProvider() override;
+
+  // Configure from the Settings → Integrations GitLab card. `host` is the
+  // instance base (e.g. "https://gitlab.com"); `project` is a numeric id or a
+  // URL-encoded "group/name" path; `token` a PAT. All required.
+  void setConfig(const QString& host, const QString& project, const QString& token);
+  bool isConfigured() const;
+
+  QString id() const override {
+    return QStringLiteral("gitlab");
+  }
+
+  QString displayName() const override {
+    return QStringLiteral("GitLab");
+  }
+
+  void testConnection() override;
+  void pullTasks() override;
+  void pushStatusChange(const QString& externalId, const QString& newStatus) override;
+
+ private:
+  QNetworkAccessManager* m_nam = nullptr;
+  QString m_host;     // "https://gitlab.com" (no trailing slash)
+  QString m_project;  // numeric id or URL-encoded path
+  QString m_token;    // PAT
+};
+
+}  // namespace heap::integrations

--- a/src/integrations/JiraProvider.cpp
+++ b/src/integrations/JiraProvider.cpp
@@ -1,0 +1,218 @@
+#include "integrations/JiraProvider.h"
+#include "integrations/StatusMap.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrl>
+#include <QUrlQuery>
+
+namespace heap::integrations {
+
+namespace {
+
+// Recursively collect every "text" leaf of an ADF node, separating block-level
+// nodes with newlines so paragraphs stay readable.
+void walkAdf(const QJsonValue& node, QString& out) {
+  if(node.isString()) {
+    out += node.toString();
+    return;
+  }
+  if(node.isArray()) {
+    for(const auto& child : node.toArray()) {
+      walkAdf(child, out);
+    }
+    return;
+  }
+  if(!node.isObject()) {
+    return;
+  }
+  const QJsonObject o = node.toObject();
+  const QString type = o.value(QStringLiteral("type")).toString();
+  if(o.contains(QStringLiteral("text"))) {
+    out += o.value(QStringLiteral("text")).toString();
+  }
+  if(o.contains(QStringLiteral("content"))) {
+    walkAdf(o.value(QStringLiteral("content")), out);
+  }
+  // Block separators keep list items / paragraphs on their own lines.
+  if(type == QStringLiteral("paragraph") || type == QStringLiteral("listItem") || type == QStringLiteral("heading")) {
+    out += QChar('\n');
+  }
+}
+
+QString adfValueToText(const QJsonValue& description) {
+  if(description.isString()) {
+    return description.toString();
+  }
+  QString out;
+  walkAdf(description, out);
+  return out.trimmed();
+}
+
+}  // namespace
+
+QString jiraAdfToPlainText(const QByteArray& adfJson) {
+  const QJsonDocument doc = QJsonDocument::fromJson(adfJson);
+  if(doc.isObject()) {
+    return adfValueToText(doc.object());
+  }
+  if(doc.isArray()) {
+    return adfValueToText(doc.array());
+  }
+  return QString();
+}
+
+QVector<ExternalTask> parseJiraIssues(const QByteArray& json, const QString& baseUrl) {
+  QVector<ExternalTask> out;
+  const QJsonDocument doc = QJsonDocument::fromJson(json);
+  if(!doc.isObject()) {
+    return out;
+  }
+  QString site = baseUrl;
+  while(site.endsWith('/')) {
+    site.chop(1);
+  }
+  const QJsonArray issues = doc.object().value(QStringLiteral("issues")).toArray();
+  out.reserve(issues.size());
+  for(const auto& v : issues) {
+    const QJsonObject o = v.toObject();
+    const QJsonObject fields = o.value(QStringLiteral("fields")).toObject();
+    ExternalTask t;
+    t.providerId = QStringLiteral("jira");
+    t.externalId = o.value(QStringLiteral("key")).toString();  // e.g. "PROJ-123"
+    t.url = site + QStringLiteral("/browse/") + t.externalId;
+    t.title = fields.value(QStringLiteral("summary")).toString();
+    t.body = adfValueToText(fields.value(QStringLiteral("description")));
+    t.status = fields.value(QStringLiteral("status")).toObject().value(QStringLiteral("name")).toString();
+    t.priority = fields.value(QStringLiteral("priority")).toObject().value(QStringLiteral("name")).toString();
+    for(const auto& lv : fields.value(QStringLiteral("labels")).toArray()) {
+      const QString name = lv.toString();
+      if(!name.isEmpty()) {
+        t.labels.append(name);
+      }
+    }
+    t.updatedAt = QDateTime::fromString(fields.value(QStringLiteral("updated")).toString(), Qt::ISODate);
+    out.append(t);
+  }
+  return out;
+}
+
+JiraProvider::JiraProvider(QObject* parent) : IntegrationProvider(parent), m_nam(new QNetworkAccessManager(this)) {
+}
+
+JiraProvider::~JiraProvider() = default;
+
+void JiraProvider::setConfig(const QString& baseUrl, const QString& email, const QString& token, const QString& jql) {
+  m_baseUrl = baseUrl.trimmed();
+  while(m_baseUrl.endsWith('/')) {
+    m_baseUrl.chop(1);
+  }
+  m_email = email.trimmed();
+  m_token = token.trimmed();
+  m_jql = jql.trimmed();
+}
+
+bool JiraProvider::isConfigured() const {
+  return !m_baseUrl.isEmpty() && !m_email.isEmpty() && !m_token.isEmpty();
+}
+
+namespace {
+
+// Build an authenticated Jira Cloud request. Auth is Basic base64(email:token).
+QNetworkRequest apiRequest(const QString& baseUrl, const QString& email, const QString& token, const QString& path) {
+  QNetworkRequest req{QUrl(baseUrl + QStringLiteral("/rest/api/3") + path)};
+  req.setRawHeader("Accept", "application/json");
+  req.setRawHeader("User-Agent", "heap-sync");
+  const QByteArray basic = (email + QChar(':') + token).toUtf8().toBase64();
+  req.setRawHeader("Authorization", QByteArrayLiteral("Basic ") + basic);
+  return req;
+}
+
+}  // namespace
+
+void JiraProvider::testConnection() {
+  if(!isConfigured()) {
+    emit connectionTested(false, QStringLiteral("Jira URL/email/token not configured"));
+    return;
+  }
+  QNetworkReply* reply = m_nam->get(apiRequest(m_baseUrl, m_email, m_token, QStringLiteral("/myself")));
+  connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+    reply->deleteLater();
+    emit connectionTested(reply->error() == QNetworkReply::NoError, reply->errorString());
+  });
+}
+
+void JiraProvider::pullTasks() {
+  if(!isConfigured()) {
+    emit tasksFetched({});
+    return;
+  }
+  QUrlQuery q;
+  q.addQueryItem(QStringLiteral("jql"), m_jql.isEmpty() ? QStringLiteral("order by updated DESC") : m_jql);
+  q.addQueryItem(QStringLiteral("maxResults"), QStringLiteral("100"));
+  q.addQueryItem(QStringLiteral("fields"), QStringLiteral("summary,description,status,priority,labels,updated"));
+  const QString path = QStringLiteral("/search?") + q.query(QUrl::FullyEncoded);
+  const QString site = m_baseUrl;
+  QNetworkReply* reply = m_nam->get(apiRequest(m_baseUrl, m_email, m_token, path));
+  connect(reply, &QNetworkReply::finished, this, [this, reply, site]() {
+    reply->deleteLater();
+    if(reply->error() != QNetworkReply::NoError) {
+      emit tasksFetched({});
+      return;
+    }
+    emit tasksFetched(parseJiraIssues(reply->readAll(), site));
+  });
+}
+
+void JiraProvider::pushStatusChange(const QString& externalId, const QString& newStatus) {
+  if(!isConfigured() || externalId.isEmpty()) {
+    emit taskPushed(externalId, false, QStringLiteral("not configured"));
+    return;
+  }
+  // Jira has no direct "set status" — you POST one of the issue's available
+  // workflow transitions. Fetch them, pick the one whose target status maps to
+  // the requested heap column, then execute it.
+  QNetworkReply* getReply =
+      m_nam->get(apiRequest(m_baseUrl, m_email, m_token, QStringLiteral("/issue/") + externalId + QStringLiteral("/transitions")));
+  connect(getReply, &QNetworkReply::finished, this, [this, getReply, externalId, newStatus]() {
+    getReply->deleteLater();
+    if(getReply->error() != QNetworkReply::NoError) {
+      emit taskPushed(externalId, false, getReply->errorString());
+      return;
+    }
+    const QJsonDocument doc = QJsonDocument::fromJson(getReply->readAll());
+    const QJsonArray transitions = doc.object().value(QStringLiteral("transitions")).toArray();
+    QString transitionId;
+    for(const auto& tv : transitions) {
+      const QJsonObject to = tv.toObject().value(QStringLiteral("to")).toObject();
+      const QString targetColumn = StatusMap::column(to.value(QStringLiteral("name")).toString(), {}, QString());
+      if(targetColumn == newStatus) {
+        transitionId = tv.toObject().value(QStringLiteral("id")).toString();
+        break;
+      }
+    }
+    if(transitionId.isEmpty()) {
+      emit taskPushed(externalId, false, QStringLiteral("no matching transition for column '%1'").arg(newStatus));
+      return;
+    }
+    QNetworkRequest req = apiRequest(m_baseUrl, m_email, m_token, QStringLiteral("/issue/") + externalId + QStringLiteral("/transitions"));
+    req.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/json"));
+    QJsonObject body;
+    QJsonObject tr;
+    tr.insert(QStringLiteral("id"), transitionId);
+    body.insert(QStringLiteral("transition"), tr);
+    const QByteArray payload = QJsonDocument(body).toJson(QJsonDocument::Compact);
+    QNetworkReply* postReply = m_nam->post(req, payload);
+    connect(postReply, &QNetworkReply::finished, this, [this, postReply, externalId]() {
+      postReply->deleteLater();
+      emit taskPushed(externalId, postReply->error() == QNetworkReply::NoError, postReply->errorString());
+    });
+  });
+}
+
+}  // namespace heap::integrations

--- a/src/integrations/JiraProvider.h
+++ b/src/integrations/JiraProvider.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "integrations/IntegrationProvider.h"
+#include "integrations/IntegrationTypes.h"
+
+#include <QByteArray>
+#include <QString>
+#include <QVector>
+
+class QNetworkAccessManager;
+
+namespace heap::integrations {
+
+// Parse a Jira Cloud REST v3 search response ({ "issues": [...] }) into
+// ExternalTasks. `baseUrl` builds each issue's browse URL. Descriptions arrive
+// as ADF (Atlassian Document Format) JSON and are flattened to plain text.
+// Pure, no network — unit-tested with canned JSON.
+QVector<ExternalTask> parseJiraIssues(const QByteArray& json, const QString& baseUrl);
+
+// Flatten an Atlassian Document Format value (string or ADF object) to plain
+// text by concatenating every "text" leaf. Exposed for unit testing.
+QString jiraAdfToPlainText(const QByteArray& adfJson);
+
+// Concrete IntegrationProvider backed by the Jira Cloud REST API v3 (HEAP-75).
+// Auth is HTTP Basic with an Atlassian account email + API token. Status pushes
+// go through the issue's available workflow transitions.
+class JiraProvider : public IntegrationProvider {
+  Q_OBJECT
+
+ public:
+  explicit JiraProvider(QObject* parent = nullptr);
+  ~JiraProvider() override;
+
+  // Configure from the Settings → Integrations Jira card. `baseUrl` is the site
+  // ("https://acme.atlassian.net"); `email` + `token` form the Basic-auth pair;
+  // `jql` selects which issues to pull. All required.
+  void setConfig(const QString& baseUrl, const QString& email, const QString& token, const QString& jql);
+  bool isConfigured() const;
+
+  QString id() const override {
+    return QStringLiteral("jira");
+  }
+
+  QString displayName() const override {
+    return QStringLiteral("Jira");
+  }
+
+  void testConnection() override;
+  void pullTasks() override;
+  void pushStatusChange(const QString& externalId, const QString& newStatus) override;
+
+ private:
+  QNetworkAccessManager* m_nam = nullptr;
+  QString m_baseUrl;  // "https://acme.atlassian.net" (no trailing slash)
+  QString m_email;
+  QString m_token;
+  QString m_jql;
+};
+
+}  // namespace heap::integrations

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,6 +122,10 @@ set(HEAP_SELECTION_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/IntegrationProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
@@ -193,6 +197,10 @@ set(HEAP_NOTES_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/IntegrationProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
@@ -297,6 +305,10 @@ set(HEAP_PERSISTENCE_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/IntegrationProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
@@ -366,6 +378,10 @@ set(HEAP_EXPORT_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/IntegrationProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
@@ -434,6 +450,10 @@ set(HEAP_PROFILE_IO_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/IntegrationProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
@@ -501,6 +521,10 @@ set(HEAP_ONBOARDING_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/IntegrationProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
@@ -587,6 +611,10 @@ set(HEAP_UNDO_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/IntegrationProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
@@ -656,6 +684,10 @@ set(HEAP_VIEW_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/IntegrationProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
@@ -820,6 +852,42 @@ target_link_libraries(heap_github_tests PRIVATE
 )
 add_test(NAME heap_github_tests COMMAND heap_github_tests)
 
+# Jira provider parse/transition helpers — pure functions with canned JSON.
+add_executable(heap_jira_tests
+        test_jira.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/IntegrationProvider.h
+)
+set_target_properties(heap_jira_tests PROPERTIES AUTOMOC ON)
+target_include_directories(heap_jira_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_link_libraries(heap_jira_tests PRIVATE
+        Qt6::Core
+        Qt6::Network
+        GTest::gtest
+        GTest::gtest_main
+)
+add_test(NAME heap_jira_tests COMMAND heap_jira_tests)
+
+# GitLab provider parse/state helpers — pure functions with canned JSON.
+add_executable(heap_gitlab_tests
+        test_gitlab.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/IntegrationProvider.h
+)
+set_target_properties(heap_gitlab_tests PROPERTIES AUTOMOC ON)
+target_include_directories(heap_gitlab_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_link_libraries(heap_gitlab_tests PRIVATE
+        Qt6::Core
+        Qt6::Network
+        GTest::gtest
+        GTest::gtest_main
+)
+add_test(NAME heap_gitlab_tests COMMAND heap_gitlab_tests)
+
 # ─── Sync (BYOS serializer) tests ───
 # Cover heap::sync::SyncSerializer — Profile/CalEvent ↔ git-friendly JSON with
 # stable (id-sorted) ordering and idempotent round-trips. Pure data code; needs
@@ -907,6 +975,10 @@ set(HEAP_APPCTRL_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GithubProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/JiraProvider.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/GitlabProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/IntegrationProvider.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp

--- a/tests/test_gitlab.cpp
+++ b/tests/test_gitlab.cpp
@@ -1,0 +1,60 @@
+#include "integrations/GitlabProvider.h"
+
+#include <gtest/gtest.h>
+
+using heap::integrations::ExternalTask;
+using heap::integrations::gitlabStateEventForColumn;
+using heap::integrations::parseGitlabIssues;
+
+TEST(GitlabParse, ParsesIssuesAndLabels) {
+  const QByteArray json = R"([
+    {
+      "iid": 42,
+      "web_url": "https://gitlab.com/acme/app/-/issues/42",
+      "title": "Fix login",
+      "description": "steps to repro",
+      "state": "opened",
+      "labels": ["backend", "priority::high"],
+      "updated_at": "2026-07-01T10:00:00.000Z"
+    },
+    {
+      "iid": 7,
+      "web_url": "https://gitlab.com/acme/app/-/issues/7",
+      "title": "Old bug",
+      "description": "",
+      "state": "closed",
+      "labels": [],
+      "updated_at": "2026-06-01T08:00:00.000Z"
+    }
+  ])";
+
+  const QVector<ExternalTask> tasks = parseGitlabIssues(json);
+  ASSERT_EQ(tasks.size(), 2);
+
+  EXPECT_EQ(tasks[0].providerId, QString("gitlab"));
+  EXPECT_EQ(tasks[0].externalId, QString("42"));  // iid, not internal id
+  EXPECT_EQ(tasks[0].url, QString("https://gitlab.com/acme/app/-/issues/42"));
+  EXPECT_EQ(tasks[0].title, QString("Fix login"));
+  EXPECT_EQ(tasks[0].body, QString("steps to repro"));
+  EXPECT_EQ(tasks[0].status, QString("opened"));
+  ASSERT_EQ(tasks[0].labels.size(), 2);
+  EXPECT_EQ(tasks[0].priority, QString("high"));  // from "priority::high" scoped label
+
+  EXPECT_EQ(tasks[1].externalId, QString("7"));
+  EXPECT_EQ(tasks[1].status, QString("closed"));
+  EXPECT_TRUE(tasks[1].priority.isEmpty());
+}
+
+TEST(GitlabParse, HandlesEmptyAndInvalid) {
+  EXPECT_TRUE(parseGitlabIssues(QByteArray()).isEmpty());
+  EXPECT_TRUE(parseGitlabIssues("{}").isEmpty());  // object, not array
+  EXPECT_TRUE(parseGitlabIssues("garbage").isEmpty());
+  EXPECT_TRUE(parseGitlabIssues("[]").isEmpty());
+}
+
+TEST(GitlabPushState, MapsColumnToStateEvent) {
+  EXPECT_EQ(gitlabStateEventForColumn("done"), QString("close"));
+  EXPECT_EQ(gitlabStateEventForColumn("todo"), QString("reopen"));
+  EXPECT_EQ(gitlabStateEventForColumn("prog"), QString("reopen"));
+  EXPECT_EQ(gitlabStateEventForColumn(""), QString("reopen"));
+}

--- a/tests/test_jira.cpp
+++ b/tests/test_jira.cpp
@@ -1,0 +1,76 @@
+#include "integrations/JiraProvider.h"
+
+#include <gtest/gtest.h>
+
+using heap::integrations::ExternalTask;
+using heap::integrations::jiraAdfToPlainText;
+using heap::integrations::parseJiraIssues;
+
+TEST(JiraParse, ParsesSearchResponse) {
+  const QByteArray json = R"({
+    "issues": [
+      {
+        "key": "LTE-2398",
+        "fields": {
+          "summary": "Handover fails on X2",
+          "description": {
+            "type": "doc",
+            "content": [
+              { "type": "paragraph", "content": [ { "type": "text", "text": "First line." } ] },
+              { "type": "paragraph", "content": [ { "type": "text", "text": "Second line." } ] }
+            ]
+          },
+          "status": { "name": "In Progress" },
+          "priority": { "name": "High" },
+          "labels": ["radio", "urgent"],
+          "updated": "2026-07-02T12:34:56.000+0000"
+        }
+      }
+    ]
+  })";
+
+  const QVector<ExternalTask> tasks = parseJiraIssues(json, "https://acme.atlassian.net/");
+  ASSERT_EQ(tasks.size(), 1);
+
+  const ExternalTask& t = tasks.first();
+  EXPECT_EQ(t.providerId, QString("jira"));
+  EXPECT_EQ(t.externalId, QString("LTE-2398"));
+  // Trailing slash on baseUrl is trimmed before building the browse URL.
+  EXPECT_EQ(t.url, QString("https://acme.atlassian.net/browse/LTE-2398"));
+  EXPECT_EQ(t.title, QString("Handover fails on X2"));
+  EXPECT_EQ(t.status, QString("In Progress"));
+  EXPECT_EQ(t.priority, QString("High"));
+  ASSERT_EQ(t.labels.size(), 2);
+  EXPECT_EQ(t.labels[0], QString("radio"));
+  // ADF flattened to plain text, paragraphs preserved on separate lines.
+  EXPECT_TRUE(t.body.contains("First line."));
+  EXPECT_TRUE(t.body.contains("Second line."));
+}
+
+TEST(JiraParse, PlainStringDescriptionAndEmpty) {
+  // Some responses (or older APIs) carry a plain-string description.
+  const QByteArray json = R"({
+    "issues": [
+      { "key": "AB-1", "fields": { "summary": "s", "description": "just text", "status": { "name": "Done" } } }
+    ]
+  })";
+  const QVector<ExternalTask> tasks = parseJiraIssues(json, "https://x.atlassian.net");
+  ASSERT_EQ(tasks.size(), 1);
+  EXPECT_EQ(tasks[0].body, QString("just text"));
+  EXPECT_EQ(tasks[0].status, QString("Done"));
+
+  EXPECT_TRUE(parseJiraIssues(QByteArray(), "https://x").isEmpty());
+  EXPECT_TRUE(parseJiraIssues("[]", "https://x").isEmpty());  // array, not the search object
+  EXPECT_TRUE(parseJiraIssues("garbage", "https://x").isEmpty());
+}
+
+TEST(JiraAdf, FlattensNestedContent) {
+  const QByteArray adf = R"({
+    "type": "doc",
+    "content": [
+      { "type": "paragraph", "content": [ { "type": "text", "text": "Hello " }, { "type": "text", "text": "world" } ] }
+    ]
+  })";
+  const QString text = jiraAdfToPlainText(adf);
+  EXPECT_TRUE(text.contains("Hello world"));
+}


### PR DESCRIPTION
Second and third `IntegrationProvider` backends after GitHub (HEAP-74), sharing the same interface, `StatusMap`, and sync loop.

### Providers
- **JiraProvider** (Cloud REST v3): JQL pull, Basic `email:token` auth, ADF→plain-text descriptions, status push via workflow **transitions** (fetch the issue's transitions, pick the one whose target status maps to the heap column, POST it).
- **GitlabProvider** (REST v4): project-issues pull, `PRIVATE-TOKEN` auth, status push via `state_event` (close/reopen). Scoped `priority::high` labels feed priority.
- Pure-function testable: `parseJiraIssues` / `parseGitlabIssues`, `jiraAdfToPlainText`, `gitlabStateEventForColumn` → new `heap_jira_tests` / `heap_gitlab_tests`.

### Wiring
- The single `m_syncProvider` becomes a **list** — every connected + configured provider runs concurrently.
- Pulled issues merge through a shared `mergeExternalTasks()` (provider-tagged, id-prefixed `gh-`/`jira-`/`gl-`).
- A `moveTask` status push routes to the provider whose `id()` owns the task (`externalProvider`).

### Settings → Integrations
- GitLab card added; Jira fields switched to baseUrl / email / token / JQL; **Sync now** now shows for GitHub, Jira, and GitLab; default settings objects aligned with the keys AppController actually reads (fixes a pre-existing drift).

### Tests
- Full suite green locally (**25/25**), including the two new provider targets.

Closes HEAP-75.