### PR TITLE
feat: [[wiki-links]] + backlinks in notes and a searchable snippet library (HEAP-79)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ qt_add_library(heap_core STATIC
     src/git/GitWatcher.cpp
     src/text/TaskTextUtils.cpp
     src/query/QueryParser.cpp
+    src/notes/NoteLinks.cpp
     src/notify/NotificationCenter.cpp
     src/notify/NotificationCenter_tray.cpp
     src/platform/GlobalHotkey.cpp
@@ -147,6 +148,7 @@ qt_add_qml_module(heap_core
         src/git/GitWatcher.h
         src/text/TaskTextUtils.h
         src/query/QueryParser.h
+        src/notes/NoteLinks.h
         src/notify/NotificationCenter.h
         src/platform/GlobalHotkey.h
         src/integrations/IntegrationTypes.h

--- a/qml/DocsEditor.qml
+++ b/qml/DocsEditor.qml
@@ -205,6 +205,14 @@ Popup {
                 }
             }
 
+            FieldLabel { text: "TAGS" }
+            FormField {
+                Layout.fillWidth: true
+                placeholderText: "comma, separated, tags"
+                text: root.draft.tags || ""
+                onTextChanged: root.draft.tags = text
+            }
+
             FieldLabel { text: "CODE" }
             ScrollView {
                 Layout.fillWidth: true; Layout.preferredHeight: 240

--- a/qml/DocsView.qml
+++ b/qml/DocsView.qml
@@ -145,15 +145,15 @@ Item {
     ]
 
     property var snippets: [
-        { title: "Build с sanitizers", lang: "sh",
+        { title: "Build с sanitizers", lang: "sh", tags: ["build", "sanitizers"],
           code: "# AddressSanitizer\nbazel build --config=asan //enb/core/...\n\n# ThreadSanitizer (для гонок)\nbazel build --config=tsan //enb/core/...\n\n# UBSan + ASan combo\nbazel build --config=asan-ubsan //enb/core/..." },
-        { title: "GDB · attach к running eNB", lang: "sh",
+        { title: "GDB · attach к running eNB", lang: "sh", tags: ["debug", "gdb"],
           code: "sudo gdb -p $(pgrep -f enb-core)\n(gdb) info threads\n(gdb) thread apply all bt 30\n(gdb) bt full\n(gdb) p *self  # пример pretty-print" },
-        { title: "PCAP capture per-cell", lang: "sh",
+        { title: "PCAP capture per-cell", lang: "sh", tags: ["network", "capture"],
           code: "# S1AP (port 36412) + X2AP (36422) к указанному MME\ntcpdump -i any -w /tmp/lte-cell-3.pcap \\\n  'host 10.0.0.5 and (port 36412 or port 36422)'\n\n# C-plane + U-plane всё разом\ntcpdump -i any -w /tmp/full.pcap \\\n  'port 36412 or port 36422 or port 2152'" },
-        { title: "S1AP cause codes (36.413 §9.2.1.3)", lang: "cpp",
+        { title: "S1AP cause codes (36.413 §9.2.1.3)", lang: "cpp", tags: ["reference", "enum"],
           code: "enum class S1apCause : uint8_t {\n  RadioNetwork_Unspecified = 0,\n  Transport_Unspecified    = 1,\n  NAS_Unspecified          = 2,\n  Protocol_Unspecified     = 3,\n  Misc_Unspecified         = 4,\n};\n\n// Для UE Context Release Request (§9.1.4.5)\nconstexpr auto kUeCtxRelTimeout =\n  std::chrono::seconds{10};" },
-        { title: "Logging hot-path safe", lang: "cpp",
+        { title: "Logging hot-path safe", lang: "cpp", tags: ["logging", "perf"],
           code: "// В hot path — только структурированный bin-log,\n// никаких fmt::format / std::ostream.\nLOG_BIN(kHarqRetx, ueId, harqId, ndi, rv);\n\n// Slow-path (ошибки, init) — обычный log OK\nLOG_WARN(\"PDCP SN wrap on bearer {}\", drbId);" }
     ]
 
@@ -438,6 +438,14 @@ Item {
     }
 
     function saveSnippet(draft, idx) {
+        // The editor holds tags as a comma-separated string; store them as a
+        // normalized array so search/persistence stay structured (HEAP-79).
+        if (typeof draft.tags === "string") {
+            draft.tags = draft.tags.split(",").map(function (s) { return s.trim(); })
+                                   .filter(function (s) { return s.length > 0; });
+        } else if (!Array.isArray(draft.tags)) {
+            draft.tags = [];
+        }
         const list = snippets.slice();
         if (idx < 0 || idx === undefined) {
             list.push(draft);
@@ -1081,14 +1089,16 @@ Item {
         editor.kind = "snippet";
         editor.idx = -1;
         editor.isNew = true;
-        editor.draft = ({ title: "", lang: "sh", code: "" });
+        editor.draft = ({ title: "", lang: "sh", code: "", tags: "" });
         editor.open();
     }
     function openSnippetEdit(idx) {
         editor.kind = "snippet";
         editor.idx = idx;
         editor.isNew = false;
-        editor.draft = Object.assign({}, root.snippets[idx]);
+        const d = Object.assign({}, root.snippets[idx]);
+        d.tags = Array.isArray(d.tags) ? d.tags.join(", ") : (d.tags || "");
+        editor.draft = d;
         editor.open();
     }
     function openContactCreate() {

--- a/qml/NotesView.qml
+++ b/qml/NotesView.qml
@@ -43,6 +43,12 @@ Item {
     property var    acMatches: []
     property int    acSelected: 0
 
+    // ── Backlinks pane (HEAP-79) ─────────────────────────────────────
+    // Recomputed live from the editor text (not the saved blob) so links show
+    // up as you type. Empty (and uncomputed) while the pane is hidden.
+    property bool showBacklinks: false
+    property var  _backlinks: showBacklinks ? AppController.noteBacklinks(editor.text) : []
+
     function _fuzzyScore(q, s) {
         if (q.length === 0) return 0;
         const ql = q.toLowerCase();
@@ -92,15 +98,24 @@ Item {
         return out;
     }
 
+    function _headingEntries() {
+        const out = [];
+        const hs = AppController.noteHeadings(editor.text);
+        for (let i = 0; i < hs.length; i++) {
+            out.push({ kind: "heading", id: "", label: hs[i], sub: "", color: Theme.accent });
+        }
+        return out;
+    }
+
     function _rebuildMatches() {
-        const source = acTrigger === "@" ? _peopleEntries()
-                     : acTrigger === "#" ? _taskEntries()
+        const source = acTrigger === "@"  ? _peopleEntries()
+                     : acTrigger === "#"  ? _taskEntries()
+                     : acTrigger === "[[" ? _headingEntries()
                      : [];
         const scored = [];
         for (let i = 0; i < source.length; i++) {
             const e = source[i];
-            const hay = (acTrigger === "@") ? e.label
-                                            : (e.id + " " + e.label);
+            const hay = (acTrigger === "#") ? (e.id + " " + e.label) : e.label;
             const sc = _fuzzyScore(acFilter, hay);
             if (sc < 0) continue;
             scored.push({ entry: e, score: sc });
@@ -125,10 +140,34 @@ Item {
         return /[\s.,;:!?()\[\]{}]/.test(ch);
     }
 
+    function _openAcPopup() {
+        if (acMatches.length === 0) { acPopup.close(); return; }
+        const cr = editor.cursorRectangle;
+        const p  = editor.mapToItem(root, cr.x, cr.y + cr.height);
+        acPopup.x = Math.min(p.x, root.width - acPopup.width - 8);
+        acPopup.y = Math.max(0, Math.min(p.y + 4, root.height - acPopup.height - 8));
+        if (!acPopup.opened) acPopup.open();
+    }
+
     function _detectAutocomplete() {
         const pos = editor.cursorPosition;
         const txt = editor.text;
         if (pos <= 0) { _hideAutocomplete(); return; }
+
+        // [[wiki-link]] trigger (HEAP-79) — filter may contain spaces, so scan
+        // to the nearest "[[" on the current line rather than a single word.
+        const lineStart = txt.lastIndexOf("\n", pos - 1) + 1;
+        const before = txt.substring(lineStart, pos);
+        const openIdx = before.lastIndexOf("[[");
+        if (openIdx >= 0 && before.substring(openIdx + 2).indexOf("]]") < 0) {
+            acTrigger    = "[[";
+            acTriggerPos = lineStart + openIdx;   // index of the first '['
+            acFilter     = before.substring(openIdx + 2);
+            _rebuildMatches();
+            _openAcPopup();
+            return;
+        }
+
         let i = pos - 1;
         while (i >= 0 && /[A-Za-z0-9_.\-]/.test(txt[i])) i--;
         if (i < 0) { _hideAutocomplete(); return; }
@@ -161,14 +200,34 @@ Item {
             return;
         }
         const e = acMatches[acSelected];
-        const insert = (acTrigger === "@")
-            ? "@" + _slugifyName(e.label) + " "
-            : "#" + e.id + " ";
+        const insert = (acTrigger === "@")  ? "@" + _slugifyName(e.label) + " "
+                     : (acTrigger === "[[") ? "[[" + e.label + "]] "
+                     : "#" + e.id + " ";
         const pos = editor.cursorPosition;
         // Replace the "@filter" / "#filter" span in place (remove + insert) so
         // the caret stays at the edit point instead of resetting to 0. (HEAP-65)
         Mention.commit(editor, acTriggerPos, pos, insert);
         _hideAutocomplete();
+    }
+
+    // Move the caret to `off` and scroll the editor so it is visible.
+    function _jumpToOffset(off) {
+        if (off < 0) return;
+        if (root.viewMode === "preview") root.viewMode = "split";
+        editor.forceActiveFocus();
+        editor.cursorPosition = off;
+        const cr = editor.positionToRectangle(off);
+        const maxY = Math.max(0, notesScroll.contentHeight - notesScroll.height);
+        notesScroll.contentY = Math.max(0, Math.min(cr.y - 40, maxY));
+    }
+    function _jumpToHeading(name) {
+        _jumpToOffset(AppController.noteHeadingOffset(editor.text, name));
+    }
+    function _jumpToLine(lineNum) {
+        const lines = editor.text.split("\n");
+        let off = 0;
+        for (let i = 0; i < lineNum - 1 && i < lines.length; i++) off += lines[i].length + 1;
+        _jumpToOffset(off);
     }
 
     Rectangle { anchors.fill: parent; color: Theme.bg }
@@ -220,6 +279,31 @@ Item {
                     color: Theme.textDim
                     font.family: Theme.fontMono
                     font.pixelSize: 11
+                }
+
+                // ── Backlinks pane toggle (HEAP-79) ────────────────────
+                Rectangle {
+                    Layout.preferredHeight: 24
+                    radius: 6
+                    color: root.showBacklinks ? Theme.accent : (blToggleMA.containsMouse ? Theme.panel3 : Theme.panel2)
+                    border.color: root.showBacklinks ? Theme.accent : Theme.border
+                    border.width: 1
+                    implicitWidth: blToggleTxt.implicitWidth + 20
+                    Text {
+                        id: blToggleTxt
+                        anchors.centerIn: parent
+                        text: "⌗ Links"
+                        color: root.showBacklinks ? "#06121a" : Theme.textMuted
+                        font.pixelSize: 11
+                        font.weight: Font.Medium
+                    }
+                    MouseArea {
+                        id: blToggleMA
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: root.showBacklinks = !root.showBacklinks
+                    }
                 }
 
                 // ── Edit · Split · Preview toggle ──────────────────────
@@ -520,6 +604,87 @@ Item {
                     onLinkActivated: (link) => Qt.openUrlExternally(link)
                 }
             }
+
+            // ── Backlinks pane (HEAP-79) ──────────────────────────────
+            Rectangle {
+                visible: root.showBacklinks
+                Layout.preferredWidth: 240
+                Layout.fillHeight: true
+                color: Theme.panel
+                Rectangle { anchors.top: parent.top; anchors.bottom: parent.bottom; anchors.left: parent.left; width: 1; color: Theme.border }
+                ColumnLayout {
+                    anchors.fill: parent
+                    anchors.margins: 12
+                    spacing: 8
+                    Text {
+                        text: "Backlinks"
+                        color: Theme.text
+                        font.pixelSize: 12
+                        font.weight: Font.DemiBold
+                    }
+                    Text {
+                        visible: root._backlinks.length === 0
+                        text: "No [[wiki-links]] yet.\nType [[ to link a heading."
+                        color: Theme.textDim
+                        font.pixelSize: 11
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+                    ListView {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        clip: true
+                        model: root._backlinks
+                        spacing: 8
+                        ScrollBar.vertical: ThinScrollBar {}
+                        delegate: ColumnLayout {
+                            required property var modelData
+                            width: ListView.view.width
+                            spacing: 2
+                            RowLayout {
+                                Layout.fillWidth: true
+                                spacing: 6
+                                Text {
+                                    text: (modelData.resolved ? "⌗ " : "⚠ ") + modelData.target
+                                    color: modelData.resolved ? Theme.mOneone : Theme.p1
+                                    font.pixelSize: 11
+                                    font.weight: Font.DemiBold
+                                    elide: Text.ElideRight
+                                    Layout.fillWidth: true
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        cursorShape: modelData.resolved ? Qt.PointingHandCursor : Qt.ArrowCursor
+                                        onClicked: if (modelData.resolved) root._jumpToHeading(modelData.target)
+                                    }
+                                }
+                                Text {
+                                    text: modelData.refs.length
+                                    color: Theme.textDim
+                                    font.family: Theme.fontMono
+                                    font.pixelSize: 10
+                                }
+                            }
+                            Repeater {
+                                model: modelData.refs
+                                delegate: Text {
+                                    required property var modelData
+                                    Layout.fillWidth: true
+                                    Layout.leftMargin: 10
+                                    text: "└ " + modelData.text
+                                    color: Theme.textMuted
+                                    font.pixelSize: 10
+                                    elide: Text.ElideRight
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        cursorShape: Qt.PointingHandCursor
+                                        onClicked: root._jumpToLine(modelData.line)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -552,6 +717,7 @@ Item {
             quote:        Theme.textMuted,
             mention:      Theme.mStandup,
             ticket:       Theme.p2,
+            wikilink:     Theme.mOneone,
             link:         Theme.accent,
             list:         Theme.accent,
             tableRow:     Theme.accentStrong,
@@ -630,6 +796,19 @@ Item {
                             font.weight: Font.DemiBold
                         }
                     }
+                    Rectangle {
+                        visible: modelData.kind === "heading"
+                        width: 22; height: 18; radius: 4
+                        color: "transparent"
+                        border.color: "#b58ad7"; border.width: 1
+                        Text {
+                            anchors.centerIn: parent
+                            text: "⌗"
+                            color: "#b58ad7"
+                            font.pixelSize: 11
+                            font.weight: Font.DemiBold
+                        }
+                    }
 
                     ColumnLayout {
                         Layout.fillWidth: true
@@ -642,8 +821,8 @@ Item {
                             Layout.fillWidth: true
                         }
                         Text {
-                            visible: modelData.sub.length > 0
-                            text: modelData.sub
+                            visible: (modelData.sub || "").length > 0
+                            text: modelData.sub || ""
                             color: Theme.textMuted
                             font.family: Theme.fontMono
                             font.pixelSize: 9

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -9,6 +9,7 @@
 #include "integrations/GitlabProvider.h"
 #include "integrations/JiraProvider.h"
 #include "integrations/StatusMap.h"
+#include "notes/NoteLinks.h"
 #include "notify/NotificationCenter.h"
 #include "platform/GlobalHotkey.h"
 #include "text/TaskTextUtils.h"
@@ -608,6 +609,18 @@ void AppController::appendNoteEntry(const QString& text) {
     next += QStringLiteral("\n\n----\n### %1\n\n%2").arg(stamp, body);
   }
   setNotesState(next);
+}
+
+QStringList AppController::noteHeadings(const QString& markdown) const {
+  return heap::notes::collectHeadings(markdown);
+}
+
+QVariantList AppController::noteBacklinks(const QString& markdown) const {
+  return heap::notes::collectBacklinks(markdown);
+}
+
+int AppController::noteHeadingOffset(const QString& markdown, const QString& heading) const {
+  return heap::notes::headingOffset(markdown, heading);
 }
 
 void AppController::setAppSettingsJson(const QString& v) {
@@ -2769,7 +2782,16 @@ QVariantList AppController::commandPaletteEntries() const {
           m["kind"] = "snippet";
           m["label"] = sn["title"].toString();
           m["sub"] = QString("%1 · %2").arg(p.name, sn["lang"].toString());
-          m["body"] = cap(sn["code"].toString());
+          // Full-text (HEAP-79): language + tags + code so the palette can find
+          // a snippet by tag or language, not just its title.
+          QStringList tagList;
+          for(const auto& tg : sn["tags"].toArray()) {
+            const QString s = tg.toString().trimmed();
+            if(!s.isEmpty()) {
+              tagList << s;
+            }
+          }
+          m["body"] = cap(sn["lang"].toString() + QChar(' ') + tagList.join(QChar(' ')) + QChar(' ') + sn["code"].toString());
           m["profileId"] = p.id;
           m["idx"] = snipIdx++;
           m["color"] = p.color;

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -218,6 +218,14 @@ class AppController : public QObject {
   // (no leading HR — there is nothing to separate from yet).
   Q_INVOKABLE void appendNoteEntry(const QString& text);
 
+  // Note wiki-links (HEAP-79). Headings feed [[…]] autocomplete; backlinks list
+  // which lines reference each [[target]]; the offset lets the editor jump to a
+  // heading. The caller passes the live editor text so results reflect unsaved
+  // edits (the pure logic lives in heap::notes and is unit-tested there).
+  Q_INVOKABLE QStringList noteHeadings(const QString& markdown) const;
+  Q_INVOKABLE QVariantList noteBacklinks(const QString& markdown) const;
+  Q_INVOKABLE int noteHeadingOffset(const QString& markdown, const QString& heading) const;
+
   QString appSettingsJson() const {
     return m_appSettingsJson;
   }

--- a/src/NotesHighlighter.cpp
+++ b/src/NotesHighlighter.cpp
@@ -1,329 +1,379 @@
 #include "NotesHighlighter.h"
 
+#include <QColor>
 #include <QQuickTextDocument>
 #include <QTextDocument>
-#include <QColor>
 
-NotesHighlighter::NotesHighlighter(QObject *parent)
-    : QSyntaxHighlighter(parent)
-{
-    rebuildRules();
+NotesHighlighter::NotesHighlighter(QObject* parent) : QSyntaxHighlighter(parent) {
+  rebuildRules();
 }
 
-void NotesHighlighter::setTarget(QQuickTextDocument *t) {
-    QTextDocument *newDoc = t ? t->textDocument() : nullptr;
-    const bool targetChange = (m_target != t);
-    const bool docChange    = (document() != newDoc);
-    if (!targetChange && !docChange) return;
-    m_target = t;
-    if (docChange) setDocument(newDoc);
-    if (targetChange) emit targetChanged();
-    if (document()) rehighlight();
+void NotesHighlighter::setTarget(QQuickTextDocument* t) {
+  QTextDocument* newDoc = t ? t->textDocument() : nullptr;
+  const bool targetChange = (m_target != t);
+  const bool docChange = (document() != newDoc);
+  if(!targetChange && !docChange) {
+    return;
+  }
+  m_target = t;
+  if(docChange) {
+    setDocument(newDoc);
+  }
+  if(targetChange) {
+    emit targetChanged();
+  }
+  if(document()) {
+    rehighlight();
+  }
 }
 
-void NotesHighlighter::setPalette(const QVariantMap &p) {
-    if (m_palette == p) return;
-    m_palette = p;
-    emit paletteChanged();
-    rebuildRules();
-    if (document()) rehighlight();
+void NotesHighlighter::setPalette(const QVariantMap& p) {
+  if(m_palette == p) {
+    return;
+  }
+  m_palette = p;
+  emit paletteChanged();
+  rebuildRules();
+  if(document()) {
+    rehighlight();
+  }
 }
 
-QTextCharFormat NotesHighlighter::fmt(const char *key, bool bold, bool italic) const {
-    QTextCharFormat f;
-    const QVariant v = m_palette.value(QString::fromLatin1(key));
-    QColor c = v.value<QColor>();
-    if (!c.isValid()) {
-        // Sometimes QML hands us a QJSValue / QString instead of a QColor —
-        // try parsing the string form before falling back to literals.
-        const QString s = v.toString();
-        if (!s.isEmpty()) c = QColor(s);
+QTextCharFormat NotesHighlighter::fmt(const char* key, bool bold, bool italic) const {
+  QTextCharFormat f;
+  const QVariant v = m_palette.value(QString::fromLatin1(key));
+  auto c = v.value<QColor>();
+  if(!c.isValid()) {
+    // Sometimes QML hands us a QJSValue / QString instead of a QColor —
+    // try parsing the string form before falling back to literals.
+    const QString s = v.toString();
+    if(!s.isEmpty()) {
+      c = QColor(s);
     }
-    if (!c.isValid()) {
-        // Sensible dark-mode fallbacks.
-        const QByteArray k(key);
-        if (k == "heading")          c = QColor("#8ad7ec");
-        else if (k == "bold")        c = QColor("#e5ecf3");
-        else if (k == "italic")      c = QColor("#e5ecf3");
-        else if (k == "code")        c = QColor("#d8c277");
-        else if (k == "codeBlock")   c = QColor("#d8c277");
-        else if (k == "quote")       c = QColor("#8a94a3");
-        else if (k == "mention")     c = QColor("#5aa3e6");
-        else if (k == "ticket")      c = QColor("#d8c277");
-        else if (k == "link")        c = QColor("#5cc2dd");
-        else if (k == "list")        c = QColor("#8a94a3");
-        else if (k == "tableRow")    c = QColor("#8ad7ec");
-        else if (k == "tableSep")    c = QColor("#5cc2dd");
-        else if (k == "latex")       c = QColor("#c07acf");
-        else if (k == "checkboxDone")c = QColor("#6ec18a");
-        else if (k == "hr")          c = QColor("#323a48");
-        else                         c = QColor("#e5ecf3");
+  }
+  if(!c.isValid()) {
+    // Sensible dark-mode fallbacks.
+    const QByteArray k(key);
+    if(k == "heading") {
+      c = QColor("#8ad7ec");
+    } else if(k == "bold") {
+      c = QColor("#e5ecf3");
+    } else if(k == "italic") {
+      c = QColor("#e5ecf3");
+    } else if(k == "code") {
+      c = QColor("#d8c277");
+    } else if(k == "codeBlock") {
+      c = QColor("#d8c277");
+    } else if(k == "quote") {
+      c = QColor("#8a94a3");
+    } else if(k == "mention") {
+      c = QColor("#5aa3e6");
+    } else if(k == "ticket") {
+      c = QColor("#d8c277");
+    } else if(k == "wikilink") {
+      c = QColor("#b58ad7");
+    } else if(k == "link") {
+      c = QColor("#5cc2dd");
+    } else if(k == "list") {
+      c = QColor("#8a94a3");
+    } else if(k == "tableRow") {
+      c = QColor("#8ad7ec");
+    } else if(k == "tableSep") {
+      c = QColor("#5cc2dd");
+    } else if(k == "latex") {
+      c = QColor("#c07acf");
+    } else if(k == "checkboxDone") {
+      c = QColor("#6ec18a");
+    } else if(k == "hr") {
+      c = QColor("#323a48");
+    } else {
+      c = QColor("#e5ecf3");
     }
-    f.setForeground(c);
-    if (bold)   f.setFontWeight(QFont::DemiBold);
-    if (italic) f.setFontItalic(true);
-    return f;
+  }
+  f.setForeground(c);
+  if(bold) {
+    f.setFontWeight(QFont::DemiBold);
+  }
+  if(italic) {
+    f.setFontItalic(true);
+  }
+  return f;
 }
 
 void NotesHighlighter::rebuildRules() {
-    m_rules.clear();
+  m_rules.clear();
 
-    // Block-level format used by the multiline state machine — fenced code
-    // blocks paint the entire line with this format (forecolor + optional bg).
-    {
-        QTextCharFormat f = fmt("codeBlock");
-        f.setFontFamilies({ QStringLiteral("JetBrains Mono"),
-                            QStringLiteral("Fira Code"),
-                            QStringLiteral("DejaVu Sans Mono") });
-        const QVariant bgv = m_palette.value(QStringLiteral("codeBlockBg"));
-        QColor bg = bgv.value<QColor>();
-        if (!bg.isValid()) {
-            const QString s = bgv.toString();
-            if (!s.isEmpty()) bg = QColor(s);
-        }
-        if (!bg.isValid()) bg = QColor("#0f131a");
-        f.setBackground(bg);
-        m_codeBlockFmt = f;
+  // Block-level format used by the multiline state machine — fenced code
+  // blocks paint the entire line with this format (forecolor + optional bg).
+  {
+    QTextCharFormat f = fmt("codeBlock");
+    f.setFontFamilies({QStringLiteral("JetBrains Mono"), QStringLiteral("Fira Code"), QStringLiteral("DejaVu Sans Mono")});
+    const QVariant bgv = m_palette.value(QStringLiteral("codeBlockBg"));
+    auto bg = bgv.value<QColor>();
+    if(!bg.isValid()) {
+      const QString s = bgv.toString();
+      if(!s.isEmpty()) {
+        bg = QColor(s);
+      }
     }
+    if(!bg.isValid()) {
+      bg = QColor("#0f131a");
+    }
+    f.setBackground(bg);
+    m_codeBlockFmt = f;
+  }
 
-    // LaTeX block format — mono + accent colour, no background.
-    {
-        QTextCharFormat f = fmt("latex");
-        f.setFontFamilies({ QStringLiteral("JetBrains Mono"),
-                            QStringLiteral("Fira Code"),
-                            QStringLiteral("DejaVu Sans Mono") });
-        m_latexFmt = f;
-    }
+  // LaTeX block format — mono + accent colour, no background.
+  {
+    QTextCharFormat f = fmt("latex");
+    f.setFontFamilies({QStringLiteral("JetBrains Mono"), QStringLiteral("Fira Code"), QStringLiteral("DejaVu Sans Mono")});
+    m_latexFmt = f;
+  }
 
-    // --- Horizontal rule: ---  ***  ___  ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("^(?:-{3,}|\\*{3,}|_{3,})\\s*$"));
-        r.format = fmt("hr", true);
-        m_rules.push_back(r);
-    }
+  // --- Horizontal rule: ---  ***  ___  ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("^(?:-{3,}|\\*{3,}|_{3,})\\s*$"));
+    r.format = fmt("hr", true);
+    m_rules.push_back(r);
+  }
 
-    // --- Headings: # / ## / ### / #### / ##### / ###### ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("^#{1,6}\\s.+$"));
-        r.format = fmt("heading", true);
-        m_rules.push_back(r);
-    }
+  // --- Headings: # / ## / ### / #### / ##### / ###### ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("^#{1,6}\\s.+$"));
+    r.format = fmt("heading", true);
+    m_rules.push_back(r);
+  }
 
-    // --- Table separator row: |---|:---:|---:| ---
-    // Must come before the generic table-row rule so the separator gets the
-    // stronger format (rule order is paint order — later rules win on overlap,
-    // but both are full-line matches, so we keep this declaration first and
-    // overwrite with the row rule below).
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("^\\s*\\|?\\s*:?-{3,}:?\\s*(?:\\|\\s*:?-{3,}:?\\s*)+\\|?\\s*$"));
-        r.format = fmt("tableSep", true);
-        m_rules.push_back(r);
-    }
+  // --- Table separator row: |---|:---:|---:| ---
+  // Must come before the generic table-row rule so the separator gets the
+  // stronger format (rule order is paint order — later rules win on overlap,
+  // but both are full-line matches, so we keep this declaration first and
+  // overwrite with the row rule below).
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("^\\s*\\|?\\s*:?-{3,}:?\\s*(?:\\|\\s*:?-{3,}:?\\s*)+\\|?\\s*$"));
+    r.format = fmt("tableSep", true);
+    m_rules.push_back(r);
+  }
 
-    // --- Table row: any line that contains a pipe between non-pipe chars ---
-    // The separator rule above paints the dashes; the row rule re-paints any
-    // other pipe-delimited line. Order matters — separator must come first so
-    // its format isn't clobbered when the row pattern matches it too.
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("^\\s*\\|[^\\n]*\\|\\s*$"));
-        r.format = fmt("tableRow");
-        m_rules.push_back(r);
-    }
+  // --- Table row: any line that contains a pipe between non-pipe chars ---
+  // The separator rule above paints the dashes; the row rule re-paints any
+  // other pipe-delimited line. Order matters — separator must come first so
+  // its format isn't clobbered when the row pattern matches it too.
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("^\\s*\\|[^\\n]*\\|\\s*$"));
+    r.format = fmt("tableRow");
+    m_rules.push_back(r);
+  }
 
-    // --- Checklist done: - [x] / * [X] / + [x] ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("^\\s*[-*+]\\s+\\[[xX]\\]\\s+.*$"));
-        QTextCharFormat f = fmt("checkboxDone");
-        f.setFontStrikeOut(true);
-        r.format = f;
-        m_rules.push_back(r);
-    }
+  // --- Checklist done: - [x] / * [X] / + [x] ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("^\\s*[-*+]\\s+\\[[xX]\\]\\s+.*$"));
+    QTextCharFormat f = fmt("checkboxDone");
+    f.setFontStrikeOut(true);
+    r.format = f;
+    m_rules.push_back(r);
+  }
 
-    // --- Checklist todo: - [ ] / * [ ] / + [ ] (marker portion only) ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("^\\s*[-*+]\\s+\\[\\s\\]"));
-        r.format = fmt("list", true);
-        m_rules.push_back(r);
-    }
+  // --- Checklist todo: - [ ] / * [ ] / + [ ] (marker portion only) ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("^\\s*[-*+]\\s+\\[\\s\\]"));
+    r.format = fmt("list", true);
+    m_rules.push_back(r);
+  }
 
-    // --- List markers (the dash, not the whole line) ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("^\\s*([-*+])\\s"));
-        r.format = fmt("list", true);
-        r.captureGroup = 1;
-        m_rules.push_back(r);
-    }
+  // --- List markers (the dash, not the whole line) ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("^\\s*([-*+])\\s"));
+    r.format = fmt("list", true);
+    r.captureGroup = 1;
+    m_rules.push_back(r);
+  }
 
-    // --- Numbered list markers: "1. " "12. " ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("^\\s*(\\d+\\.)\\s"));
-        r.format = fmt("list", true);
-        r.captureGroup = 1;
-        m_rules.push_back(r);
-    }
+  // --- Numbered list markers: "1. " "12. " ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("^\\s*(\\d+\\.)\\s"));
+    r.format = fmt("list", true);
+    r.captureGroup = 1;
+    m_rules.push_back(r);
+  }
 
-    // --- Quote block ">" ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("^\\s*>+\\s.*$"));
-        r.format = fmt("quote", false, true);
-        m_rules.push_back(r);
-    }
+  // --- Quote block ">" ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("^\\s*>+\\s.*$"));
+    r.format = fmt("quote", false, true);
+    m_rules.push_back(r);
+  }
 
-    // --- Markdown link [text](url) — color the whole match ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("\\[[^\\]\\n]+\\]\\([^)\\n]+\\)"));
-        QTextCharFormat f = fmt("link");
-        f.setFontUnderline(true);
-        r.format = f;
-        m_rules.push_back(r);
-    }
+  // --- Markdown link [text](url) — color the whole match ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("\\[[^\\]\\n]+\\]\\([^)\\n]+\\)"));
+    QTextCharFormat f = fmt("link");
+    f.setFontUnderline(true);
+    r.format = f;
+    m_rules.push_back(r);
+  }
 
-    // --- Strike-through ~~text~~ ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("~~[^~\\n]+~~"));
-        QTextCharFormat f = fmt("quote");
-        f.setFontStrikeOut(true);
-        r.format = f;
-        m_rules.push_back(r);
-    }
+  // --- Strike-through ~~text~~ ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("~~[^~\\n]+~~"));
+    QTextCharFormat f = fmt("quote");
+    f.setFontStrikeOut(true);
+    r.format = f;
+    m_rules.push_back(r);
+  }
 
-    // --- Bold **text** ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("\\*\\*[^*\\n]+\\*\\*"));
-        r.format = fmt("bold", true);
-        m_rules.push_back(r);
-    }
+  // --- Bold **text** ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("\\*\\*[^*\\n]+\\*\\*"));
+    r.format = fmt("bold", true);
+    m_rules.push_back(r);
+  }
 
-    // --- Italic *text* (avoid eating the inside of **bold**) ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("(?<![*\\w])\\*(?!\\s)[^*\\n]+\\*(?!\\w)"));
-        r.format = fmt("italic", false, true);
-        m_rules.push_back(r);
-    }
+  // --- Italic *text* (avoid eating the inside of **bold**) ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("(?<![*\\w])\\*(?!\\s)[^*\\n]+\\*(?!\\w)"));
+    r.format = fmt("italic", false, true);
+    m_rules.push_back(r);
+  }
 
-    // --- Inline code `code` ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("`[^`\\n]+`"));
-        QTextCharFormat f = fmt("code");
-        f.setFontFamilies({ QStringLiteral("JetBrains Mono"),
-                            QStringLiteral("Fira Code"),
-                            QStringLiteral("DejaVu Sans Mono") });
-        // Subtle background — derived from "codeBg" if present, otherwise leave bare.
-        const QVariant bgv = m_palette.value(QStringLiteral("codeBg"));
-        QColor bg = bgv.value<QColor>();
-        if (bg.isValid()) f.setBackground(bg);
-        r.format = f;
-        m_rules.push_back(r);
+  // --- Inline code `code` ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("`[^`\\n]+`"));
+    QTextCharFormat f = fmt("code");
+    f.setFontFamilies({QStringLiteral("JetBrains Mono"), QStringLiteral("Fira Code"), QStringLiteral("DejaVu Sans Mono")});
+    // Subtle background — derived from "codeBg" if present, otherwise leave bare.
+    const QVariant bgv = m_palette.value(QStringLiteral("codeBg"));
+    const auto bg = bgv.value<QColor>();
+    if(bg.isValid()) {
+      f.setBackground(bg);
     }
+    r.format = f;
+    m_rules.push_back(r);
+  }
 
