### PR TITLE
ci: fix macOS release .dmg — re-sign bundle + drag-install layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,6 +494,68 @@ jobs:
           ctest --test-dir build-san/tests --output-on-failure
 
   # ──────────────────────────────────────────────────────────────────
+  # 7b. macOS packaging smoke-test.
+  # Exercises the release `.dmg` assembly on every push/PR using the ad-hoc
+  # signing path (no secrets), so a change that re-breaks the bundle signature
+  # or the dmg layout fails HERE — via `codesign --verify` — instead of
+  # silently shipping a "damaged" artifact from the tag-triggered Release
+  # workflow. Mirrors release.yml's package-macos (arm64, deployment target
+  # 12.0, macdeployqt relocation guard, ad-hoc sign, hdiutil drag-install dmg).
+  # ──────────────────────────────────────────────────────────────────
+  package-macos-smoke:
+    name: package (macOS smoke)
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Qt6
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "6.8.1"
+          cache: true
+
+      - name: Install ninja
+        run: brew install ninja
+
+      - name: Configure & build
+        run: |
+          set -eu
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DHEAP_BUILD_TESTS=OFF \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0
+          cmake --build build --parallel --target heap
+          test -d build/heap.app
+
+      - name: Deploy + ad-hoc sign + assemble dmg
+        run: |
+          set -eu
+          macdeployqt build/heap.app -qmldir="$PWD/qml"
+          test -d build/heap.app/Contents/Frameworks/QtCore.framework
+          if otool -L build/heap.app/Contents/MacOS/heap | grep -Eiq '/Users/runner/work/.*Qt|/aqt'; then
+            echo "::error::macdeployqt left absolute Qt paths — relocation failed"
+            exit 1
+          fi
+          # The re-sign + verify that the original workflow was missing: an
+          # invalidated signature (the "damaged" bug) fails this verify.
+          codesign --force --deep --sign - build/heap.app
+          codesign --verify --deep --strict --verbose=2 build/heap.app
+          STAGE="$RUNNER_TEMP/dmg"
+          mkdir -p "$STAGE"
+          cp -R build/heap.app "$STAGE/"
+          ln -s /Applications "$STAGE/Applications"
+          hdiutil create -volname "heap" -srcfolder "$STAGE" -fs HFS+ -format UDZO -ov smoke.dmg
+
+      - name: Verify dmg mounts with the app + Applications target
+        run: |
+          set -eu
+          hdiutil attach smoke.dmg -nobrowse -mountpoint /Volumes/heap
+          test -d /Volumes/heap/heap.app
+          test -L /Volumes/heap/Applications
+          hdiutil detach /Volumes/heap
+
+  # ──────────────────────────────────────────────────────────────────
   # 8. Aggregator — single required status check for branch protection.
   #
   # Branch-protection rules in GitHub require each contributing job to be
@@ -519,6 +581,7 @@ jobs:
       - build
       - test
       - sanitizers
+      - package-macos-smoke
     runs-on: ubuntu-24.04
     timeout-minutes: 2
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,36 +280,117 @@ jobs:
         with:
           version: "6.8.1"
 
-      - name: Configure & build
-        run: |
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DHEAP_BUILD_TESTS=OFF
-          cmake --build build --parallel --target heap
-
-      - name: Deploy + make .dmg
+      # Generate the macOS app icon (.icns) from the brand SVG BEFORE configure,
+      # so CMake's `if(EXISTS heap.icns)` (a configure-time check) wires it into
+      # the bundle. Recipe mirrors design/brand-export/README.md
+      # (librsvg → iconset → iconutil). Without this the .app carries Qt's
+      # generic icon.
+      - name: Generate app icon (.icns)
         run: |
           set -eu
