### PR TITLE
ci: fix macOS Release Qt install (unblocks the whole Release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,10 +273,12 @@ jobs:
         run: brew install ninja
 
       - name: Install Qt6
+        # No `modules:` — for 6.8.1 qtdeclarative is an essential module bundled
+        # with the base install; passing it to aqt errors ("packages
+        # ['qtdeclarative'] were not found"). Mirrors the working ci.yml macOS job.
         uses: jurplel/install-qt-action@v4
         with:
           version: "6.8.1"
-          modules: qtdeclarative
 
       - name: Configure & build
         run: |
@@ -321,7 +323,15 @@ jobs:
   # ──────────────────────────────────────────────────────────────────
   publish:
     name: Publish release
+    # Wait for macOS (so its .dmg is uploaded before we gather artifacts) but
+    # don't let it block the release: as long as Windows + Linux packaged, we
+    # publish whatever artifacts exist. A macOS failure no longer sinks the
+    # whole release (it did twice before).
     needs: [meta, package-windows, package-linux, package-macos]
+    if: >-
+      ${{ always() && needs.meta.result == 'success'
+          && needs.package-windows.result == 'success'
+          && needs.package-linux.result == 'success' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
The Release workflow was failing (run 28703031714): **Package (macOS)** died at *Install Qt6*, and since `publish` needed it, **no Windows/Linux release was produced either**.

Root cause: the macOS step passed `modules: qtdeclarative`, but for **Qt 6.8.1** `qtdeclarative` is an *essential* module bundled with the base install — `aqt` errors `The packages ['qtdeclarative'] were not found`. (The `ci.yml` macOS build job works precisely because it passes no `modules:`.)

**Fixes:**
1. Drop the `modules: qtdeclarative` line from the macOS Install Qt6 step.
2. Make `publish` resilient — it still waits for `package-macos` (so the `.dmg` uploads first) but runs as long as **Windows + Linux** packaged, so a macOS hiccup never sinks the whole release again.

Windows + Linux packaging already pass; this makes macOS install Qt like CI does, and decouples the cross-platform release from macOS.