-    // --- @mention ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("(?<![A-Za-z0-9_])@[A-Za-z0-9_.\\-]+"));
-        r.format = fmt("mention", true);
-        m_rules.push_back(r);
-    }
+  // --- @mention ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("(?<![A-Za-z0-9_])@[A-Za-z0-9_.\\-]+"));
+    r.format = fmt("mention", true);
+    m_rules.push_back(r);
+  }
 
-    // --- #TICKET-id (e.g. LTE-2401) ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("(?<![A-Za-z0-9_])#[A-Z][A-Z0-9]*-\\d+"));
-        r.format = fmt("ticket", true);
-        m_rules.push_back(r);
-    }
+  // --- #TICKET-id (e.g. LTE-2401) ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("(?<![A-Za-z0-9_])#[A-Z][A-Z0-9]*-\\d+"));
+    r.format = fmt("ticket", true);
+    m_rules.push_back(r);
+  }
 
-    // --- Inline LaTeX: $...$ (single line). Skip $$ (block fence) and \$. ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("(?<![\\\\$])\\$(?!\\$)[^\\$\\n]+\\$(?!\\$)"));
-        QTextCharFormat f = fmt("latex");
-        f.setFontFamilies({ QStringLiteral("JetBrains Mono"),
-                            QStringLiteral("Fira Code"),
-                            QStringLiteral("DejaVu Sans Mono") });
-        r.format = f;
-        m_rules.push_back(r);
-    }
+  // --- [[wiki-link]] to a note heading (HEAP-79) ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("\\[\\[[^\\]\\n]+\\]\\]"));
+    r.format = fmt("wikilink", true);
+    m_rules.push_back(r);
+  }
 
