### PR TITLE
fix(git): re-match focused branch on prefix change + settings hint

### DIFF
--- a/qml/I18n.qml
+++ b/qml/I18n.qml
@@ -492,6 +492,7 @@ QtObject {
             // Git section
             "settings.git.repos": "Watched repositories",
             "settings.git.repos.hint": "Each path is the root of a git worktree (contains .git). Task prefix comes from Tasks → idPrefix.",
+            "settings.git.match.hint": "A branch links to a task only when its name contains %1-<number> — e.g. %1-42 or feature/%1-42-login. Otherwise the git banner stays hidden. With one prefix, a bare 3–7 digit number in the branch also matches.",
             "settings.git.autoOn": "Automations on checkout",
             "settings.git.autoMove": "Move task to In Progress",
             "settings.git.autoMove.hint": "When git checkout lands on a branch with a known task prefix.",
@@ -1005,6 +1006,7 @@ QtObject {
 
             "settings.git.repos": "Отслеживаемые репозитории",
             "settings.git.repos.hint": "Каждый путь — корень git worktree (содержит .git). Префикс задачи берётся из секции Tasks → idPrefix.",
+            "settings.git.match.hint": "Ветка связывается с задачей только если её имя содержит %1-<число> — например %1-42 или feature/%1-42-login. Иначе git-баннер не показывается. С одним префиксом подходит и просто число из 3–7 цифр в имени ветки.",
             "settings.git.autoOn": "Автоматизации при checkout",
             "settings.git.autoMove": "Перевести задачу в In Progress",
             "settings.git.autoMove.hint": "Когда git checkout попадает в ветку с известным префиксом задачи.",

--- a/qml/SettingsView.qml
+++ b/qml/SettingsView.qml
@@ -1639,6 +1639,14 @@ Item {
                         font.pixelSize: 11
                         wrapMode: Text.WordWrap
                     }
+                    Text {
+                        Layout.fillWidth: true
+                        text: I18n.t("settings.git.match.hint")
+                                .arg(((root.settings.tasks && root.settings.tasks.idPrefix) || "LTE").toUpperCase())
+                        color: Theme.textMuted
+                        font.pixelSize: 11
+                        wrapMode: Text.WordWrap
+                    }
                     Repeater {
                         model: (root.settings.git && root.settings.git.watchedRepos) || []
                         delegate: RowLayout {

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -372,6 +372,7 @@ AppController::AppController(QObject* parent) :
   connect(this, &AppController::activeProfileChanged, this, [this]() {
     if(m_gitWatcher) {
       m_gitWatcher->setPrefixes(collectPrefixes());
+      refreshFocusedTaskId();
     }
   });
 
@@ -3972,6 +3973,24 @@ void AppController::applyGitSettingsFromMap(const QVariantMap& g) {
   m_gitWatcher->setPrefixes(collectPrefixes());
   m_gitWatcher->setWatchedRepos(repos);
   m_gitWatcher->setPrFetchEnabled(g.value("watchPrState", true).toBool());
+  // A prefix edit lands here (idPrefix lives in app settings) but leaves HEAD
+  // untouched, so re-match the branch we're already on for the banner.
+  refreshFocusedTaskId();
+}
+
+void AppController::refreshFocusedTaskId() {
+  if(m_focusedBranch.isEmpty() || m_focusedBranch == QStringLiteral("(detached HEAD)")) {
+    return;
+  }
+  const heap::git::BranchTaskMatcher m(collectPrefixes());
+  const auto mr = m.extract(m_focusedBranch);
+  const QString newId = mr.matched ? mr.taskId : QString();
+  if(newId == m_focusedTaskId) {
+    return;
+  }
+  m_focusedTaskId = newId;
+  m_dismissedBranches.remove(m_focusedBranch);  // re-arm banner for a now-matching branch
+  emit focusedGitChanged();
 }
 
 void AppController::onGitBranchChanged(const QString& repo, const QString& branch, const QString& taskId) {

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -679,6 +679,10 @@ class AppController : public QObject {
   QVariantMap m_focusedRepoState;
   QSet<QString> m_dismissedBranches;  // in-memory only; per branch name
   void applyGitSettingsFromMap(const QVariantMap& git);
+  // Re-derive the focused branch's task id under the current id-prefix and
+  // refresh the banner. Needed because a prefix change (settings/profile) does
+  // not move HEAD, so no branchChanged fires to re-run the match on its own.
+  void refreshFocusedTaskId();
   void onGitBranchChanged(const QString& repo, const QString& branch, const QString& taskId);
   void onGitRepoState(const QString& repo, const QVariantMap& state);
   void onGitCommits(const QString& repo, const QVariantMap& commitsByTask);

--- a/tests/test_appcontroller.cpp
+++ b/tests/test_appcontroller.cpp
@@ -13,6 +13,9 @@
 #include <QDateTime>
 #include <QDir>
 #include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QStandardPaths>
 #include <QStringList>
 #include <QTemporaryDir>
@@ -351,6 +354,42 @@ TEST_F(AppControllerTest, TemplateCreatesPrefilledChecklistTask) {
     }
   }
   EXPECT_TRUE(found);
+}
+
+// ─── Git focus: prefix change re-matches the current branch ───────────
+
+TEST_F(AppControllerTest, GitPrefixChangeRematchesFocusedBranch) {
+  // Watched repo sitting on branch "HEAP-77-x". With prefix LTE the branch
+  // carries no recognizable task id (77 is too short for the lone-digit rule);
+  // switching the prefix to HEAP must make the banner pick it up WITHOUT any
+  // HEAD movement. Regression: setPrefixes updated the matcher but never re-ran
+  // the match on the branch already checked out, so the banner stayed stale
+  // until the next checkout.
+  QTemporaryDir repo;
+  ASSERT_TRUE(repo.isValid());
+  const QString gitDir = repo.path() + QStringLiteral("/.git");
+  ASSERT_TRUE(QDir().mkpath(gitDir));
+  {
+    QFile head(gitDir + QStringLiteral("/HEAD"));
+    ASSERT_TRUE(head.open(QIODevice::WriteOnly | QIODevice::Text));
+    head.write("ref: refs/heads/HEAP-77-x\n");
+  }
+  const QString repoPath = QDir(repo.path()).absolutePath();
+
+  const auto settings = [&](const QString& prefix) {
+    const QJsonObject root{{"tasks", QJsonObject{{"idPrefix", prefix}}}, {"git", QJsonObject{{"watchedRepos", QJsonArray{repoPath}}}}};
+    return QString::fromUtf8(QJsonDocument(root).toJson(QJsonDocument::Compact));
+  };
+
+  app_->setAppSettingsJson(settings(QStringLiteral("LTE")));
+  EXPECT_EQ(app_->focusedBranch(), QStringLiteral("HEAP-77-x"));
+  EXPECT_EQ(app_->focusedTaskId(), QString());  // no match under LTE
+
+  app_->setAppSettingsJson(settings(QStringLiteral("HEAP")));
+  EXPECT_EQ(app_->focusedTaskId(), QStringLiteral("HEAP-77"));  // linked live
+
+  app_->setAppSettingsJson(settings(QStringLiteral("LTE")));
+  EXPECT_EQ(app_->focusedTaskId(), QString());  // un-match propagates too
 }
 
 // ─── headless boot ────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem
Git-watcher banner never reacted to a **task id prefix change**. `GitWatcher::setPrefixes` swapped the matcher regex but never re-ran the match on the branch already checked out — so editing `tasks.idPrefix` in Settings (or switching profile) left the "Working on <task>" banner stale until the next `git checkout`.

Also: no UI hint explained that a branch links to a task only when it matches the prefix, so a branch like `feat/test_git_heap` showed nothing and read as "watcher broken".

## Fix
- `AppController::refreshFocusedTaskId()` — re-derives the focused branch's task id under the current prefix and refreshes the banner. No task-move/notify side effects.
- Called on both prefix-change paths: settings edit (`applyGitSettingsFromMap`) and profile switch (`activeProfileChanged`).
- Settings → Git: new hint (en/ru) documenting the `<PREFIX>-<number>` match rule, with the live prefix interpolated.

## Test
`GitPrefixChangeRematchesFocusedBranch` — branch `HEAP-77-x`, `focusedTaskId` flips `""` (LTE) → `HEAP-77` (HEAP) → `""` (LTE) live, no HEAD movement.

- heap_appcontroller_tests: 26/26
- heap_git_tests: 27/27
- app launches to settings view, zero QML errors