### PR TITLE
ci(release): semver release naming + v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,22 +55,26 @@ jobs:
               echo "::error::tag $tag core ($core) != CMakeLists project version ($cmver) — bump CMakeLists.txt before tagging"
               exit 1
             fi
-            echo "tag=$tag" >> "$GITHUB_OUTPUT"
-            echo "release=true" >> "$GITHUB_OUTPUT"
+            release=true
             # A hyphen (e.g. v1.1.0-rc.1) marks a pre-release: published, but
             # softprops keeps it off /releases/latest so the updater ignores it.
             case "$tag" in
-              *-*) echo "prerelease=true"  >> "$GITHUB_OUTPUT" ;;
-              *)   echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+              *-*) prerelease=true ;;
+              *)   prerelease=false ;;
             esac
           else
             # Manual dispatch = test build only. A SemVer-valid pre-release string
             # so the in-app updater (Updater::isNewerVersion) ranks it OLDER than
             # any real release. No tag is created; the publish job is skipped.
-            echo "tag=v${cmver}-dev.$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-            echo "release=false" >> "$GITHUB_OUTPUT"
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            tag="v${cmver}-dev.$(git rev-parse --short HEAD)"
+            release=false
+            prerelease=true
           fi
+          {
+            echo "tag=$tag"
+            echo "release=$release"
+            echo "prerelease=$prerelease"
+          } >> "$GITHUB_OUTPUT"
 
   # ──────────────────────────────────────────────────────────────────
   # Windows: portable zip (proven windeployqt bundle) + Inno Setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Release
 
-# Cross-platform packaging. Fires automatically when a version tag is pushed
-# (git tag v1.2.3 && git push --tags) and can also be run manually, in which
-# case a dated tag vYYYY.MM.DD-<sha> is minted.
+# Cross-platform packaging. Fires automatically when a semver tag is pushed
+# (git tag v1.2.3 && git push origin v1.2.3) — the tag drives every artifact
+# name and the published release. Running it manually (workflow_dispatch)
+# produces a dev test build (vX.Y.Z-dev.<sha>): artifacts are attached to the
+# run, but nothing is tagged or published.
 on:
   push:
     tags:
@@ -14,27 +16,60 @@ permissions:
 
 jobs:
   # ──────────────────────────────────────────────────────────────────
-  # Resolve the release tag once so every packaging job agrees on the
-  # artifact naming and the publish job knows what to tag.
+  # Resolve the version once so every packaging job agrees on artifact
+  # naming and the publish job knows what to tag. CMakeLists' project()
+  # VERSION is the single source of truth; a pushed tag must match it.
+  # Outputs:
+  #   tag        — vX.Y.Z (real) or vX.Y.Z-dev.<sha> (manual test build)
+  #   release    — "true" only for a pushed tag (gates the publish job)
+  #   prerelease — "true" for a hyphenated tag (rc/dev): never the update target
   # ──────────────────────────────────────────────────────────────────
   meta:
-    name: Resolve tag
+    name: Resolve version
     runs-on: ubuntu-24.04
     outputs:
-      tag: ${{ steps.tag.outputs.value }}
+      tag: ${{ steps.tag.outputs.tag }}
+      release: ${{ steps.tag.outputs.release }}
+      prerelease: ${{ steps.tag.outputs.prerelease }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Compute release tag
+      - name: Resolve version & release kind
         id: tag
         shell: bash
         run: |
           set -euo pipefail
+          # Single source of truth for the numeric version.
+          cmver=$(sed -nE 's/^project\(heap VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' CMakeLists.txt | head -n1)
+          if [ -z "$cmver" ]; then
+            echo "::error::could not read project VERSION from CMakeLists.txt"
+            exit 1
+          fi
           if [ "${{ github.ref_type }}" = "tag" ]; then
-            echo "value=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            # Real release: the pushed tag drives naming. Its numeric core must
+            # equal the CMake version so the binary and the release never drift.
+            tag="${{ github.ref_name }}"
+            core="${tag#v}"; core="${core%%-*}"
+            if [ "$core" != "$cmver" ]; then
+              echo "::error::tag $tag core ($core) != CMakeLists project version ($cmver) — bump CMakeLists.txt before tagging"
+              exit 1
+            fi
+            echo "tag=$tag" >> "$GITHUB_OUTPUT"
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            # A hyphen (e.g. v1.1.0-rc.1) marks a pre-release: published, but
+            # softprops keeps it off /releases/latest so the updater ignores it.
+            case "$tag" in
+              *-*) echo "prerelease=true"  >> "$GITHUB_OUTPUT" ;;
+              *)   echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+            esac
           else
