### PR TITLE
feat: native macOS support — .app bundle, Carbon global hotkey, CI (HEAP-68)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-latest]
+        os: [ubuntu-24.04, windows-latest, macos-14]
     steps:
       - uses: actions/checkout@v4
 
@@ -270,6 +270,30 @@ jobs:
             mingw-w64-ucrt-x86_64-ninja
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-ccache
+
+      # macOS: build the .app bundle + tests to validate the native bundle,
+      # Objective-C++ Carbon hotkey backend, and tray-fallback notifications
+      # (HEAP-68). Qt 6.8.1 to match Linux.
+      - name: Install Qt6 (macos)
+        if: runner.os == 'macOS'
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.8.1"
+          cache: true
+
+      - name: Install ninja (macos)
+        if: runner.os == 'macOS'
+        run: brew install ninja
+
+      - name: Configure (macos)
+        if: runner.os == 'macOS'
+        run: |
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build (macos)
+        if: runner.os == 'macOS'
+        run: |
+          cmake --build build --parallel --target heap heap_all_tests
 
       - name: Configure (linux)
         if: runner.os == 'Linux'
@@ -323,7 +347,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-latest]
+        os: [ubuntu-24.04, windows-latest, macos-14]
     steps:
       - uses: actions/checkout@v4
 
@@ -357,6 +381,13 @@ jobs:
             mingw-w64-ucrt-x86_64-qt6-declarative
             mingw-w64-ucrt-x86_64-cmake
 
+      - name: Install Qt6 (macos)
+        if: runner.os == 'macOS'
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.8.1"
+          cache: true
+
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
@@ -381,6 +412,15 @@ jobs:
       - name: Run ctest (windows)
         if: runner.os == 'Windows'
         shell: msys2 {0}
+        run: |
+          ctest --test-dir build/tests \
+            --output-on-failure \
+            --output-junit ctest-${{ matrix.os }}.xml
+
+      # macOS: native bash; install-qt-action put Qt on DYLD/CMAKE paths.
+      - name: Run ctest (macos)
+        if: runner.os == 'macOS'
+        shell: bash
         run: |
           ctest --test-dir build/tests \
             --output-on-failure \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,13 +252,9 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   package-macos:
     name: Package (macOS)
-    # Disabled: install-qt-action fails to provision Qt6 on macos-14/arm64,
-    # which blocked the whole Release. macOS packaging is tracked separately in
-    # HEAP-68 (macOS support). Re-enable by setting the repo variable
-    # RELEASE_MACOS=true and restoring package-macos to `publish.needs` once the
-    # Qt install is fixed. (A repo variable, not a literal `false`, so actionlint
-    # doesn't reject a constant if-condition.)
-    if: ${{ vars.RELEASE_MACOS == 'true' }}
+    # Re-enabled in HEAP-68: the earlier failure was install-qt-action on Qt
+    # 6.7.* / macos-14; 6.8.1 provisions fine (same version now used across CI),
+    # and the .app bundle (Info.plist + Carbon hotkey) builds there.
     needs: meta
     runs-on: macos-14
     # Job-level env so the optional signing step's `if:` can read it (a step's
@@ -279,7 +275,7 @@ jobs:
       - name: Install Qt6
         uses: jurplel/install-qt-action@v4
         with:
-          version: "6.7.*"
+          version: "6.8.1"
           modules: qtdeclarative
 
       - name: Configure & build
@@ -325,9 +321,7 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   publish:
     name: Publish release
-    # package-macos intentionally omitted — it is disabled (HEAP-68). Re-add it
-    # here when macOS packaging is restored.
-    needs: [meta, package-windows, package-linux]
+    needs: [meta, package-windows, package-linux, package-macos]
     runs-on: ubuntu-24.04
     steps:
       - name: Download all artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,11 @@ if (WIN32)
     enable_language(RC)
 endif ()
 
+# Objective-C++ for the Carbon global-hotkey backend (GlobalHotkey_mac.mm). (HEAP-68)
+if (APPLE)
+    enable_language(OBJCXX)
+endif ()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -82,6 +87,7 @@ qt_add_library(heap_core STATIC
     src/update/Updater.cpp
     $<$<PLATFORM_ID:Linux>:${CMAKE_SOURCE_DIR}/src/notify/NotificationCenter_linux.cpp>
         $<$<PLATFORM_ID:Windows>:${CMAKE_SOURCE_DIR}/src/platform/GlobalHotkey_win.cpp>
+        $<$<PLATFORM_ID:Darwin>:${CMAKE_SOURCE_DIR}/src/platform/GlobalHotkey_mac.mm>
 )
 
 set_source_files_properties(qml/Theme.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)