-          APP="build/heap.app"
-          test -d "$APP" || { echo "::error::expected an .app bundle at $APP"; exit 1; }
-          macdeployqt "$APP" -qmldir="$PWD/qml" -dmg
-          mv build/heap.dmg "heap-${{ needs.meta.outputs.tag }}-macos.dmg"
+          brew install librsvg
+          SVG=design/brand-export/icon/heap-icon.svg
+          ICONSET="$RUNNER_TEMP/heap.iconset"
+          mkdir -p "$ICONSET"
+          for sz in 16 32 128 256 512; do
+            rsvg-convert -w "$sz"       -h "$sz"       -a "$SVG" -o "$ICONSET/icon_${sz}x${sz}.png"
+            rsvg-convert -w "$((sz*2))" -h "$((sz*2))" -a "$SVG" -o "$ICONSET/icon_${sz}x${sz}@2x.png"
+          done
+          iconutil -c icns "$ICONSET" -o design/brand-export/icon/heap.icns
+          test -f design/brand-export/icon/heap.icns
 
-      # Codesign + notarize only when the Apple secrets are configured. See
-      # docs/PACKAGING.md for the required secret names.
-      - name: Codesign & notarize (optional)
+      # arm64 (native to macos-14). CMAKE_OSX_DEPLOYMENT_TARGET pins the Mach-O
+      # `minos` to match Info.plist's LSMinimumSystemVersion (12.0) — otherwise it
+      # is stamped from the runner SDK (14), silently blocking macOS 12/13 users.
+      - name: Configure & build
+        run: |
+          set -eu
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DHEAP_BUILD_TESTS=OFF \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0
+          cmake --build build --parallel --target heap
+          test -d build/heap.app
+
+      # Bundle Qt frameworks/plugins into the .app. NOTE: no -dmg — the .app must
+      # be code-signed AFTER macdeployqt (its install_name_tool rpath rewrites
+      # invalidate the linker's ad-hoc arm64 signatures, which is what makes the
+      # downloaded app read as "damaged") and BEFORE it is sealed into a read-only
+      # dmg. macdeployqt exits 0 even on failure, so verify the relocation worked.
+      - name: Deploy Qt into the bundle
+        run: |
+          set -eu
+          macdeployqt build/heap.app -qmldir="$PWD/qml"
+          test -d build/heap.app/Contents/Frameworks/QtCore.framework
+          if otool -L build/heap.app/Contents/MacOS/heap | grep -Eiq '/Users/runner/work/.*Qt|/aqt'; then
+            echo "::error::macdeployqt left absolute Qt paths — relocation failed"
+            exit 1
+          fi
+
+      # Re-sign the bundle so the arm64 binary + rewritten frameworks carry a
+      # VALID signature — this is the fix for the fatal Gatekeeper "damaged"
+      # state. Developer ID + hardened runtime when the signing secret is present
+      # (sign inside-out, app last); otherwise an ad-hoc signature, which is
+      # enough to make the app openable via right-click → Open. Runs always
+      # (branches internally) — unlike the notarize step it is not secret-gated.
+      - name: Codesign the app
+        run: |
+          set -eu
+          APP=build/heap.app
+          if [ -n "${MACOS_CERT_P12:-}" ]; then
+            echo "$MACOS_CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+            security create-keychain -p ci build.keychain
+            security set-keychain-settings -lut 21600 build.keychain
+            security default-keychain -s build.keychain
+            security unlock-keychain -p ci build.keychain
+            security import "$RUNNER_TEMP/cert.p12" -k build.keychain -P "$MACOS_CERT_PASSWORD" -T /usr/bin/codesign
+            security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ci build.keychain
+            IDENT="Developer ID Application"
+            # inside-out: nested dylibs (incl. QML plugins), then framework
+            # bundles, then the outer app. Consistent identity satisfies Library
+            # Validation, so no disable-library-validation entitlement is needed.
+            find "$APP" -name '*.dylib' -print0 \
+              | xargs -0 -I{} codesign --force --options runtime --timestamp --sign "$IDENT" {}
+            find "$APP/Contents/Frameworks" -type d -name '*.framework' -print0 \
+              | xargs -0 -I{} codesign --force --options runtime --timestamp --sign "$IDENT" {}
+            codesign --force --options runtime --timestamp \
+              --entitlements packaging/macos/heap.entitlements --sign "$IDENT" "$APP"
+            rm -f "$RUNNER_TEMP/cert.p12"
+          else
+            codesign --force --deep --sign - "$APP"
+          fi
+          codesign --verify --deep --strict --verbose=2 "$APP"
+
+      # Assemble a drag-to-Applications .dmg by hand (hdiutil). This replaces
+      # `macdeployqt -dmg`, whose bare image (just heap.app, no /Applications
+      # target) is what made the mounted dmg look like a lone icon rather than an
+      # installer. create-dmg is avoided — it drives Finder via AppleScript, which
+      # hangs on headless runners.
+      - name: Build .dmg
+        run: |
+          set -eu
+          STAGE="$RUNNER_TEMP/dmg"
+          mkdir -p "$STAGE"
+          cp -R build/heap.app "$STAGE/"
+          ln -s /Applications "$STAGE/Applications"
+          hdiutil create -volname "heap" -srcfolder "$STAGE" -fs HFS+ -format UDZO -ov \
+            "heap-${{ needs.meta.outputs.tag }}-macos.dmg"
+
+      # Notarize only when the Apple secrets are configured — the .app is already
+      # signed + hardened above. Sign the dmg, submit, staple, accept-check. Do
+      # NOT run spctl on the ad-hoc default: it is expected to report "rejected".
+      # See docs/PACKAGING.md for the required secret names.
+      - name: Notarize & staple (optional)
         if: ${{ env.MACOS_CERT_P12 != '' }}
         run: |
           set -eu