-    // --- Image source ![alt](url) — same look as a link plus a leading bang. ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("!\\[[^\\]\\n]*\\]\\([^)\\n]+\\)"));
-        QTextCharFormat f = fmt("link");
-        f.setFontUnderline(false);
-        f.setFontItalic(true);
-        r.format = f;
-        m_rules.push_back(r);
-    }
+  // --- Inline LaTeX: $...$ (single line). Skip $$ (block fence) and \$. ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("(?<![\\\\$])\\$(?!\\$)[^\\$\\n]+\\$(?!\\$)"));
+    QTextCharFormat f = fmt("latex");
+    f.setFontFamilies({QStringLiteral("JetBrains Mono"), QStringLiteral("Fira Code"), QStringLiteral("DejaVu Sans Mono")});
+    r.format = f;
+    m_rules.push_back(r);
+  }
 
-    // --- Bare URL auto-link http(s):// up to whitespace. ---
-    {
-        Rule r;
-        r.pattern = QRegularExpression(QStringLiteral("\\bhttps?://[^\\s)\\]]+"));
-        QTextCharFormat f = fmt("link");
-        f.setFontUnderline(true);
-        r.format = f;
-        m_rules.push_back(r);
-    }
+  // --- Image source ![alt](url) — same look as a link plus a leading bang. ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("!\\[[^\\]\\n]*\\]\\([^)\\n]+\\)"));
+    QTextCharFormat f = fmt("link");
+    f.setFontUnderline(false);
+    f.setFontItalic(true);
+    r.format = f;
+    m_rules.push_back(r);
+  }
+
+  // --- Bare URL auto-link http(s):// up to whitespace. ---
+  {
+    Rule r;
+    r.pattern = QRegularExpression(QStringLiteral("\\bhttps?://[^\\s)\\]]+"));
+    QTextCharFormat f = fmt("link");
+    f.setFontUnderline(true);
+    r.format = f;
+    m_rules.push_back(r);
+  }
 }
 