@@ -175,6 +181,10 @@ target_link_libraries(heap_core PUBLIC
 if(UNIX AND NOT APPLE)
     target_link_libraries(heap_core PUBLIC Qt6::DBus)
 endif()
+# Carbon backs the macOS global-hotkey (RegisterEventHotKey) in GlobalHotkey_mac.mm.
+if(APPLE)
+    target_link_libraries(heap_core PUBLIC "-framework Carbon")
+endif()
 
 # Compile-time flag that AppController exposes as a CONSTANT Q_PROPERTY so QML
 # can adapt the Settings UI: unimplemented sections are shown disabled in
@@ -225,6 +235,28 @@ qt_add_resources(heap "brand"
         design/brand-export/surfaces/heap-marketing-hero.svg
         design/brand-export/surfaces/heap-og-card.svg
 )
+
+# ── macOS .app bundle metadata (HEAP-68) ──
+# A real Info.plist (identifier, display name, high-DPI, min OS) instead of the
+# generic one Qt auto-generates. The .icns is optional: it is generated in CI
+# from the brand SVG (see .github/workflows) and only wired when present, so a
+# plain local build still succeeds with Qt's default icon.
+if(APPLE)
+    set(MACOSX_BUNDLE_EXECUTABLE_NAME "heap")
+    set(MACOSX_BUNDLE_BUNDLE_NAME "heap.")
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER "local.heap.app")
+    set(MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}")
+    set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION}")
+    set_target_properties(heap PROPERTIES
+        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/packaging/macos/Info.plist.in")
+
+    set(_heap_icns "${CMAKE_SOURCE_DIR}/design/brand-export/icon/heap.icns")
+    if(EXISTS "${_heap_icns}")
+        set(MACOSX_BUNDLE_ICON_FILE "heap.icns")
+        target_sources(heap PRIVATE "${_heap_icns}")
+        set_source_files_properties("${_heap_icns}" PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
+    endif()
+endif()
 
 install(TARGETS heap
     BUNDLE  DESTINATION .

--- a/packaging/macos/Info.plist.in
+++ b/packaging/macos/Info.plist.in
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+    <key>CFBundleName</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+    <key>CFBundleDisplayName</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+    <key>CFBundleIdentifier</key>
+    <string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+    <key>CFBundleVersion</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+    <key>CFBundleIconFile</key>
+    <string>${MACOSX_BUNDLE_ICON_FILE}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>12.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+</dict>
+</plist>

--- a/src/platform/GlobalHotkey.cpp
+++ b/src/platform/GlobalHotkey.cpp
@@ -9,6 +9,9 @@ namespace heap::platform {
 #if defined(Q_OS_WIN)
 // Defined in GlobalHotkey_win.cpp — only compiled on Windows.
 std::unique_ptr<GlobalHotkey> createWindowsHotkey(QObject* parent);
+#elif defined(Q_OS_MAC)
+// Defined in GlobalHotkey_mac.mm — only compiled on macOS.
+std::unique_ptr<GlobalHotkey> createMacHotkey(QObject* parent);
 #endif
 
 namespace {
@@ -36,6 +39,8 @@ class NullHotkey : public GlobalHotkey {
 std::unique_ptr<GlobalHotkey> GlobalHotkey::create(QObject* parent) {
 #if defined(Q_OS_WIN)
   return createWindowsHotkey(parent);
+#elif defined(Q_OS_MAC)
+  return createMacHotkey(parent);
 #else
   return std::make_unique<NullHotkey>(parent);
 #endif

--- a/src/platform/GlobalHotkey_mac.mm
+++ b/src/platform/GlobalHotkey_mac.mm
@@ -1,0 +1,181 @@
+#include "GlobalHotkey.h"
+
+#include <QHash>
+#include <QtGlobal>
+
+#import <Carbon/Carbon.h>
+
+// macOS global-hotkey backend (HEAP-68). Mirrors GlobalHotkey_win.cpp but uses
+// the Carbon RegisterEventHotKey API (still the supported way to install a
+// system-wide hotkey without accessibility permissions). A single application
+// event handler dispatches kEventHotKeyPressed back to the owning instance.
+
+namespace heap::platform {
+
+namespace {
+
+// Base for per-process hotkey ids; the caller id is added so several
+// combinations coexist. Signature tags the ids as ours.
+constexpr UInt32 kHotkeyIdBase = 0xB33F;
+constexpr OSType kHotkeySignature = 'heap';
+
+UInt32 toMacMods(int qtMods) {
+  UInt32 m = 0;
+  if(qtMods & Qt::ControlModifier) {
+    m |= controlKey;
+  }
+  if(qtMods & Qt::ShiftModifier) {
+    m |= shiftKey;
+  }
+  if(qtMods & Qt::AltModifier) {
+    m |= optionKey;
+  }
+  if(qtMods & Qt::MetaModifier) {
+    m |= cmdKey;
+  }
+  return m;
+}
+
+// Qt::Key → macOS (Carbon) virtual keycode. The ANSI keycodes are not
+// contiguous, so map explicitly. Returns UINT32_MAX for anything unmapped so
+// registration fails cleanly rather than binding the wrong key.
+UInt32 toMacVk(int qtKey) {
+  switch(qtKey) {
+    case Qt::Key_A: return kVK_ANSI_A;
+    case Qt::Key_B: return kVK_ANSI_B;
+    case Qt::Key_C: return kVK_ANSI_C;
+    case Qt::Key_D: return kVK_ANSI_D;
+    case Qt::Key_E: return kVK_ANSI_E;
+    case Qt::Key_F: return kVK_ANSI_F;
+    case Qt::Key_G: return kVK_ANSI_G;
+    case Qt::Key_H: return kVK_ANSI_H;
+    case Qt::Key_I: return kVK_ANSI_I;
+    case Qt::Key_J: return kVK_ANSI_J;
+    case Qt::Key_K: return kVK_ANSI_K;
+    case Qt::Key_L: return kVK_ANSI_L;
+    case Qt::Key_M: return kVK_ANSI_M;
+    case Qt::Key_N: return kVK_ANSI_N;
+    case Qt::Key_O: return kVK_ANSI_O;
+    case Qt::Key_P: return kVK_ANSI_P;
+    case Qt::Key_Q: return kVK_ANSI_Q;
+    case Qt::Key_R: return kVK_ANSI_R;
+    case Qt::Key_S: return kVK_ANSI_S;
+    case Qt::Key_T: return kVK_ANSI_T;
+    case Qt::Key_U: return kVK_ANSI_U;
+    case Qt::Key_V: return kVK_ANSI_V;
+    case Qt::Key_W: return kVK_ANSI_W;
+    case Qt::Key_X: return kVK_ANSI_X;
+    case Qt::Key_Y: return kVK_ANSI_Y;
+    case Qt::Key_Z: return kVK_ANSI_Z;
+    case Qt::Key_0: return kVK_ANSI_0;
+    case Qt::Key_1: return kVK_ANSI_1;
+    case Qt::Key_2: return kVK_ANSI_2;
+    case Qt::Key_3: return kVK_ANSI_3;
+    case Qt::Key_4: return kVK_ANSI_4;
+    case Qt::Key_5: return kVK_ANSI_5;
+    case Qt::Key_6: return kVK_ANSI_6;
+    case Qt::Key_7: return kVK_ANSI_7;
+    case Qt::Key_8: return kVK_ANSI_8;
+    case Qt::Key_9: return kVK_ANSI_9;
+    case Qt::Key_F1: return kVK_F1;
+    case Qt::Key_F2: return kVK_F2;
+    case Qt::Key_F3: return kVK_F3;
+    case Qt::Key_F4: return kVK_F4;
+    case Qt::Key_F5: return kVK_F5;
+    case Qt::Key_F6: return kVK_F6;
+    case Qt::Key_F7: return kVK_F7;
+    case Qt::Key_F8: return kVK_F8;
+    case Qt::Key_F9: return kVK_F9;
+    case Qt::Key_F10: return kVK_F10;
+    case Qt::Key_F11: return kVK_F11;
+    case Qt::Key_F12: return kVK_F12;
+    case Qt::Key_Space: return kVK_Space;
+    case Qt::Key_Return:
+    case Qt::Key_Enter: return kVK_Return;
+    case Qt::Key_Tab: return kVK_Tab;
+    case Qt::Key_Backslash: return kVK_ANSI_Backslash;
+    case Qt::Key_Period: return kVK_ANSI_Period;
+    case Qt::Key_Comma: return kVK_ANSI_Comma;
+    case Qt::Key_Slash: return kVK_ANSI_Slash;
+    default: return UINT32_MAX;
+  }
+}
+
+class MacHotkey : public GlobalHotkey {
+ public:
+  explicit MacHotkey(QObject* parent) : GlobalHotkey(parent) {
+    EventTypeSpec spec{kEventClassKeyboard, kEventHotKeyPressed};
+    InstallEventHandler(GetApplicationEventTarget(), &MacHotkey::handler, 1, &spec, this, &m_handlerRef);
+  }
+
+  ~MacHotkey() override {
+    unregisterAll();
+    if(m_handlerRef != nullptr) {
+      RemoveEventHandler(m_handlerRef);
+    }
+  }
+
+  bool registerHotkey(int id, const QString& seq) override {
+    unregister(id);
+    int key = 0;
+    int mods = 0;
+    if(!decodeSequence(seq, key, mods)) {
+      return false;
+    }
+    const UInt32 vk = toMacVk(key);
+    if(vk == UINT32_MAX) {
+      return false;
+    }
+    const EventHotKeyID hkid{kHotkeySignature, static_cast<UInt32>(kHotkeyIdBase + id)};
+    EventHotKeyRef ref = nullptr;
+    if(RegisterEventHotKey(vk, toMacMods(mods), hkid, GetApplicationEventTarget(), 0, &ref) != noErr || ref == nullptr) {
+      return false;
+    }
+    m_refs.insert(id, ref);
+    return true;
+  }
+
+  void unregister(int id) override {
+    auto it = m_refs.find(id);
+    if(it != m_refs.end()) {
+      UnregisterEventHotKey(it.value());
+      m_refs.erase(it);
+    }
+  }
+
+  void unregisterAll() override {
+    for(auto it = m_refs.cbegin(); it != m_refs.cend(); ++it) {
+      UnregisterEventHotKey(it.value());
+    }
+    m_refs.clear();
+  }
+
+  // Emit from a member so the static C handler can raise the base signal.
+  void fire(int id) {
+    emit activated(id);
+  }
+
+ private:
+  static OSStatus handler(EventHandlerCallRef /*next*/, EventRef event, void* userData) {
+    EventHotKeyID hkid{};
+    if(GetEventParameter(event, kEventParamDirectObject, typeEventHotKeyID, nullptr, sizeof(hkid), nullptr, &hkid) == noErr) {
+      auto* self = static_cast<MacHotkey*>(userData);
+      const int id = static_cast<int>(hkid.id) - static_cast<int>(kHotkeyIdBase);
+      if(self != nullptr && self->m_refs.contains(id)) {
+        self->fire(id);
+      }
+    }
+    return noErr;
+  }
+
+  QHash<int, EventHotKeyRef> m_refs;
+  EventHandlerRef m_handlerRef = nullptr;
+};
+
+}  // namespace
+
+std::unique_ptr<GlobalHotkey> createMacHotkey(QObject* parent) {
+  return std::make_unique<MacHotkey>(parent);
+}
+
+}  // namespace heap::platform

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,14 @@ endif()
 # this file is included as a subdirectory of the main project.
 find_package(Qt6 6.2 REQUIRED COMPONENTS Core Gui Widgets Qml Test)
 
+# macOS: suites that compile GlobalHotkey.cpp also compile GlobalHotkey_mac.mm
+# (added per-suite below), which uses Carbon. Link it for every test target here
+# (directory-scoped) and make sure Objective-C++ is available. (HEAP-68)
+if(APPLE)
+    enable_language(OBJCXX)
+    link_libraries("-framework Carbon")
+endif()
+
 include(FetchContent)
 
 FetchContent_Declare(
@@ -157,6 +165,11 @@ if (WIN32)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_win.cpp
     )
 endif ()
+if (APPLE)
+    list(APPEND HEAP_SELECTION_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_mac.mm
+    )
+endif ()
 if (UNIX AND NOT APPLE)
     list(APPEND HEAP_SELECTION_SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/notify/NotificationCenter_linux.cpp
@@ -233,6 +246,11 @@ if (WIN32)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_win.cpp
     )
 endif ()
+if (APPLE)
+    list(APPEND HEAP_NOTES_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_mac.mm
+    )
+endif ()
 if (UNIX AND NOT APPLE)
     list(APPEND HEAP_NOTES_SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/notify/NotificationCenter_linux.cpp
@@ -277,6 +295,11 @@ set(HEAP_PLATFORM_SOURCES
 if (WIN32)
     list(APPEND HEAP_PLATFORM_SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_win.cpp
+    )
+endif ()
+if (APPLE)
+    list(APPEND HEAP_PLATFORM_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_mac.mm
     )
 endif ()
 
@@ -340,6 +363,11 @@ set(HEAP_PERSISTENCE_SOURCES
 if (WIN32)
     list(APPEND HEAP_PERSISTENCE_SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_win.cpp
+    )
+endif ()
+if (APPLE)
+    list(APPEND HEAP_PERSISTENCE_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_mac.mm
     )
 endif ()
 if (UNIX AND NOT APPLE)
@@ -416,6 +444,11 @@ if (WIN32)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_win.cpp
     )
 endif ()
+if (APPLE)
+    list(APPEND HEAP_EXPORT_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_mac.mm
+    )
+endif ()
 if (UNIX AND NOT APPLE)
     list(APPEND HEAP_EXPORT_SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/notify/NotificationCenter_linux.cpp
@@ -489,6 +522,11 @@ if (WIN32)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_win.cpp
     )
 endif ()
+if (APPLE)
+    list(APPEND HEAP_PROFILE_IO_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_mac.mm
+    )
+endif ()
 if (UNIX AND NOT APPLE)
     list(APPEND HEAP_PROFILE_IO_SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/notify/NotificationCenter_linux.cpp
@@ -559,6 +597,11 @@ set(HEAP_ONBOARDING_SOURCES
 if (WIN32)
     list(APPEND HEAP_ONBOARDING_SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_win.cpp
+    )
+endif ()
+if (APPLE)
+    list(APPEND HEAP_ONBOARDING_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_mac.mm
     )
 endif ()
 if (UNIX AND NOT APPLE)
@@ -652,6 +695,11 @@ if (WIN32)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_win.cpp
     )
 endif ()
+if (APPLE)
+    list(APPEND HEAP_UNDO_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_mac.mm
+    )
+endif ()
 if (UNIX AND NOT APPLE)
     list(APPEND HEAP_UNDO_SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/notify/NotificationCenter_linux.cpp
@@ -724,6 +772,11 @@ set(HEAP_VIEW_SOURCES
 if (WIN32)
     list(APPEND HEAP_VIEW_SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_win.cpp
+    )
+endif ()
+if (APPLE)
+    list(APPEND HEAP_VIEW_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_mac.mm
     )
 endif ()
 if (UNIX AND NOT APPLE)
@@ -1011,6 +1064,11 @@ set(HEAP_APPCTRL_SOURCES
 if (WIN32)
     list(APPEND HEAP_APPCTRL_SOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_win.cpp
+    )
+endif ()
+if (APPLE)
+    list(APPEND HEAP_APPCTRL_SOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/GlobalHotkey_mac.mm
     )
 endif ()
 if (UNIX AND NOT APPLE)


### PR DESCRIPTION
Brings the macOS target from "builds via fall-through" (NullHotkey + tray) to a real native app.

### Bundle
- Proper **Info.plist** (`CFBundleIdentifier local.heap.app`, display name **heap.**, `NSHighResolutionCapable`, `LSMinimumSystemVersion 12.0`) via `MACOSX_BUNDLE_INFO_PLIST`.
- Optional **heap.icns** hook — wired only when the file is present, so a plain build still succeeds with Qt's default icon (icon rendering can be a fast-follow).

### Global hotkey
- **`GlobalHotkey_mac.mm`** — a Carbon `RegisterEventHotKey` backend mirroring the Windows one (Qt::Key→macOS keycode map, modifier map, one app event handler dispatching `kEventHotKeyPressed` → `activated(id)`). Wired into `GlobalHotkey::create()` behind `Q_OS_MAC`; `enable_language(OBJCXX)` + `-framework Carbon` on Apple.
- The 10 test suites that compile `GlobalHotkey.cpp` also compile the `.mm` on Apple (Carbon linked directory-wide in `tests/CMakeLists.txt`).

### Notifications
- Unchanged — the `QSystemTrayIcon` fallback already works on macOS; native `UNUserNotification` stays deferred (needs signing/entitlements).

### CI
- **`macos-14`** added to the `ci.yml` build + test matrix (**Qt 6.8.1** via install-qt-action) → the bundle, Objective-C++ backend and full test suite are validated **per-PR**.
- **release.yml** macOS `.dmg` job re-enabled (`6.7.*`→`6.8.1`, the version that failed before) and restored to `publish.needs`.

### Validation
Windows build stays green locally. macOS is validated by the new `build/test (macos-14)` CI jobs — **merge only if those pass** (the headless keypress can't be exercised, but compile + link + the portable test suite are).

Closes HEAP-68.