-          echo "$MACOS_CERT_P12" | base64 --decode > cert.p12
-          security create-keychain -p ci build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p ci build.keychain
-          security import cert.p12 -k build.keychain -P "$MACOS_CERT_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: -s -k ci build.keychain
-          codesign --deep --force --options runtime --sign "Developer ID Application" "heap-${{ needs.meta.outputs.tag }}-macos.dmg"
-          xcrun notarytool submit "heap-${{ needs.meta.outputs.tag }}-macos.dmg" \
+          DMG="heap-${{ needs.meta.outputs.tag }}-macos.dmg"
+          codesign --force --timestamp --sign "Developer ID Application" "$DMG"
+          xcrun notarytool submit "$DMG" \
             --apple-id "$MACOS_NOTARY_APPLE_ID" --password "$MACOS_NOTARY_PASSWORD" \
             --team-id "$MACOS_NOTARY_TEAM_ID" --wait
-          xcrun stapler staple "heap-${{ needs.meta.outputs.tag }}-macos.dmg"
+          xcrun stapler staple "$DMG"
+          spctl -a -t open --context context:primary-signature -vv "$DMG"
 
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v4

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -26,14 +26,31 @@ Release.
 | Windows  | `…-windows-setup.exe`    | Inno Setup ([`installer/heap.iss`](../installer/heap.iss)) wrapping the portable bundle |
 | Linux    | `…-linux-amd64.deb`      | `dpkg-deb` over [`packaging/linux/`](../packaging/linux/) staging |
 | Linux    | `…-linux-x86_64.AppImage`| `linuxdeploy` + the Qt plugin (best-effort; the `.deb` still ships if it fails) |
-| macOS    | `…-macos.dmg`            | `macdeployqt -dmg` (unsigned unless signing secrets are set) |
+| macOS    | `…-macos.dmg`            | `macdeployqt` → `hdiutil` drag-to-Applications dmg, **ad-hoc codesigned** (Developer ID + notarized when signing secrets are set) |
 
 ## macOS signing & notarization
 
