### PR TITLE
feat: per-task time tracking + weekly "what I shipped" report (HEAP-78)

### DIFF
--- a/qml/ArchiveView.qml
+++ b/qml/ArchiveView.qml
@@ -90,6 +90,8 @@ Item {
                 gitAhead: m.data(idx, Qt.UserRole + 14),
                 gitBehind: m.data(idx, Qt.UserRole + 15),
                 recentCommits: m.data(idx, Qt.UserRole + 16),
+                trackedSeconds: m.data(idx, Qt.UserRole + 17),
+                isTiming: m.data(idx, Qt.UserRole + 18),
             };
             if (!root.passesFilter(t)) continue;
             out.push(t);

--- a/qml/I18n.qml
+++ b/qml/I18n.qml
@@ -151,6 +151,8 @@ QtObject {
             "taskcard.copyId": "Copy ID",
             "taskcard.copyBranch": "Copy branch",
             "taskcard.createBranch": "Create branch",
+            "taskcard.startTimer": "Start timer",
+            "taskcard.stopTimer": "Stop timer",
 
             // ── TaskEditor / EventEditor / PersonEditor / ProfileEditor ──
             "editor.new.task": "New task",
@@ -672,6 +674,8 @@ QtObject {
             "taskcard.copyId": "Копировать ID",
             "taskcard.copyBranch": "Копировать branch",
             "taskcard.createBranch": "Создать ветку",
+            "taskcard.startTimer": "Запустить таймер",
+            "taskcard.stopTimer": "Остановить таймер",
 
             "editor.new.task": "Новая задача",
             "editor.edit.task": "Редактировать задачу",

--- a/qml/KanbanBoard.qml
+++ b/qml/KanbanBoard.qml
@@ -417,6 +417,8 @@ Item {
                                             required property int    gitAhead
                                             required property int    gitBehind
                                             required property var    recentCommits
+                                            required property int    trackedSeconds
+                                            required property bool   isTiming
                                             width: bodyCol.width
 
                                             readonly property var taskData: ({
@@ -426,7 +428,8 @@ Item {
                                                 archived: tc.archived, blockedStuck: tc.blockedStuck,
                                                 prState: tc.prState, prNumber: tc.prNumber, prUrl: tc.prUrl,
                                                 gitAhead: tc.gitAhead, gitBehind: tc.gitBehind,
-                                                recentCommits: tc.recentCommits
+                                                recentCommits: tc.recentCommits,
+                                                trackedSeconds: tc.trackedSeconds, isTiming: tc.isTiming
                                             })
                                             task: taskData
                                             scheduled: root.scheduleMap[tc.id] || ""

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -573,6 +573,12 @@ ApplicationWindow {
         onActivated: AppController.copyActiveProfileMarkdownToClipboard()
     }
     Shortcut {
+        sequence: _kbd("profile.weeklyReport")
+        context: Qt.ApplicationShortcut
+        enabled: sequence.length > 0 && !hotkeys.isCapturing
+        onActivated: AppController.copyWeeklyReportToClipboard()
+    }
+    Shortcut {
         sequence: _kbd("tweaks.open")
         context: Qt.ApplicationShortcut
         enabled: sequence.length > 0 && !hotkeys.isCapturing

--- a/qml/TaskCard.qml
+++ b/qml/TaskCard.qml
@@ -19,6 +19,21 @@ Rectangle {
 
     signal rangeSelectRequested(string anchorId)
 
+    // Time tracking (HEAP-78): tick once a second while this task's timer runs
+    // so the elapsed chip stays live; _timerTick is read in the chip binding.
+    property int _timerTick: 0
+    Timer {
+        interval: 1000; repeat: true
+        running: card.task && card.task.isTiming === true
+        onTriggered: card._timerTick++
+    }
+    function _fmtElapsed(s) {
+        const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60), sec = s % 60;
+        if (h > 0) return h + "h " + m + "m";
+        if (m > 0) return m + "m " + sec + "s";
+        return sec + "s";
+    }
+
     radius: 8
     color: _isArchived ? Theme.withAlpha(Theme.panel2, 0.55)
         : _selected ? Theme.withAlpha(Theme.accent, 0.10)
@@ -261,6 +276,41 @@ Rectangle {
                 font.pixelSize: 10
             }
             Item { Layout.fillWidth: true }
+            // Time-tracking chip — click to start/stop; live while running.
+            Rectangle {
+                visible: card.task && (card.task.isTiming || (card.task.trackedSeconds || 0) > 0)
+                radius: 4
+                color: card.task && card.task.isTiming ? Theme.withAlpha(Theme.p1, 0.18) : Theme.withAlpha(Theme.textDim, 0.14)
+                border.color: card.task && card.task.isTiming ? Theme.p1 : Theme.border
+                border.width: 1
+                implicitWidth: timerT.implicitWidth + 10
+                implicitHeight: timerT.implicitHeight + 2
+                Text {
+                    id: timerT
+                    anchors.centerIn: parent
+                    text: {
+                        card._timerTick;  // re-evaluate each tick while running
+                        if (!card.task) return "";
+                        const s = card.task.isTiming ? AppController.elapsedSecondsFor(card.task.id)
+                                                     : (card.task.trackedSeconds || 0);
+                        return (card.task.isTiming ? "▶ " : "⏱ ") + card._fmtElapsed(s);
+                    }
+                    color: card.task && card.task.isTiming ? Theme.p1 : Theme.textMuted
+                    font.family: Theme.fontMono
+                    font.pixelSize: 10
+                    font.weight: Font.DemiBold
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        if (!card.task) return;
+                        if (card.task.isTiming) AppController.stopTaskTimer(card.task.id);
+                        else AppController.startTaskTimer(card.task.id);
+                    }
+                }
+            }
             Rectangle {
                 visible: card.scheduled && card.scheduled.length > 0
                 radius: 4
@@ -358,6 +408,15 @@ Rectangle {
         }
         QQC.MenuItem {
             text: "✎  " + I18n.t("taskcard.edit"); onTriggered: card.clicked()
+        }
+        QQC.MenuItem {
+            text: card.task && card.task.isTiming ? ("⏹  " + I18n.t("taskcard.stopTimer"))
+                                                  : ("▶  " + I18n.t("taskcard.startTimer"))
+            onTriggered: {
+                if (!card.task) return;
+                if (card.task.isTiming) AppController.stopTaskTimer(card.task.id);
+                else AppController.startTaskTimer(card.task.id);
+            }
         }
         QQC.MenuSeparator {}
         QQC.MenuItem {

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -85,6 +85,7 @@ const QHash<QString, I18nEntry>& i18nTable() {
       {"profile.duplicated", {"Profile duplicated: %1", "Дублирован профиль: %1"}},
       {"profile.exported", {"Profile exported: %1", "Профиль экспортирован: %1"}},
       {"profile.mdCopied", {"Profile Markdown copied to clipboard", "Markdown профиля скопирован в буфер"}},
+      {"profile.weeklyCopied", {"Weekly report copied to clipboard", "Недельный отчёт скопирован в буфер"}},
       {"profile.imported", {"Profile imported: %1", "Импортирован профиль: %1"}},
       {"tasks.renamed", {"Tasks renamed: %1", "Переименовано задач: %1"}},
       {"backup.restored", {"Restored from %1", "Восстановлено из %1"}},
@@ -132,6 +133,10 @@ const QHash<QString, I18nEntry>& i18nTable() {
       {"shortcut.profile.exportMd.label", {"Export profile to Markdown", "Экспорт профиля в Markdown"}},
       {"shortcut.profile.exportMd.desc",
        {"Puts a markdown summary of the active profile into the clipboard.", "Кладёт markdown-выжимку активного профиля в буфер."}},
+      {"shortcut.profile.weeklyReport.label", {"Weekly shipped report", "Недельный отчёт"}},
+      {"shortcut.profile.weeklyReport.desc",
+       {"Copies a Markdown report of tasks marked done in the last 7 days, with tracked time.",
+        "Копирует Markdown-отчёт задач, завершённых за последние 7 дней, с учётом времени."}},
       {"shortcut.tweaks.open.label", {"Open Tweaks", "Открыть Tweaks"}},
       {"shortcut.tweaks.open.desc", {"Theme, density, workday.", "Тема, плотность, рабочий день."}},
       {"shortcut.hotkeys.open.label", {"Open Hotkeys", "Открыть Hotkeys"}},
@@ -755,7 +760,9 @@ void AppController::saveTask(const QVariantMap& draft) {
       const Task& prev = m_tasks.items().at(existing);
       t.archived = draft.contains("archived") ? draft.value("archived").toBool() : prev.archived;
       t.statusChangedAt = prev.statusChangedAt;
-      // The editor never exposes the tracker link — carry it across edits.
+      // The editor exposes neither the tracker link nor the timer — carry both.
+      t.trackedSeconds = prev.trackedSeconds;
+      t.timerStartedAt = prev.timerStartedAt;
       t.externalId = prev.externalId;
       t.externalUrl = prev.externalUrl;
       t.externalProvider = prev.externalProvider;
@@ -1224,6 +1231,8 @@ QVariantMap AppController::taskById(const QString& id) const {
   m["deadline"] = t.deadline;
   m["branch"] = t.branch;
   m["archived"] = t.archived;
+  m["trackedSeconds"] = t.trackedSeconds;
+  m["isTiming"] = t.timerStartedAt.isValid();
   return m;
 }
 
@@ -1469,6 +1478,93 @@ void AppController::copyActiveProfileMarkdownToClipboard() {
 
   copyToClipboard(md);
   emit toast(tr_("profile.mdCopied"));
+}
+
+namespace {
+QString formatTrackedDuration(int secs) {
+  const int h = secs / 3600;
+  const int m = (secs % 3600) / 60;
+  return h > 0 ? QStringLiteral("%1h %2m").arg(h).arg(m) : QStringLiteral("%1m").arg(m);
+}
+}  // namespace
+
+void AppController::copyWeeklyReportToClipboard() {
+  snapshotActiveProfile();
+  const int pi = profileIndexOf(m_activeProfileId);
+  if(pi < 0) {
+    return;
+  }
+  const Profile& p = m_profiles[pi];
+  const QDate since = QDate::currentDate().addDays(-7);
+
+  QVector<const Task*> shipped;
+  int totalSecs = 0;
+  for(const Task& t : p.tasks) {
+    if(t.status == QStringLiteral("done") && t.statusChangedAt.isValid() && t.statusChangedAt.date() >= since) {
+      shipped.push_back(&t);
+      totalSecs += t.trackedSeconds;
+    }
+  }
+
+  QString md;
+  md += QStringLiteral("# What I shipped — ") + p.name + QStringLiteral("\n\n");
+  md += QStringLiteral("_") + since.toString(Qt::ISODate) + QStringLiteral(" → ") + QDate::currentDate().toString(Qt::ISODate) +
+        QStringLiteral("_\n\n");
+  if(shipped.isEmpty()) {
+    md += QStringLiteral("_Nothing marked done in the last 7 days._\n");
+  } else {
+    md += QStringLiteral("**") + QString::number(shipped.size()) + QStringLiteral(" task(s) shipped");
+    if(totalSecs > 0) {
+      md += QStringLiteral(" · ") + formatTrackedDuration(totalSecs) + QStringLiteral(" tracked");
+    }
+    md += QStringLiteral("**\n\n");
+    for(const Task* t : shipped) {
+      QString line = QStringLiteral("- ");
+      if(!t->id.isEmpty()) {
+        line += QStringLiteral("`") + t->id + QStringLiteral("` ");
+      }
+      line += t->title;
+      QStringList meta;
+      meta << QStringLiteral("done ") + t->statusChangedAt.date().toString(Qt::ISODate);
+      if(t->trackedSeconds > 0) {
+        meta << formatTrackedDuration(t->trackedSeconds);
+      }
+      line += QStringLiteral("  — ") + meta.join(QStringLiteral(" · "));
+      md += line + QStringLiteral("\n");
+    }
+  }
+
+  copyToClipboard(md);
+  emit toast(tr_("profile.weeklyCopied"));
+}
+
+void AppController::startTaskTimer(const QString& id) {
+  if(m_tasks.indexOfId(id) < 0) {
+    return;
+  }
+  m_tasks.startTiming(id);
+  scheduleSave();
+}
+
+void AppController::stopTaskTimer(const QString& id) {
+  if(m_tasks.indexOfId(id) < 0) {
+    return;
+  }
+  m_tasks.stopTiming(id);
+  scheduleSave();
+}
+
+int AppController::elapsedSecondsFor(const QString& id) const {
+  const int row = m_tasks.indexOfId(id);
+  if(row < 0) {
+    return 0;
+  }
+  const Task& t = m_tasks.items().at(row);
+  int secs = t.trackedSeconds;
+  if(t.timerStartedAt.isValid()) {
+    secs += static_cast<int>(t.timerStartedAt.secsTo(QDateTime::currentDateTime()));
+  }
+  return secs;
 }
 
 void AppController::markWelcomeSeen() {
@@ -1861,6 +1957,14 @@ QJsonArray tasksToJson(const QVector<Task>& xs) {
     o["branch"] = t.branch;
     o["statusChangedAt"] = t.statusChangedAt.isValid() ? t.statusChangedAt.toString(Qt::ISODate) : QString();
     o["archived"] = t.archived;
+    // Time tracking (HEAP-78) — omitted when zero/stopped so untimed task JSON
+    // stays byte-identical.
+    if(t.trackedSeconds > 0) {
+      o["trackedSeconds"] = t.trackedSeconds;
+    }
+    if(t.timerStartedAt.isValid()) {
+      o["timerStartedAt"] = t.timerStartedAt.toString(Qt::ISODate);
+    }
     // Tracker-sync link — only emitted for synced tasks so locally-created
     // task JSON stays byte-identical to before HEAP-74.
     if(!t.externalId.isEmpty()) {
@@ -1891,6 +1995,8 @@ QVector<Task> tasksFromJson(const QJsonArray& a) {
       t.statusChangedAt = QDateTime::currentDateTime();
     }
     t.archived = o["archived"].toBool(false);
+    t.trackedSeconds = o["trackedSeconds"].toInt(0);
+    t.timerStartedAt = QDateTime::fromString(o["timerStartedAt"].toString(), Qt::ISODate);
     t.externalId = o["externalId"].toString();
     t.externalUrl = o["externalUrl"].toString();
     t.externalProvider = o["externalProvider"].toString();
@@ -3006,6 +3112,7 @@ void AppController::seedShortcutCatalog() {
   add("profile.next", "Ctrl+]");
   add("profile.prev", "Ctrl+[");
   add("profile.exportMd", "Ctrl+Shift+E");
+  add("profile.weeklyReport", "Ctrl+Shift+W");
   add("tweaks.open", "Ctrl+,");
   add("hotkeys.open", "Ctrl+/");
   add("undo", "Ctrl+Z");

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -266,6 +266,12 @@ class AppController : public QObject {
   Q_INVOKABLE bool canTransitionStatus(const QString& taskId, const QString& newStatus);
   Q_INVOKABLE void setArchived(const QString& taskId, bool archived);
 
+  // Time tracking (HEAP-78). start/stop the per-task timer (only one runs at a
+  // time); elapsedSecondsFor returns the live total incl. the running session.
+  Q_INVOKABLE void startTaskTimer(const QString& id);
+  Q_INVOKABLE void stopTaskTimer(const QString& id);
+  Q_INVOKABLE int elapsedSecondsFor(const QString& id) const;
+
   // ---- Multi-select API ----
   QStringList selectedTaskIds() const {
     return m_selectedTaskIdsList;
@@ -423,6 +429,9 @@ class AppController : public QObject {
   // people, notes) and put it on the clipboard. Bound to the profile.exportMd
   // shortcut (Ctrl+Shift+E).
   Q_INVOKABLE void copyActiveProfileMarkdownToClipboard();
+  // Weekly "what I shipped" report (HEAP-78): done tasks from the last 7 days
+  // with tracked time, copied to the clipboard as Markdown.
+  Q_INVOKABLE void copyWeeklyReportToClipboard();
   Q_INVOKABLE QString importProfileFromJson(const QString& jsonText, bool activate = true);
   Q_INVOKABLE QString importProfileFromFile(const QUrl& fileUrl, bool activate = true);
 

--- a/src/Models.cpp
+++ b/src/Models.cpp
@@ -20,6 +20,8 @@ QHash<int, QByteArray> TaskModel::roleNames() const {
       {GitAheadRole, "gitAhead"},
       {GitBehindRole, "gitBehind"},
       {RecentCommitsRole, "recentCommits"},
+      {TrackedSecondsRole, "trackedSeconds"},
+      {IsTimingRole, "isTiming"},
   };
 }
 
@@ -61,6 +63,10 @@ QVariant TaskModel::data(const QModelIndex& idx, int role) const {
       return m_git.value(t.id).behind;
     case RecentCommitsRole:
       return m_git.value(t.id).recentCommits;
+    case TrackedSecondsRole:
+      return t.trackedSeconds;
+    case IsTimingRole:
+      return t.timerStartedAt.isValid();
   }
   return {};
 }
@@ -138,6 +144,36 @@ void TaskModel::stampStatusChange(const QString& id) {
   m_items[row].statusChangedAt = QDateTime::currentDateTime();
   const QModelIndex mi = index(row, 0);
   emit dataChanged(mi, mi, {StatusChangedAtRole});
+}
+
+void TaskModel::startTiming(const QString& id) {
+  const int row = indexOfId(id);
+  if(row < 0 || m_items[row].timerStartedAt.isValid()) {
+    return;
+  }
+  // Only one task tracks at a time — stop any other running timer first.
+  for(int i = 0; i < m_items.size(); ++i) {
+    if(i != row && m_items[i].timerStartedAt.isValid()) {
+      stopTiming(m_items[i].id);
+    }
+  }
+  m_items[row].timerStartedAt = QDateTime::currentDateTime();
+  const QModelIndex mi = index(row, 0);
+  emit dataChanged(mi, mi, {TrackedSecondsRole, IsTimingRole});
+}
+
+void TaskModel::stopTiming(const QString& id) {
+  const int row = indexOfId(id);
+  if(row < 0 || !m_items[row].timerStartedAt.isValid()) {
+    return;
+  }
+  const qint64 elapsed = m_items[row].timerStartedAt.secsTo(QDateTime::currentDateTime());
+  if(elapsed > 0) {
+    m_items[row].trackedSeconds += static_cast<int>(elapsed);
+  }
+  m_items[row].timerStartedAt = QDateTime();  // clear → stopped
+  const QModelIndex mi = index(row, 0);
+  emit dataChanged(mi, mi, {TrackedSecondsRole, IsTimingRole});
 }
 
 void TaskModel::setArchived(const QString& id, bool archived) {

--- a/src/Models.h
+++ b/src/Models.h
@@ -22,6 +22,11 @@ struct Task {
   QString branch;
   QDateTime statusChangedAt;  // last time `status` was mutated
   bool archived = false;      // hidden from Board/Timeline once auto-archived
+  // Time tracking (HEAP-78). trackedSeconds is the accumulated total; while a
+  // timer runs, timerStartedAt marks when the current session began (invalid =
+  // stopped). Live elapsed = trackedSeconds + (now - timerStartedAt).
+  int trackedSeconds = 0;
+  QDateTime timerStartedAt;
   // Tracker-sync link (HEAP-74): set when this task mirrors an external issue.
   // Empty for locally-created tasks. Used to route status pushes and to match
   // pulled issues back to their task on the next sync.
@@ -90,6 +95,8 @@ class TaskModel : public QAbstractListModel {
     GitAheadRole,
     GitBehindRole,
     RecentCommitsRole,
+    TrackedSecondsRole,
+    IsTimingRole,
   };
 
   explicit TaskModel(QObject* parent = nullptr) : QAbstractListModel(parent) {
@@ -100,6 +107,11 @@ class TaskModel : public QAbstractListModel {
   void setBlockedStuckIds(const QSet<QString>& ids);
   void setArchived(const QString& id, bool archived);
   void stampStatusChange(const QString& id);
+  // Time tracking (HEAP-78). startTiming marks a task running (stopping any
+  // other running task); stopTiming folds the elapsed session into
+  // trackedSeconds. Both emit dataChanged for the timing roles.
+  void startTiming(const QString& id);
+  void stopTiming(const QString& id);
 
   // Push live git-derived data for a task (PR state, ahead/behind). Only
   // keys present in \p info are updated; others stay as-is. Emits

--- a/tests/test_appcontroller.cpp
+++ b/tests/test_appcontroller.cpp
@@ -289,6 +289,29 @@ TEST_F(AppControllerTest, SnippetTagsAndLanguageReachPaletteBody) {
   EXPECT_TRUE(ok);
 }
 
+// ─── Time tracking (HEAP-78) ──────────────────────────────────────────
+
+TEST_F(AppControllerTest, TaskTimerStartStopAndSingleActive) {
+  app_->tasks()->reset({mkTask(QStringLiteral("A"), QStringLiteral("a")), mkTask(QStringLiteral("B"), QStringLiteral("b"))});
+  const auto timing = [&](const QString& id) {
+    const int row = app_->tasks()->indexOfId(id);
+    return app_->tasks()->data(app_->tasks()->index(row, 0), TaskModel::IsTimingRole).toBool();
+  };
+
+  app_->startTaskTimer(QStringLiteral("A"));
+  EXPECT_TRUE(timing(QStringLiteral("A")));
+  EXPECT_GE(app_->elapsedSecondsFor(QStringLiteral("A")), 0);
+
+  // Only one timer runs at a time — starting B stops A.
+  app_->startTaskTimer(QStringLiteral("B"));
+  EXPECT_TRUE(timing(QStringLiteral("B")));
+  EXPECT_FALSE(timing(QStringLiteral("A")));
+
+  // Stopping clears the running flag.
+  app_->stopTaskTimer(QStringLiteral("B"));
+  EXPECT_FALSE(timing(QStringLiteral("B")));
+}
+
 // ─── headless boot ────────────────────────────────────────────────────
 
 int main(int argc, char** argv) {

--- a/tests/test_export_markdown.cpp
+++ b/tests/test_export_markdown.cpp
@@ -13,6 +13,7 @@
 
 #include <QApplication>
 #include <QClipboard>
+#include <QDateTime>
 #include <QDir>
 #include <QFile>
 #include <QStandardPaths>
@@ -91,6 +92,28 @@ TEST_F(MarkdownExportTest, ArchivedTasksAreExcluded) {
 
   EXPECT_TRUE(md.contains(QStringLiteral("`T-NEW`")));
   EXPECT_FALSE(md.contains(QStringLiteral("`T-OLD`")));
+}
+
+// ─── Weekly "what I shipped" report (HEAP-78) ─────────────────────────
+
+TEST_F(MarkdownExportTest, WeeklyReportIncludesRecentDoneWithTrackedTime) {
+  Task recent = makeTask(QStringLiteral("W-1"), QStringLiteral("Shipped this week"), QStringLiteral("P1"), QStringLiteral("done"));
+  recent.statusChangedAt = QDateTime::currentDateTime().addDays(-2);
+  recent.trackedSeconds = 3 * 3600 + 30 * 60;  // 3h30m
+  Task old = makeTask(QStringLiteral("W-OLD"), QStringLiteral("Shipped long ago"), QStringLiteral("P2"), QStringLiteral("done"));
+  old.statusChangedAt = QDateTime::currentDateTime().addDays(-30);
+  Task wip = makeTask(QStringLiteral("W-WIP"), QStringLiteral("Still going"), QStringLiteral("P1"), QStringLiteral("prog"));
+  wip.statusChangedAt = QDateTime::currentDateTime().addDays(-1);
+  app_->tasks()->reset({recent, old, wip});
+
+  app_->copyWeeklyReportToClipboard();
+  const QString md = QGuiApplication::clipboard()->text();
+
+  EXPECT_TRUE(md.contains(QStringLiteral("What I shipped"))) << md.toStdString();
+  EXPECT_TRUE(md.contains(QStringLiteral("`W-1`")));
+  EXPECT_TRUE(md.contains(QStringLiteral("3h 30m")));    // tracked time rendered
+  EXPECT_FALSE(md.contains(QStringLiteral("`W-OLD`")));  // >7 days → excluded
+  EXPECT_FALSE(md.contains(QStringLiteral("`W-WIP`")));  // not done → excluded
 }
 
 int main(int argc, char** argv) {

--- a/tests/test_persistence.cpp
+++ b/tests/test_persistence.cpp
@@ -131,6 +131,26 @@ TEST_F(PersistenceTest, AbsentStateIsCleanFirstRun) {
   EXPECT_EQ(firstProfileName(app), QStringLiteral("Example"));
 }
 
+// Tracked time must survive an app restart (HEAP-78 "across sessions").
+TEST_F(PersistenceTest, TrackedSecondsSurvivesReload) {
+  {
+    AppController app;
+    Task t;
+    t.id = QStringLiteral("TIME-1");
+    t.title = QStringLiteral("timed");
+    t.status = QStringLiteral("todo");
+    t.priority = QStringLiteral("P2");
+    t.trackedSeconds = 4242;
+    app.tasks()->reset({t});
+    app.setCrumbUser(QStringLiteral("arm-save"));  // arm the save timer
+    app.flushSave();
+  }
+  AppController app2;
+  const int row = app2.tasks()->indexOfId(QStringLiteral("TIME-1"));
+  ASSERT_GE(row, 0);
+  EXPECT_EQ(app2.tasks()->items().at(row).trackedSeconds, 4242);
+}
+
 int main(int argc, char** argv) {
   qputenv("QT_QPA_PLATFORM", "offscreen");
   QStandardPaths::setTestModeEnabled(true);


### PR DESCRIPTION
### Time tracking
- `Task` gains `trackedSeconds` + `timerStartedAt` — persisted (byte-stable when unused), carried across edits.
- `TaskModel` exposes `trackedSeconds`/`isTiming` roles and `startTiming`/`stopTiming` (**only one task tracks at a time** — starting one stops the other).
- `AppController`: `startTaskTimer` / `stopTaskTimer` / `elapsedSecondsFor` invokables.
- Task card gets a **live elapsed chip** (ticks each second while running) + a **Start/Stop timer** context-menu item.

### Weekly report
- `copyWeeklyReportToClipboard` (**Ctrl+Shift+W**): Markdown of tasks marked **done in the last 7 days** with tracked time, gated on `statusChangedAt` — extends the profile Markdown export.

### Acceptance
- Track time on a task across sessions (persists across restart). ✅
- Export a weekly report of done tasks + time. ✅

### Tests
- `heap_export_tests`: weekly report includes recent done + tracked time, excludes >7-day / not-done.
- `heap_persistence_tests`: `trackedSeconds` survives reload.
- `heap_appcontroller_tests`: timer start/stop + single-active invariant.
- Full suite green locally (**25/25**).

Closes HEAP-78.