### PR TITLE
feat: recurring tasks + reusable task/checklist templates (HEAP-77)

### DIFF
--- a/qml/ArchiveView.qml
+++ b/qml/ArchiveView.qml
@@ -92,6 +92,7 @@ Item {
                 recentCommits: m.data(idx, Qt.UserRole + 16),
                 trackedSeconds: m.data(idx, Qt.UserRole + 17),
                 isTiming: m.data(idx, Qt.UserRole + 18),
+                recurrence: m.data(idx, Qt.UserRole + 19),
             };
             if (!root.passesFilter(t)) continue;
             out.push(t);

--- a/qml/CommandPalette.qml
+++ b/qml/CommandPalette.qml
@@ -123,6 +123,9 @@ Popup {
                 root.openPerson(entry.personId);
             } else if (entry.kind === "note") {
                 AppController.currentView = "notes";
+            } else if (entry.kind === "template") {
+                AppController.currentView = "board";
+                AppController.createTaskFromTemplate(entry.templateName);
             }
             root.close();
         });
@@ -225,6 +228,7 @@ Popup {
                                     case "profile": return "●";
                                     case "person":  return "P";
                                     case "note":    return "N";
+                                    case "template": return "✚";
                                 }
                                 return "?";
                             }

--- a/qml/KanbanBoard.qml
+++ b/qml/KanbanBoard.qml
@@ -419,6 +419,7 @@ Item {
                                             required property var    recentCommits
                                             required property int    trackedSeconds
                                             required property bool   isTiming
+                                            required property string recurrence
                                             width: bodyCol.width
 
                                             readonly property var taskData: ({
@@ -429,7 +430,8 @@ Item {
                                                 prState: tc.prState, prNumber: tc.prNumber, prUrl: tc.prUrl,
                                                 gitAhead: tc.gitAhead, gitBehind: tc.gitBehind,
                                                 recentCommits: tc.recentCommits,
-                                                trackedSeconds: tc.trackedSeconds, isTiming: tc.isTiming
+                                                trackedSeconds: tc.trackedSeconds, isTiming: tc.isTiming,
+                                                recurrence: tc.recurrence
                                             })
                                             task: taskData
                                             scheduled: root.scheduleMap[tc.id] || ""

--- a/qml/QuickCapturePopup.qml
+++ b/qml/QuickCapturePopup.qml
@@ -155,6 +155,11 @@ Popup {
         if (_preview && _preview.ok && _preview.start) {
             draft.deadline = _preview.start;
         }
+        // Persist a parsed recurrence ("every weekday…") so completing the task
+        // regenerates it (HEAP-77).
+        if (_preview && _preview.recurrence && _preview.recurrence.length > 0) {
+            draft.recurrence = _preview.recurrence;
+        }
         AppController.saveTask(draft);
 
         // Calendar entry rules:

--- a/qml/TaskCard.qml
+++ b/qml/TaskCard.qml
@@ -33,6 +33,21 @@ Rectangle {
         if (m > 0) return m + "m " + sec + "s";
         return sec + "s";
     }
+    function _recurLabel(r) {
+        switch (r) {
+            case "every:day":     return "daily";
+            case "every:week":    return "weekly";
+            case "every:weekday": return "weekdays";
+            case "every:mon":     return "Mondays";
+            case "every:tue":     return "Tuesdays";
+            case "every:wed":     return "Wednesdays";
+            case "every:thu":     return "Thursdays";
+            case "every:fri":     return "Fridays";
+            case "every:sat":     return "Saturdays";
+            case "every:sun":     return "Sundays";
+        }
+        return r ? String(r).replace("every:", "") : "";
+    }
 
     radius: 8
     color: _isArchived ? Theme.withAlpha(Theme.panel2, 0.55)
@@ -274,6 +289,25 @@ Rectangle {
                 }
                 font.family: Theme.fontMono
                 font.pixelSize: 10
+            }
+            // Recurrence chip (HEAP-77).
+            Rectangle {
+                visible: card.task && card.task.recurrence && String(card.task.recurrence).length > 0
+                radius: 4
+                color: Theme.withAlpha(Theme.mOneone, 0.14)
+                border.color: Theme.mOneone
+                border.width: 1
+                implicitWidth: recurT.implicitWidth + 10
+                implicitHeight: recurT.implicitHeight + 2
+                Text {
+                    id: recurT
+                    anchors.centerIn: parent
+                    text: "🔁 " + card._recurLabel(card.task ? card.task.recurrence : "")
+                    color: Theme.mOneone
+                    font.family: Theme.fontMono
+                    font.pixelSize: 10
+                    font.weight: Font.DemiBold
+                }
             }
             Item { Layout.fillWidth: true }
             // Time-tracking chip — click to start/stop; live while running.

--- a/qml/TaskEditor.qml
+++ b/qml/TaskEditor.qml
@@ -36,6 +36,7 @@ Popup {
         priBox.currentIndex = Math.max(0, ["P0", "P1", "P2", "P3"].indexOf(draft.priority || "P2"));
         branchField.text = draft.branch || "";
         deadlineField.text = formatDate(draft.deadline);
+        recurBox.currentIndex = Math.max(0, recurBox._vals.indexOf(draft.recurrence || ""));
         open();
         // Kick a one-shot PR/state refresh for this task's branch across all
         // watched repos. Result lands on TaskModel via repoStateUpdated and
@@ -336,6 +337,26 @@ Popup {
                 color: Theme.text
                 placeholderTextColor: Theme.textDim
             }
+
+            FieldLabel { text: "RECURRENCE" }
+            FieldLabel { text: "" }
+            ComboBox {
+                id: recurBox
+                Layout.fillWidth: true
+                readonly property var _vals: ["", "every:day", "every:week", "every:weekday",
+                                              "every:mon", "every:tue", "every:wed", "every:thu", "every:fri"]
+                model: ["None", "Daily", "Weekly", "Weekdays",
+                        "Every Mon", "Every Tue", "Every Wed", "Every Thu", "Every Fri"]
+                background: FieldBg {
+                }
+                contentItem: Text {
+                    text: recurBox.displayText
+                    color: Theme.text
+                    leftPadding: 10
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+            Item {}
         }
 
         RowLayout {
@@ -393,7 +414,8 @@ Popup {
                         priority: priBox.currentText,
                         status: root.statusList()[statusBox.currentIndex],
                         deadline: root.parseDate(deadlineField.text),
-                        branch: branchField.text
+                        branch: branchField.text,
+                        recurrence: recurBox._vals[recurBox.currentIndex] || ""
                     };
                     AppController.saveTask(d);
                     // Same classification rules as QuickCapturePopup — only

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -12,6 +12,7 @@
 #include "notes/NoteLinks.h"
 #include "notify/NotificationCenter.h"
 #include "platform/GlobalHotkey.h"
+#include "recur/RecurrenceEngine.h"
 #include "text/TaskTextUtils.h"
 #include "update/Updater.h"
 
@@ -40,6 +41,7 @@
 #include <QUrlQuery>
 #include <QUuid>
 
+#include <algorithm>
 #include <cmath>
 
 // Version is injected by CMake (PROJECT_VERSION); this fallback keeps standalone
@@ -659,6 +661,9 @@ void AppController::moveTask(const QString& id, const QString& newStatus) {
   }
   const QString taskId = t.id;
   const QString prevStatus = t.status;
+  // Capture before any upsert can invalidate the `t` reference (HEAP-77).
+  const QString recurrence = t.recurrence;
+  const QDate recurBase = t.deadline;
   m_tasks.setStatus(id, newStatus);
 
   // Mirror the change back to the linked tracker issue (e.g. moving to Done
@@ -694,6 +699,38 @@ void AppController::moveTask(const QString& id, const QString& newStatus) {
     const QVariantMap cal = s.value("calendar").toMap();
     if(cal.value("autoFocusBlock", true).toBool()) {
       scheduleFocusBlockFor(taskId);
+    }
+  }
+
+  // Recurring task completed → spawn the next occurrence (HEAP-77).
+  if(newStatus == QStringLiteral("done") && !recurrence.isEmpty()) {
+    const QDate base = recurBase.isValid() ? recurBase : QDate::currentDate();
+    const QDate next = heap::recur::nextOccurrence(recurrence, base);
+    const int srcRow = m_tasks.indexOfId(taskId);
+    if(next.isValid() && srcRow >= 0) {
+      Task copy = m_tasks.items().at(srcRow);  // clone title/desc/priority/branch
+      // Fresh unique id (strip any prior "-rN" suffix) so upsert inserts a new
+      // row rather than overwriting the just-completed one.
+      QString stem = taskId;
+      static const QRegularExpression kRSuffix(QStringLiteral("-r\\d+$"));
+      stem.remove(kRSuffix);
+      QString newId;
+      int n = 1;
+      do {
+        newId = stem + QStringLiteral("-r") + QString::number(n++);
+      } while(m_tasks.indexOfId(newId) >= 0);
+      copy.id = newId;
+      copy.status = QStringLiteral("todo");
+      copy.deadline = next;
+      copy.statusChangedAt = QDateTime::currentDateTime();
+      copy.trackedSeconds = 0;
+      copy.timerStartedAt = QDateTime();
+      copy.recurrence = recurrence;  // stays recurring
+      copy.externalId.clear();       // a new local occurrence, not the synced issue
+      copy.externalUrl.clear();
+      copy.externalProvider.clear();
+      m_tasks.upsert(copy);
+      emit toast(tr("Recurs: %1 due %2").arg(newId, next.toString(Qt::ISODate)));
     }
   }
 
@@ -733,6 +770,74 @@ QVariantMap AppController::newQuickTaskDraft() const {
   return m;
 }
 
+namespace {
+// Built-in task/checklist templates (HEAP-77). Checklists are markdown
+// `- [ ]` lines in the description — they render as checkboxes in the notes
+// preview and stay plain, editable text everywhere else.
+struct TaskTemplate {
+  QString name;
+  QString title;
+  QString desc;
+  QString priority;
+};
+
+const QVector<TaskTemplate>& builtinTemplates() {
+  static const QVector<TaskTemplate> kTemplates = {
+      {QStringLiteral("PR review"),
+       QStringLiteral("Review PR: "),
+       QStringLiteral("- [ ] Pull the branch and build\n- [ ] Tests pass locally\n- [ ] Logic + edge cases\n- [ ] Naming / style\n- [ ] "
+                      "No leftover debug code\n- [ ] Approve or request changes"),
+       QStringLiteral("P2")},
+      {QStringLiteral("Release checklist"),
+       QStringLiteral("Release "),
+       QStringLiteral("- [ ] Version bumped\n- [ ] Changelog updated\n- [ ] CI green on main\n- [ ] Tag pushed\n- [ ] Artifacts signed\n- "
+                      "[ ] Release notes published\n- [ ] Announce"),
+       QStringLiteral("P1")},
+      {QStringLiteral("Bug report"),
+       QStringLiteral("Bug: "),
+       QStringLiteral(
+           "**Steps to reproduce:**\n1. \n\n**Expected:**\n\n**Actual:**\n\n- [ ] Repro confirmed\n- [ ] Root cause\n- [ ] Fix + "
+           "test"),
+       QStringLiteral("P1")},
+  };
+  return kTemplates;
+}
+}  // namespace
+
+QVariantList AppController::taskTemplates() const {
+  QVariantList out;
+  for(const auto& t : builtinTemplates()) {
+    QVariantMap m;
+    m["name"] = t.name;
+    m["title"] = t.title;
+    m["desc"] = t.desc;
+    out.append(m);
+  }
+  return out;
+}
+
+void AppController::createTaskFromTemplate(const QString& name) {
+  const auto& templates = builtinTemplates();
+  const auto it = std::find_if(templates.cbegin(), templates.cend(), [&](const TaskTemplate& t) {
+    return t.name == name;
+  });
+  if(it == templates.cend()) {
+    return;
+  }
+  const QVariantMap draft = newTaskDraft(QStringLiteral("todo"));
+  Task t;
+  t.id = draft.value("id").toString();
+  t.title = it->title;
+  t.desc = it->desc;
+  t.priority = it->priority;
+  t.status = QStringLiteral("todo");
+  t.statusChangedAt = QDateTime::currentDateTime();
+  m_tasks.upsert(t);
+  scheduleSave();
+  emit toast(tr("Created from template: %1").arg(it->name));
+  emit openTaskRequested(t.id);  // open the editor so the user fills in the blank
+}
+
 void AppController::saveTask(const QVariantMap& draft) {
   Task t;
   t.id = draft.value("id").toString().trimmed();
@@ -742,6 +847,7 @@ void AppController::saveTask(const QVariantMap& draft) {
   t.status = draft.value("status").toString();
   t.deadline = draft.value("deadline").toDate();
   t.branch = draft.value("branch").toString();
+  t.recurrence = draft.value("recurrence").toString();
   const bool isNew = draft.value("_isNew").toBool();
   if(isNew && t.title.trimmed().isEmpty()) {
     return;
@@ -763,6 +869,8 @@ void AppController::saveTask(const QVariantMap& draft) {
       // The editor exposes neither the tracker link nor the timer — carry both.
       t.trackedSeconds = prev.trackedSeconds;
       t.timerStartedAt = prev.timerStartedAt;
+      // Recurrence: honour the draft when it carries the key, else preserve.
+      t.recurrence = draft.contains("recurrence") ? draft.value("recurrence").toString() : prev.recurrence;
       t.externalId = prev.externalId;
       t.externalUrl = prev.externalUrl;
       t.externalProvider = prev.externalProvider;
@@ -1233,6 +1341,7 @@ QVariantMap AppController::taskById(const QString& id) const {
   m["archived"] = t.archived;
   m["trackedSeconds"] = t.trackedSeconds;
   m["isTiming"] = t.timerStartedAt.isValid();
+  m["recurrence"] = t.recurrence;
   return m;
 }
 
@@ -1965,6 +2074,10 @@ QJsonArray tasksToJson(const QVector<Task>& xs) {
     if(t.timerStartedAt.isValid()) {
       o["timerStartedAt"] = t.timerStartedAt.toString(Qt::ISODate);
     }
+    // Recurrence (HEAP-77) — omitted for non-recurring tasks.
+    if(!t.recurrence.isEmpty()) {
+      o["recurrence"] = t.recurrence;
+    }
     // Tracker-sync link — only emitted for synced tasks so locally-created
     // task JSON stays byte-identical to before HEAP-74.
     if(!t.externalId.isEmpty()) {
@@ -1997,6 +2110,7 @@ QVector<Task> tasksFromJson(const QJsonArray& a) {
     t.archived = o["archived"].toBool(false);
     t.trackedSeconds = o["trackedSeconds"].toInt(0);
     t.timerStartedAt = QDateTime::fromString(o["timerStartedAt"].toString(), Qt::ISODate);
+    t.recurrence = o["recurrence"].toString();
     t.externalId = o["externalId"].toString();
     t.externalUrl = o["externalUrl"].toString();
     t.externalProvider = o["externalProvider"].toString();
@@ -2801,6 +2915,17 @@ bool AppController::restoreFromBackup(const QString& fileName) {
 
 QVariantList AppController::commandPaletteEntries() const {
   QVariantList out;
+
+  // Task templates (HEAP-77) — "New from template: …" actions.
+  for(const auto& t : builtinTemplates()) {
+    QVariantMap m;
+    m["kind"] = "template";
+    m["label"] = QStringLiteral("New from template: ") + t.name;
+    m["sub"] = QStringLiteral("template");
+    m["templateName"] = t.name;
+    m["color"] = QStringLiteral("#b58ad7");
+    out.append(m);
+  }
 
   // Profiles themselves.
   for(const Profile& p : m_profiles) {

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -261,6 +261,11 @@ class AppController : public QObject {
   // the project prefix — used by QuickCapture so the user is reminded to
   // assign a real ticket id later.
   Q_INVOKABLE QVariantMap newQuickTaskDraft() const;
+  // Reusable task/checklist templates (HEAP-77). taskTemplates lists the
+  // built-ins ({name, title, desc}); createTaskFromTemplate drops a pre-filled
+  // task (checklist in the description) onto the board.
+  Q_INVOKABLE QVariantList taskTemplates() const;
+  Q_INVOKABLE void createTaskFromTemplate(const QString& name);
   Q_INVOKABLE void saveTask(const QVariantMap& draft);
   Q_INVOKABLE void deleteTask(const QString& id);
   Q_INVOKABLE bool canTransitionStatus(const QString& taskId, const QString& newStatus);

--- a/src/Models.cpp
+++ b/src/Models.cpp
@@ -22,6 +22,7 @@ QHash<int, QByteArray> TaskModel::roleNames() const {
       {RecentCommitsRole, "recentCommits"},
       {TrackedSecondsRole, "trackedSeconds"},
       {IsTimingRole, "isTiming"},
+      {RecurrenceRole, "recurrence"},
   };
 }
 
@@ -67,6 +68,8 @@ QVariant TaskModel::data(const QModelIndex& idx, int role) const {
       return t.trackedSeconds;
     case IsTimingRole:
       return t.timerStartedAt.isValid();
+    case RecurrenceRole:
+      return t.recurrence;
   }
   return {};
 }

--- a/src/Models.h
+++ b/src/Models.h
@@ -27,6 +27,9 @@ struct Task {
   // stopped). Live elapsed = trackedSeconds + (now - timerStartedAt).
   int trackedSeconds = 0;
   QDateTime timerStartedAt;
+  // Recurrence (HEAP-77): "" = none, else a chrono token like "every:weekday".
+  // Completing (moving to done) a recurring task spawns the next occurrence.
+  QString recurrence;
   // Tracker-sync link (HEAP-74): set when this task mirrors an external issue.
   // Empty for locally-created tasks. Used to route status pushes and to match
   // pulled issues back to their task on the next sync.
@@ -97,6 +100,7 @@ class TaskModel : public QAbstractListModel {
     RecentCommitsRole,
     TrackedSecondsRole,
     IsTimingRole,
+    RecurrenceRole,
   };
 
   explicit TaskModel(QObject* parent = nullptr) : QAbstractListModel(parent) {

--- a/src/recur/RecurrenceEngine.h
+++ b/src/recur/RecurrenceEngine.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <QDate>
+#include <QHash>
+#include <QString>
+
+// Pure recurrence engine (HEAP-77). Given a recurrence token produced by the
+// chrono parser (heap::chrono, e.g. "every:weekday") and a base date, returns
+// the next occurrence's date. Header-only + inline so it needs no library or
+// test wiring — include and call. Returns an invalid QDate for unknown/empty
+// tokens (the caller treats that as "no recurrence").
+namespace heap::recur {
+
+inline QDate nextOccurrence(const QString& recurrence, const QDate& from) {
+  if(recurrence.isEmpty() || !from.isValid()) {
+    return {};
+  }
+  const QString r = recurrence.trimmed().toLower();
+  if(r == QStringLiteral("every:day")) {
+    return from.addDays(1);
+  }
+  if(r == QStringLiteral("every:week")) {
+    return from.addDays(7);
+  }
+  if(r == QStringLiteral("every:weekday")) {
+    QDate d = from.addDays(1);
+    while(d.dayOfWeek() > 5) {  // Qt::Saturday=6, Qt::Sunday=7 → skip
+      d = d.addDays(1);
+    }
+    return d;
+  }
+  // "every:<dow>" — the next date strictly after `from` on that weekday.
+  static const QHash<QString, int> kDow = {{QStringLiteral("mon"), 1},
+                                           {QStringLiteral("tue"), 2},
+                                           {QStringLiteral("wed"), 3},
+                                           {QStringLiteral("thu"), 4},
+                                           {QStringLiteral("fri"), 5},
+                                           {QStringLiteral("sat"), 6},
+                                           {QStringLiteral("sun"), 7}};
+  if(r.startsWith(QStringLiteral("every:"))) {
+    const auto it = kDow.constFind(r.mid(6));
+    if(it != kDow.constEnd()) {
+      int delta = (it.value() - from.dayOfWeek() + 7) % 7;
+      if(delta == 0) {
+        delta = 7;  // land on the following week, never the same day
+      }
+      return from.addDays(delta);
+    }
+  }
+  return {};
+}
+
+// True when `recurrence` is a token this engine understands.
+inline bool isRecurring(const QString& recurrence) {
+  return nextOccurrence(recurrence, QDate(2000, 1, 1)).isValid();
+}
+
+}  // namespace heap::recur

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,12 @@ target_link_libraries(heap_chrono_tests PRIVATE
 
 add_test(NAME heap_chrono_tests COMMAND heap_chrono_tests)
 
+# Recurrence engine (HEAP-77) — header-only, so only the test TU compiles.
+add_executable(heap_recur_tests test_recur.cpp)
+target_include_directories(heap_recur_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_link_libraries(heap_recur_tests PRIVATE Qt6::Core GTest::gtest GTest::gtest_main)
+add_test(NAME heap_recur_tests COMMAND heap_recur_tests)
+
 add_executable(heap_git_tests
     test_branch_task_matcher.cpp
     test_git_watcher_parse.cpp

--- a/tests/test_appcontroller.cpp
+++ b/tests/test_appcontroller.cpp
@@ -312,6 +312,47 @@ TEST_F(AppControllerTest, TaskTimerStartStopAndSingleActive) {
   EXPECT_FALSE(timing(QStringLiteral("B")));
 }
 
+// ─── Recurring tasks + templates (HEAP-77) ────────────────────────────
+
+TEST_F(AppControllerTest, CompletingRecurringTaskSpawnsNext) {
+  Task t = mkTask(QStringLiteral("REC-1"), QStringLiteral("Daily standup"));
+  t.status = QStringLiteral("todo");
+  t.recurrence = QStringLiteral("every:day");
+  t.deadline = QDate(2026, 7, 4);
+  app_->tasks()->reset({t});
+  const int before = app_->tasks()->rowCount();
+
+  app_->moveTask(QStringLiteral("REC-1"), QStringLiteral("done"));
+
+  ASSERT_EQ(app_->tasks()->rowCount(), before + 1);
+  bool foundNext = false;
+  for(const Task& x : app_->tasks()->items()) {
+    if(x.id != QStringLiteral("REC-1") && x.recurrence == QStringLiteral("every:day")) {
+      EXPECT_EQ(x.status, QString("todo"));
+      EXPECT_EQ(x.deadline, QDate(2026, 7, 5));  // next day
+      foundNext = true;
+    }
+  }
+  EXPECT_TRUE(foundNext);
+}
+
+TEST_F(AppControllerTest, TemplateCreatesPrefilledChecklistTask) {
+  ASSERT_FALSE(app_->taskTemplates().isEmpty());
+  const int before = app_->tasks()->rowCount();
+
+  app_->createTaskFromTemplate(QStringLiteral("PR review"));
+
+  EXPECT_EQ(app_->tasks()->rowCount(), before + 1);
+  bool found = false;
+  for(const Task& x : app_->tasks()->items()) {
+    if(x.title.startsWith(QStringLiteral("Review PR"))) {
+      EXPECT_TRUE(x.desc.contains(QStringLiteral("- [ ]")));  // checklist markdown
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
 // ─── headless boot ────────────────────────────────────────────────────
 
 int main(int argc, char** argv) {

--- a/tests/test_recur.cpp
+++ b/tests/test_recur.cpp
@@ -1,0 +1,57 @@
+// Pure recurrence engine (HEAP-77): nextOccurrence() over the chrono parser's
+// "every:*" tokens. No Qt app needed — QDate is self-contained.
+
+#include "recur/RecurrenceEngine.h"
+
+#include <QDate>
+
+#include <gtest/gtest.h>
+
+using heap::recur::isRecurring;
+using heap::recur::nextOccurrence;
+
+TEST(Recur, EveryDayAndWeek) {
+  const QDate d(2026, 7, 4);
+  EXPECT_EQ(nextOccurrence(QStringLiteral("every:day"), d), d.addDays(1));
+  EXPECT_EQ(nextOccurrence(QStringLiteral("every:week"), d), d.addDays(7));
+}
+
+TEST(Recur, EveryWeekdaySkipsWeekend) {
+  QDate fri(2026, 7, 4);
+  while(fri.dayOfWeek() != 5) {  // first Friday on/after the base
+    fri = fri.addDays(1);
+  }
+  const QDate next = nextOccurrence(QStringLiteral("every:weekday"), fri);
+  EXPECT_EQ(next.dayOfWeek(), 1);   // Monday
+  EXPECT_EQ(next, fri.addDays(3));  // Fri + 3 = Mon
+
+  QDate wed(2026, 7, 4);
+  while(wed.dayOfWeek() != 3) {
+    wed = wed.addDays(1);
+  }
+  EXPECT_EQ(nextOccurrence(QStringLiteral("every:weekday"), wed), wed.addDays(1));  // Wed → Thu
+}
+
+TEST(Recur, EveryDowLandsStrictlyAfter) {
+  QDate mon(2026, 7, 4);
+  while(mon.dayOfWeek() != 1) {
+    mon = mon.addDays(1);
+  }
+  EXPECT_EQ(nextOccurrence(QStringLiteral("every:mon"), mon), mon.addDays(7));  // same weekday → next week
+  EXPECT_EQ(nextOccurrence(QStringLiteral("every:wed"), mon), mon.addDays(2));  // Mon → Wed
+}
+
+TEST(Recur, UnknownEmptyAndInvalidYieldInvalid) {
+  const QDate d(2026, 7, 4);
+  EXPECT_FALSE(nextOccurrence(QString(), d).isValid());
+  EXPECT_FALSE(nextOccurrence(QStringLiteral("every:month"), d).isValid());  // parser emits no monthly token
+  EXPECT_FALSE(nextOccurrence(QStringLiteral("nonsense"), d).isValid());
+  EXPECT_FALSE(nextOccurrence(QStringLiteral("every:day"), QDate()).isValid());
+}
+
+TEST(Recur, IsRecurringMatchesEngine) {
+  EXPECT_TRUE(isRecurring(QStringLiteral("every:weekday")));
+  EXPECT_TRUE(isRecurring(QStringLiteral("every:fri")));
+  EXPECT_FALSE(isRecurring(QString()));
+  EXPECT_FALSE(isRecurring(QStringLiteral("every:month")));
+}


### PR DESCRIPTION
### Recurrence
The chrono parser already tokenizes `every…`; this consumes it end-to-end.
- `Task` gains a `recurrence` field (persisted byte-stable, carried across edits).
- Pure **header-only** `heap::recur::nextOccurrence` over `every:day`/`week`/`weekday`/`<dow>` — weekday skips the weekend; `<dow>` lands strictly after.
- **Completing** (moving to done) a recurring task **spawns the next occurrence** — a fresh todo with the shifted deadline and a new id.
- QuickCapture persists the parsed recurrence; TaskEditor gains a recurrence dropdown; the card shows a 🔁 chip.

### Templates
- Built-in **PR review** / **Release checklist** / **Bug report** templates (checklists as `- [ ]` markdown in the description).
- `taskTemplates()` + `createTaskFromTemplate()`; **"New from template: …"** rows in the command palette (`Ctrl+K`).

### Acceptance
- A task set to "every weekday" regenerates on completion. ✅
- A template creates a pre-filled task/checklist. ✅

### Tests
- `heap_recur_tests` — the engine (day/week/weekday-weekend-skip/`<dow>`/unknown), robust (no hardcoded weekday constants).
- `heap_appcontroller_tests` — completing a recurring task spawns the next with a shifted deadline; a template creates a checklist task.
- Full suite green locally (**26/26**).

Note: monthly recurrence is out of scope — the chrono parser emits no `every:month` token yet.

Closes HEAP-77.