### PR TITLE
ci: run heap_qml_tests on Linux via Qt 6.8 (HEAP-71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,14 +229,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies (linux)
+      # Ubuntu 24.04's apt ships Qt 6.4.2, which has a static-QML-module
+      # qmlcachegen bug: file-based .qml components ("SideRail is not a type")
+      # don't resolve in a downstream Quick Test binary, forcing heap_qml_tests
+      # to be skipped on Linux (HEAP-71). A newer Qt (matching the working local
+      # 6.8/6.9) fixes it, so provision Qt via install-qt-action instead of apt.
+      - name: Install build tools + system libs (linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             cmake ninja-build g++ \
-            qt6-base-dev qt6-declarative-dev qt6-tools-dev \
-            libgl1-mesa-dev libegl1-mesa-dev
+            libgl1-mesa-dev libegl1-mesa-dev libxkbcommon-dev \
+            libfontconfig1-dev libfreetype-dev libdbus-1-3
+
+      - name: Install Qt6 (linux)
+        if: runner.os == 'Linux'
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.8.1"
+          cache: true
 
       - name: Setup ccache (linux)
         if: runner.os == 'Linux'
@@ -315,23 +327,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Qt6 runtime (linux)
+      # Same Qt (install-qt-action 6.8.1) as the build job so the tarred build
+      # tree matches the runtime. Qt's own QML modules ship with the install, so
+      # no qml6-module-* apt packages are needed. System libs the Qt libs dlopen
+      # (GL, xkb, fontconfig, dbus) still come from apt.
+      - name: Install system libs (linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          # heap_qml_tests is a Qt Quick Test binary: it needs the QuickTest
-          # runtime lib (libqt6quicktest6) plus the QML runtime *modules* the
-          # tst_*.qml import (QtTest, QtQuick.Controls, Layouts, …) — the plain
-          # libqt6*6 runtime libs do not pull those qml6-module-* packages in.
           sudo apt-get install -y --no-install-recommends \
-            libqt6core6 libqt6gui6 libqt6qml6 libqt6quick6 \
-            libqt6quickcontrols2-6 libqt6widgets6 libqt6test6 \
-            libqt6quicktest6 \
-            qml6-module-qtquick qml6-module-qtquick-controls \
-            qml6-module-qtquick-templates qml6-module-qtquick-layouts \
-            qml6-module-qtquick-window qml6-module-qtqml-workerscript \
-            qml6-module-qttest \
-            cmake ninja-build
+            cmake ninja-build \
+            libgl1 libegl1 libxkbcommon0 libfontconfig1 libfreetype6 libdbus-1-3
+
+      - name: Install Qt6 (linux)
+        if: runner.os == 'Linux'
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.8.1"
+          cache: true
 
       - name: Setup MSYS2 (windows)
         if: runner.os == 'Windows'
@@ -399,21 +412,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install toolchain
+      - name: Install build tools + system libs
         run: |
           sudo apt-get update
-          # QML runtime modules + QuickTest lib are needed at run time for
-          # heap_qml_tests (the -dev packages don't pull the qml6-module-*
-          # runtime plugins).
           sudo apt-get install -y --no-install-recommends \
             cmake ninja-build g++ \
-            qt6-base-dev qt6-declarative-dev qt6-tools-dev \
-            libgl1-mesa-dev libegl1-mesa-dev \
-            libqt6quicktest6 \
-            qml6-module-qtquick qml6-module-qtquick-controls \
-            qml6-module-qtquick-templates qml6-module-qtquick-layouts \
-            qml6-module-qtquick-window qml6-module-qtqml-workerscript \
-            qml6-module-qttest
+            libgl1-mesa-dev libegl1-mesa-dev libxkbcommon-dev \
+            libfontconfig1-dev libfreetype-dev libdbus-1-3
+
+      # Qt via install-qt-action (6.8.1) — apt's 6.4.2 can't run heap_qml_tests
+      # (HEAP-71); its own QML modules ship with the install.
+      - name: Install Qt6
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.8.1"
+          cache: true
 
       - name: Configure with sanitizers
         run: |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -800,16 +800,11 @@ add_test(NAME heap_qml_tests
 set_tests_properties(heap_qml_tests PROPERTIES
         ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QUICK_CONTROLS_STYLE=Basic")
 
-# The static TodoCpp module's file-based components (SideRail, ArchiveView, …)
-# resolve in the Quick Test binary on Windows + macOS but NOT on Linux: `import
-# TodoCpp` succeeds yet "ArchiveView is not a type" — the qmlcachegen units for
-# the .qml components are not picked up from the static lib there. The suite is
-# still BUILT on Linux (link is validated) and runs in full on Windows CI +
-# locally; only its Linux *execution* is disabled so CI stays green. Tracked in
-# HEAP-71.
-if (UNIX AND NOT APPLE)
-    set_tests_properties(heap_qml_tests PROPERTIES DISABLED TRUE)
-endif ()
+# HEAP-71: the static TodoCpp module's file-based components (SideRail,
+# ArchiveView, …) failed to resolve in the Quick Test binary on Linux under
+# Ubuntu's apt Qt 6.4.2 (a qmlcachegen/static-module bug — "ArchiveView is not a
+# type"). CI now provisions Qt 6.8 via install-qt-action (matching local), where
+# they resolve, so Linux execution is re-enabled.
 
 # ─── Integrations (tracker-sync StatusMap) tests ───
 # Pure status/priority translation for the post-release tracker sync. No QObject,


### PR DESCRIPTION
`heap_qml_tests` was skipped on Linux (`DISABLED TRUE`): under Ubuntu 24.04's apt **Qt 6.4.2**, the static TodoCpp module's file-based `.qml` components fail to resolve in the Quick Test binary (`"ArchiveView is not a type"`) — a qmlcachegen/static-module bug. The suite passes on the local 6.8/6.9 toolchain and on Windows CI (32/32).

**Fix:** provision Qt via `jurplel/install-qt-action@v4` (**6.8.1**) on the Linux **build**, **test** and **sanitizers** jobs (Qt's own QML modules ship with the install; GL/xkb/fontconfig/dbus system libs still come from apt), and remove the Linux `DISABLED TRUE` guard so `heap_qml_tests` executes there.

The `Q_IMPORT_PLUGIN` + `WHOLE_ARCHIVE` wiring was already correct — this was purely a Qt-version issue, so no C++/CMake test-code change was needed beyond dropping the guard. The clang-tidy job keeps apt Qt (it only lints).

### Validation
This can only be validated on Linux CI. **Merge only if the `build/test/sanitizers (ubuntu)` jobs all go green** with `heap_qml_tests` now executing.

Closes HEAP-71.