-            echo "value=v$(date +%Y.%m.%d)-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+            # Manual dispatch = test build only. A SemVer-valid pre-release string
+            # so the in-app updater (Updater::isNewerVersion) ranks it OLDER than
+            # any real release. No tag is created; the publish job is skipped.
+            echo "tag=v${cmver}-dev.$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
           fi
 
   # ──────────────────────────────────────────────────────────────────
@@ -409,8 +444,11 @@ jobs:
     # publish whatever artifacts exist. A macOS failure no longer sinks the
     # whole release (it did twice before).
     needs: [meta, package-windows, package-linux, package-macos]
+    # release=true only for a pushed tag, so a manual (workflow_dispatch) run
+    # never publishes — its artifacts stay attached to the run as a test build.
     if: >-
       ${{ always() && needs.meta.result == 'success'
+          && needs.meta.outputs.release == 'true'
           && needs.package-windows.result == 'success'
           && needs.package-linux.result == 'success' }}
     runs-on: ubuntu-24.04
@@ -430,4 +468,8 @@ jobs:
           tag_name: ${{ needs.meta.outputs.tag }}
           name: "heap ${{ needs.meta.outputs.tag }}"
           generate_release_notes: true
+          # A full release becomes /releases/latest (the updater's target); a
+          # hyphenated tag (rc/beta) is flagged pre-release and stays off latest.
+          prerelease: ${{ needs.meta.outputs.prerelease }}
+          make_latest: ${{ needs.meta.outputs.prerelease == 'false' }}
           files: dist/**/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(heap VERSION 0.4.2 LANGUAGES CXX)
+project(heap VERSION 1.0.0 LANGUAGES CXX)
 
 # Windows resource compiler (windres on mingw / rc.exe on MSVC). Required so
 # design/brand-export/icon/heap-icon.rc is actually compiled into heap.exe —

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -7,16 +7,29 @@ Release.
 
 ## Triggering a release
 
-- **On a version tag (primary path):**
+The version lives in **one** place — `project(heap VERSION X.Y.Z …)` in
+[`CMakeLists.txt`](../CMakeLists.txt). The release tag mirrors it, and the
+workflow refuses to publish if the two disagree.
+
+- **Cut a release (primary path):** bump `CMakeLists.txt` to the new version,
+  land it on `master`, then push the matching semver tag:
   ```bash
   git tag v1.2.3
   git push origin v1.2.3
   ```
-  The workflow uses the tag name verbatim for the release and artifact names.
+  The tag name is used verbatim for the release and artifact names. A guard in
+  the `meta` job fails the run if the tag's numeric core (`1.2.3`) does not
+  equal the CMake version. The release is marked **latest**, so the in-app
+  updater picks it up.
 
-- **Manually:** run the *Release* workflow from the Actions tab
-  (`workflow_dispatch`). A dated tag `vYYYY.MM.DD-<short-sha>` is minted
-  automatically.
+- **Pre-release:** push a hyphenated tag such as `v1.2.3-rc.1` (its core must
+  still match CMake). It is published but flagged **pre-release** and kept off
+  `/releases/latest`, so the auto-updater never offers it.
+
+- **Manual test build:** run the *Release* workflow from the Actions tab
+  (`workflow_dispatch`). It builds a `vX.Y.Z-dev.<short-sha>` bundle and
+  attaches the artifacts to the workflow run — **nothing is tagged or
+  published**. Use it to smoke-test packaging without cutting a release.
 
 ## Artifacts
 