-void NotesHighlighter::highlightBlock(const QString &text) {
-    // Block state machine — handles multi-line fenced code (```) and LaTeX
-    // ($$ ... $$) blocks. previousBlockState() / setCurrentBlockState() keep
-    // the parser stateful across paragraph boundaries.
-    const int prev = previousBlockState();
-    const bool inFence = (prev == BS_FencedCode);
-    const bool inLatex = (prev == BS_LatexBlock);
-    const QString trimmed = text.trimmed();
+void NotesHighlighter::highlightBlock(const QString& text) {
+  // Block state machine — handles multi-line fenced code (```) and LaTeX
+  // ($$ ... $$) blocks. previousBlockState() / setCurrentBlockState() keep
+  // the parser stateful across paragraph boundaries.
+  const int prev = previousBlockState();
+  const bool inFence = (prev == BS_FencedCode);
+  const bool inLatex = (prev == BS_LatexBlock);
+  const QString trimmed = text.trimmed();
 
-    // Fenced ``` open / close — paint the fence line + toggle state.
-    if (trimmed.startsWith(QStringLiteral("```"))) {
-        if (text.length() > 0) setFormat(0, text.length(), m_codeBlockFmt);
-        setCurrentBlockState(inFence ? BS_Normal : BS_FencedCode);
-        return;
+  // Fenced ``` open / close — paint the fence line + toggle state.
+  if(trimmed.startsWith(QStringLiteral("```"))) {
+    if(text.length() > 0) {
+      setFormat(0, text.length(), m_codeBlockFmt);
     }
-    if (inFence) {
-        if (text.length() > 0) setFormat(0, text.length(), m_codeBlockFmt);
-        setCurrentBlockState(BS_FencedCode);
-        return;
+    setCurrentBlockState(inFence ? BS_Normal : BS_FencedCode);
+    return;
+  }
+  if(inFence) {
+    if(text.length() > 0) {
+      setFormat(0, text.length(), m_codeBlockFmt);
     }
+    setCurrentBlockState(BS_FencedCode);
+    return;
+  }
 
-    // LaTeX $$ open / close — same state-toggle pattern.
-    if (trimmed == QStringLiteral("$$")
-        || (trimmed.startsWith(QStringLiteral("$$")) && trimmed.length() > 2 && !inLatex)
-        || (trimmed.endsWith(QStringLiteral("$$"))   && inLatex)) {
-        if (text.length() > 0) setFormat(0, text.length(), m_latexFmt);
-        setCurrentBlockState(inLatex ? BS_Normal : BS_LatexBlock);
-        return;
+  // LaTeX $$ open / close — same state-toggle pattern.
+  if(trimmed == QStringLiteral("$$") || (trimmed.startsWith(QStringLiteral("$$")) && trimmed.length() > 2 && !inLatex) ||
+     (trimmed.endsWith(QStringLiteral("$$")) && inLatex)) {
+    if(text.length() > 0) {
+      setFormat(0, text.length(), m_latexFmt);
     }
-    if (inLatex) {
-        if (text.length() > 0) setFormat(0, text.length(), m_latexFmt);
-        setCurrentBlockState(BS_LatexBlock);
-        return;
+    setCurrentBlockState(inLatex ? BS_Normal : BS_LatexBlock);
+    return;
+  }
+  if(inLatex) {
+    if(text.length() > 0) {
+      setFormat(0, text.length(), m_latexFmt);
     }
+    setCurrentBlockState(BS_LatexBlock);
+    return;
+  }
 
-    setCurrentBlockState(BS_Normal);
+  setCurrentBlockState(BS_Normal);
 
-    for (const Rule &r : m_rules) {
-        auto it = r.pattern.globalMatch(text);
-        while (it.hasNext()) {
-            const auto m = it.next();
-            const int start = m.capturedStart(r.captureGroup);
-            const int len   = m.capturedLength(r.captureGroup);
-            if (len > 0) setFormat(start, len, r.format);
-        }
+  for(const Rule& r : m_rules) {
+    auto it = r.pattern.globalMatch(text);
+    while(it.hasNext()) {
+      const auto m = it.next();
+      const int start = m.capturedStart(r.captureGroup);
+      const int len = m.capturedLength(r.captureGroup);
+      if(len > 0) {
+        setFormat(start, len, r.format);
+      }
     }
+  }
 }

--- a/src/notes/NoteLinks.cpp
+++ b/src/notes/NoteLinks.cpp
@@ -1,0 +1,99 @@
+#include "notes/NoteLinks.h"
+
+#include <QHash>
+#include <QRegularExpression>
+#include <QSet>
+#include <QVariantMap>
+
+namespace heap::notes {
+
+namespace {
+
+const QRegularExpression& headingRx() {
+  static const QRegularExpression rx(QStringLiteral("^#{1,6}\\s+(.+?)\\s*$"));
+  return rx;
+}
+
+const QRegularExpression& wikiRx() {
+  static const QRegularExpression rx(QStringLiteral("\\[\\[([^\\]\\n]+)\\]\\]"));
+  return rx;
+}
+
+}  // namespace
+
+QStringList collectHeadings(const QString& markdown) {
+  QStringList out;
+  QSet<QString> seen;
+  const auto lines = markdown.split(QChar('\n'));
+  for(const QString& line : lines) {
+    const auto m = headingRx().match(line);
+    if(!m.hasMatch()) {
+      continue;
+    }
+    const QString text = m.captured(1).trimmed();
+    if(text.isEmpty() || seen.contains(text)) {
+      continue;
+    }
+    seen.insert(text);
+    out.append(text);
+  }
+  return out;
+}
+
+QVariantList collectBacklinks(const QString& markdown) {
+  const QStringList headingList = collectHeadings(markdown);
+  const QSet<QString> headings(headingList.cbegin(), headingList.cend());
+
+  // Preserve first-seen target order, accumulate refs per target.
+  QStringList order;
+  QHash<QString, QVariantList> refsByTarget;
+
+  const auto lines = markdown.split(QChar('\n'));
+  for(int i = 0; i < lines.size(); ++i) {
+    const QString& line = lines.at(i);
+    auto it = wikiRx().globalMatch(line);
+    while(it.hasNext()) {
+      const QString target = it.next().captured(1).trimmed();
+      if(target.isEmpty()) {
+        continue;
+      }
+      if(!refsByTarget.contains(target)) {
+        order.append(target);
+      }
+      QVariantMap ref;
+      ref.insert(QStringLiteral("line"), i + 1);  // 1-based
+      ref.insert(QStringLiteral("text"), line.trimmed());
+      refsByTarget[target].append(ref);
+    }
+  }
+
+  QVariantList out;
+  order.sort(Qt::CaseInsensitive);
+  for(const QString& target : order) {
+    QVariantMap entry;
+    entry.insert(QStringLiteral("target"), target);
+    entry.insert(QStringLiteral("resolved"), headings.contains(target));
+    entry.insert(QStringLiteral("refs"), refsByTarget.value(target));
+    out.append(entry);
+  }
+  return out;
+}
+
+int headingOffset(const QString& markdown, const QString& heading) {
+  const QString needle = heading.trimmed();
+  if(needle.isEmpty()) {
+    return -1;
+  }
+  int offset = 0;
+  const auto lines = markdown.split(QChar('\n'));
+  for(const QString& line : lines) {
+    const auto m = headingRx().match(line);
+    if(m.hasMatch() && m.captured(1).trimmed().compare(needle, Qt::CaseInsensitive) == 0) {
+      return offset;
+    }
+    offset += line.size() + 1;  // +1 for the '\n' consumed by split
+  }
+  return -1;
+}
+
+}  // namespace heap::notes

--- a/src/notes/NoteLinks.h
+++ b/src/notes/NoteLinks.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <QVariantList>
+
+namespace heap::notes {
+
+// Pure note-graph helpers over a single markdown blob (heap. stores all of a
+// profile's notes as one string). No QObject, no I/O — unit-tested directly.
+
+// Every markdown heading's text (the part after the leading #'s), in document
+// order, de-duplicated. Used to populate [[wiki-link]] autocomplete.
+QStringList collectHeadings(const QString& markdown);
+
+// Backlinks: group every [[target]] occurrence by its target. Returns
+// [ { "target": <text>, "refs": [ { "line": <1-based>, "text": <trimmed line> }, … ] }, … ]
+// sorted by target. `resolved` is true when a heading with that text exists.
+QVariantList collectBacklinks(const QString& markdown);
+
+// 0-based character offset of the first heading whose text equals `heading`
+// (case-insensitive, trimmed), or -1. Lets the UI jump to a link target.
+int headingOffset(const QString& markdown, const QString& heading);
+
+}  // namespace heap::notes

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -143,6 +143,7 @@ set(HEAP_SELECTION_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/text/TaskTextUtils.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notes/NoteLinks.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/GitWatcher.h
 )
 if (WIN32)
@@ -218,6 +219,7 @@ set(HEAP_NOTES_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/text/TaskTextUtils.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notes/NoteLinks.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/GitWatcher.h
 )
 if (WIN32)
@@ -326,6 +328,7 @@ set(HEAP_PERSISTENCE_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/text/TaskTextUtils.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notes/NoteLinks.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/GitWatcher.h
 )
 if (WIN32)
@@ -399,6 +402,7 @@ set(HEAP_EXPORT_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/text/TaskTextUtils.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notes/NoteLinks.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/GitWatcher.h
 )
 if (WIN32)
@@ -471,6 +475,7 @@ set(HEAP_PROFILE_IO_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/text/TaskTextUtils.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notes/NoteLinks.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/GitWatcher.h
 )
 if (WIN32)
@@ -542,6 +547,7 @@ set(HEAP_ONBOARDING_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/text/TaskTextUtils.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notes/NoteLinks.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/GitWatcher.h
 )
 if (WIN32)
@@ -632,6 +638,7 @@ set(HEAP_UNDO_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/text/TaskTextUtils.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notes/NoteLinks.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/GitWatcher.h
 )
 if (WIN32)
@@ -705,6 +712,7 @@ set(HEAP_VIEW_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/text/TaskTextUtils.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notes/NoteLinks.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/GitWatcher.h
 )
 if (WIN32)
@@ -996,6 +1004,7 @@ set(HEAP_APPCTRL_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/text/TaskTextUtils.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/notes/NoteLinks.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/git/GitWatcher.h
 )
 if (WIN32)

--- a/tests/test_appcontroller.cpp
+++ b/tests/test_appcontroller.cpp
@@ -266,6 +266,29 @@ TEST_F(AppControllerTest, CommandPaletteEntriesCarryBodyText) {
   EXPECT_TRUE(noteOk);
 }
 
+TEST_F(AppControllerTest, SnippetTagsAndLanguageReachPaletteBody) {
+  // A snippet whose match term lives only in its tags / language must be
+  // findable from the palette (HEAP-79 "first-class snippet library").
+  const QString docs = QStringLiteral(
+      "{\"sections\":[],\"contacts\":[],\"snippets\":["
+      "{\"title\":\"Interactive rebase\",\"lang\":\"sh\",\"tags\":[\"git\",\"workflow\"],\"code\":\"git rebase -i\"}]}");
+  app_->setDocsState(docs);
+  app_->flushSave();
+
+  bool ok = false;
+  for(const QVariant& v : app_->commandPaletteEntries()) {
+    const QVariantMap m = v.toMap();
+    if(m.value("kind").toString() == QStringLiteral("snippet") && m.value("label").toString() == QStringLiteral("Interactive rebase")) {
+      const QString body = m.value("body").toString();
+      EXPECT_TRUE(body.contains(QStringLiteral("git")));       // tag
+      EXPECT_TRUE(body.contains(QStringLiteral("workflow")));  // tag
+      EXPECT_TRUE(body.contains(QStringLiteral("sh")));        // language
+      ok = true;
+    }
+  }
+  EXPECT_TRUE(ok);
+}
+
 // ─── headless boot ────────────────────────────────────────────────────
 
 int main(int argc, char** argv) {

--- a/tests/test_notes.cpp
+++ b/tests/test_notes.cpp
@@ -10,6 +10,8 @@
 #include "AppController.h"
 #include "Models.h"
 
+#include "notes/NoteLinks.h"
+
 #include <QApplication>
 #include <QRegularExpression>
 #include <QSignalSpy>
@@ -176,6 +178,39 @@ TEST_F(NotesAppendTest, NoSignalWhenInputRejected) {
   app_->appendNoteEntry(QStringLiteral("\n\t\n"));
 
   EXPECT_EQ(spy.count(), 0);
+}
+
+// ─── Wiki-links / backlinks (HEAP-79) ─────────────────────────────────
+
+TEST(NoteLinks, CollectsHeadingsDeduped) {
+  const QString md = QStringLiteral("# Alpha\n\ntext\n## Beta\n### Alpha\n#### \n");
+  const QStringList h = heap::notes::collectHeadings(md);
+  ASSERT_EQ(h.size(), 2);  // "Alpha" deduped, empty heading skipped
+  EXPECT_EQ(h.at(0), QString("Alpha"));
+  EXPECT_EQ(h.at(1), QString("Beta"));
+}
+
+TEST(NoteLinks, BacklinksGroupByTargetWithResolution) {
+  const QString md = QStringLiteral("# Alpha\n\nsee [[Beta]] here\n\n## Beta\n\nrefers to [[Alpha]] and [[Ghost]]\n");
+  const QVariantList bl = heap::notes::collectBacklinks(md);
+  // Targets: Alpha, Beta, Ghost (sorted, case-insensitive).
+  ASSERT_EQ(bl.size(), 3);
+  const QVariantMap alpha = bl.at(0).toMap();
+  EXPECT_EQ(alpha.value("target").toString(), QString("Alpha"));
+  EXPECT_TRUE(alpha.value("resolved").toBool());  // heading "# Alpha" exists
+  ASSERT_EQ(alpha.value("refs").toList().size(), 1);
+  EXPECT_EQ(alpha.value("refs").toList().at(0).toMap().value("line").toInt(), 7);
+
+  const QVariantMap ghost = bl.at(2).toMap();
+  EXPECT_EQ(ghost.value("target").toString(), QString("Ghost"));
+  EXPECT_FALSE(ghost.value("resolved").toBool());  // no such heading
+}
+
+TEST(NoteLinks, HeadingOffsetFindsCaseInsensitive) {
+  const QString md = QStringLiteral("# Alpha\n\n## Beta gamma\n");
+  const int off = heap::notes::headingOffset(md, QStringLiteral("beta gamma"));
+  EXPECT_EQ(md.mid(off, 12), QString("## Beta gamm"));
+  EXPECT_EQ(heap::notes::headingOffset(md, QStringLiteral("nope")), -1);
 }
 
 // ─── headless boot (mirrors test_selection.cpp) ──────────────────────


### PR DESCRIPTION
Strengthens the "Know" pillar toward Obsidian-grade for engineers.

### Wiki-links + backlinks
Notes are one markdown blob per profile, so `[[links]]` target **headings** within the notes.
- `NotesHighlighter` paints `[[…]]`; a pure, unit-tested `heap::notes` graph (`collectHeadings` / `collectBacklinks` / `headingOffset`) drives the UI.
- The existing `@`/`#` autocomplete gains a **`[[` trigger** that completes heading names (spaces allowed in the filter).
- A toggleable **Backlinks pane** (⌗ Links) lists every `[[target]]` with its referencing lines, flags unresolved targets, and jumps to a heading or a reference on click.

### Snippet library
- Snippets gain a **`tags`** field (editor TAGS input; stored as a normalized array in `docsState`).
- The command palette now indexes snippet **language + tags + code**, so a snippet is findable by tag or language from `Ctrl+K` and copied from its card.

### Acceptance
- Link two notes (headings) and see the backlink. ✅
- Find a snippet by tag/language from the palette and copy it. ✅

### Tests
- `heap_notes_tests` covers the note-graph parser (headings dedup, backlink grouping + resolution, heading offset).
- `heap_appcontroller_tests` asserts snippet tags/language reach the palette body.
- Full suite green locally (**25/25**).

Note: `src/NotesHighlighter.cpp` is reformatted to the repo clang-format/clang-tidy (the file predated the format bots) — the large diff there is mechanical.

Closes HEAP-79.