-The `.dmg` is **unsigned** by default, so first launch requires a
-right-click → *Open*. To codesign + notarize automatically, add these repo
-secrets — the workflow's optional step activates when `MACOS_CERT_P12` is
-present:
+By default the `.app` inside the `.dmg` is **ad-hoc codesigned** (no paid Apple
+Developer ID required). This gives it a *valid* signature — without it, the
+`install_name_tool` rpath rewrites `macdeployqt` performs on the arm64 binary
+and Qt frameworks leave broken signatures, and a downloaded (quarantined) copy
+fails to launch with the fatal *"heap is damaged and can't be opened"*.
+
+Because the ad-hoc build is not notarized, first launch still shows the
+bypassable *"unidentified developer"* prompt. Open it either way:
+
+- **Right-click → *Open*** (then *Open* again in the dialog), or
+- strip the download quarantine flag:
+  ```bash
+  xattr -dr com.apple.quarantine /Applications/heap.app
+  ```
+
+To codesign with a *Developer ID Application* certificate, notarize and staple
+the ticket automatically — which removes the prompt entirely — add these repo
+secrets. The workflow's optional step activates when `MACOS_CERT_P12` is
+present (it also signs with a hardened runtime + the `allow-jit` entitlement in
+[`packaging/macos/heap.entitlements`](../packaging/macos/heap.entitlements) that
+Qt's JS engine needs):
 
 | Secret | Meaning |
 |--------|---------|

--- a/packaging/macos/heap.entitlements
+++ b/packaging/macos/heap.entitlements
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Entitlements for the hardened-runtime / notarized macOS build. Consumed only
+  by the Developer-ID branch of release.yml's "Codesign the app" step; the
+  ad-hoc default build ignores it.
+
+  Qt's V4 JavaScript engine JIT-compiles QML/JS; under `codesign --options
+  runtime` that requires com.apple.security.cs.allow-jit or the app can crash
+  the moment it evaluates a binding. Every framework/plugin is signed with the
+  same identity, so Library Validation is satisfied and no
+  com.apple.security.cs.disable-library-validation is needed.
+-->
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Problem

The macOS release artifact shipped dead: a downloaded `.dmg` reported **"heap is damaged and can't be opened"** and mounted as a lone icon instead of an installer.

**Root cause:** `macdeployqt -dmg` rewrites the arm64 executable and every copied Qt framework with `install_name_tool`, which **invalidates the linker's ad-hoc code signatures**, and never re-signs. On Apple Silicon a quarantined (downloaded) bundle with broken signatures is the *fatal* Gatekeeper "damaged" state — not the bypassable "unidentified developer". The bare `-dmg` image also had no `/Applications` drop target, so it looked like an icon rather than an installer. The old optional signing step compounded it: it signed the **dmg** but never the **app inside**, and ran after the dmg was built.

## Fix — `release.yml` `package-macos` rewritten

- **Generate `heap.icns`** from the brand SVG *before* configure so CMake's `if(EXISTS)` wires it into the bundle.
- **Pin `CMAKE_OSX_DEPLOYMENT_TARGET=12.0`** to match `Info.plist`'s `LSMinimumSystemVersion` (was stamped from the runner SDK 14 → silently blocked macOS 12/13).
- **`macdeployqt` without `-dmg`** + a relocation guard (it exits 0 even on failure).
- **Re-sign the `.app` AFTER macdeployqt** — the actual fix for "damaged":
  - **ad-hoc by default** (no paid Apple ID) → app becomes openable via right-click → *Open*;
  - **Developer ID + hardened runtime + notarize + staple** when `MACOS_CERT_P12` et al are set (sign inside-out, app last; fixes the old wrong order).
- **Assemble a drag-to-Applications `.dmg` with `hdiutil`** (no `create-dmg` — its AppleScript/Finder layout hangs on headless runners).

## Supporting changes

- **`packaging/macos/heap.entitlements`** (new) — `com.apple.security.cs.allow-jit` for Qt's V4 JS engine under hardened runtime; consumed only by the Developer-ID path.
- **`ci.yml` `package-macos-smoke`** (new job, added to the `ci` aggregator) — runs the ad-hoc path on every push/PR: build → macdeployqt → ad-hoc sign → `codesign --verify` → mount dmg. A re-broken signature fails **here** instead of shipping another dead release.
- **`docs/PACKAGING.md`** — ad-hoc default documented, plus the `xattr -dr com.apple.quarantine` escape hatch.

## Decisions

arm64-only (matches the `macos-14` runner); ad-hoc signing is the default with the notarization path staying secret-gated.

## Verification

- YAML parses clean; `lint-actions` (actionlint) covers the workflows.
- **`package-macos-smoke` on this PR is the real proof** — it exercises the exact bundle/sign/dmg assembly the release uses.
- Manual: download the dmg from a run, mount → `heap.app` + `Applications` target; double-click → bypassable "unidentified developer" (NOT "damaged"); right-click → *Open* launches.