--- a/qml/SplashScreen.qml
+++ b/qml/SplashScreen.qml
@@ -30,7 +30,7 @@ Item {
     // Public knobs
     property real progress: 0.0          // 0..1; bind to your loader's progress
     property string status: "initializing allocator…"
-    property string buildInfo: "v" + AppController.appVersion + " · build 240617"
+    property string buildInfo: "v" + AppController.appVersion
     property string channel: "stable · channel"
     property bool autoAnimate: true      // demo: animate the loading bar
     property int autoDuration: 1200

--- a/tests/test_update.cpp
+++ b/tests/test_update.cpp
@@ -34,3 +34,15 @@ TEST(UpdateVersionCompare, HandlesDifferentComponentCounts) {
   EXPECT_FALSE(isNewerVersion("1.0.0", "1.0"));
   EXPECT_FALSE(isNewerVersion("1", "1.0.0"));
 }
+
+TEST(UpdateVersionCompare, DevBuildRanksBelowMatchingRelease) {
+  // The Release workflow names manual test builds vX.Y.Z-dev.<sha> — a SemVer
+  // pre-release of the same numeric core. A user on that dev build must be
+  // offered the matching real release, and a user already on the release must
+  // NOT be offered a dev build of the same version. This is the contract the CI
+  // naming scheme relies on (see .github/workflows/release.yml meta job).
+  EXPECT_TRUE(isNewerVersion("1.0.0-dev.abc1234", "v1.0.0"));
+  EXPECT_FALSE(isNewerVersion("1.0.0", "v1.0.0-dev.abc1234"));
+  // A newer real release still outranks an older dev build.
+  EXPECT_TRUE(isNewerVersion("1.0.0-dev.abc1234", "v1.1.0"));
+}


### PR DESCRIPTION
## What

Reworks the release naming scheme and cuts **v1.0.0**.

Manual `Release` runs used to mint a timestamp tag `vYYYY.MM.DD-<sha>`. That
polluted `/releases` with 16 dated tags and **broke the in-app updater**:
`Updater::parseVersion("v2026.07.04")` → `[2026,7,4]`, which always outranks a
real semver like `1.0.0` — a user on 1.0.0 would be told "2026.7.4 available".

## Changes

- **CMake version 0.4.2 → 1.0.0** — the single source of truth (`HEAP_VERSION`
  flows to the app, About dialog, splash, macOS bundle).
- **`release.yml` meta job** now reads the CMake version and:
  - **Tag push `vX.Y.Z`** → publishes; a guard fails the run if the tag's
    numeric core ≠ CMake version. Marked **latest** (the updater's target).
  - **`vX.Y.Z-rc.N`** → published as a **prerelease**, kept off `/releases/latest`.
  - **`workflow_dispatch`** → builds a `vX.Y.Z-dev.<sha>` test bundle; artifacts
    stay on the run — **no tag, no release**. The dev string is a valid SemVer
    prerelease so the updater ranks it below any real release.
- **Docs** (`PACKAGING.md`) rewritten for the new trigger model.
- **Splash**: drop the stale hardcoded `build 240617`.
- **Test**: `DevBuildRanksBelowMatchingRelease` locks the dev-build/updater contract.

## Verification

- `meta` bash dry-run: `v1.0.0`→release/latest, mismatched tag→exit 1,
  `v1.0.0-rc.1`→prerelease, dispatch→no-publish. ✅
- `heap_update_tests` green locally (5/5, incl. the new case). ✅
- YAML parses. ✅

## Follow-up (manual, after merge)

Delete the stale `v2026.*` tags + their 2 releases so `/releases` is clean and
`v1.0.0` is unambiguously latest, then `git tag v1.0.0 && git push origin v1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)