### PR TITLE
ci(release): sign Windows artifacts via SignPath Foundation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,7 @@ jobs:
     # step's own env is not reliably visible to its own `if`, and `secrets`
     # cannot be referenced in `if` directly). Mirrors the macOS signing pattern.
     env:
-      WINDOWS_CERT_PFX: ${{ secrets.WINDOWS_CERT_PFX }}
-      WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -144,29 +143,33 @@ jobs:
 
       # Authenticode-sign heap.exe + the bundled Qt DLLs before they are
       # packaged, so both the portable zip and the installer carry signed
-      # binaries. Runs only when the signing secret is configured — unsigned
-      # builds still ship (default). See docs/PACKAGING.md for the secrets.
-      - name: Sign binaries (optional)
-        if: ${{ env.WINDOWS_CERT_PFX != '' }}
-        shell: msys2 {0}
-        run: |
-          set -eu
-          pacman -S --noconfirm --needed mingw-w64-ucrt-x86_64-osslsigncode
-          printf '%s' "$WINDOWS_CERT_PFX" | base64 -d > cert.pfx
-          sign() {
-            osslsigncode sign \
-              -pkcs12 cert.pfx -pass "$WINDOWS_CERT_PASSWORD" \
-              -n "heap." -i "https://github.com/sectapunterx/heap" \
-              -ts http://timestamp.digicert.com -h sha256 \
-              -in "$1" -out "$1.signed"
-            mv -f "$1.signed" "$1"
-          }
-          find build/heap-portable -type f \( -iname '*.exe' -o -iname '*.dll' \) -print0 |
-            while IFS= read -r -d '' f; do
-              echo "signing: $f"
-              sign "$f"
-            done
-          rm -f cert.pfx
+      # binaries. Signing runs via SignPath Foundation (free OSS code signing):
+      # the unsigned bundle is uploaded as a workflow artifact, SignPath pulls
+      # it, signs the configured PE files, and the signed files are written back
+      # over build/heap-portable. Runs only when SIGNPATH_API_TOKEN is
+      # configured — unsigned builds still ship (default). See docs/PACKAGING.md.
+      - name: Upload unsigned portable bundle
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        id: upload-portable
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-portable
+          path: build/heap-portable
+
+      - name: Sign portable bundle (SignPath)
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORG_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_POLICY_SLUG }}
+          artifact-configuration-slug: portable
+          github-artifact-id: ${{ steps.upload-portable.outputs.artifact-id }}
+          wait-for-completion: true
+          # Overwrite the bundle in place so the zip + installer below wrap the
+          # signed binaries.
+          output-artifact-directory: build/heap-portable
 
       - name: Zip portable bundle
         shell: pwsh
@@ -188,22 +191,29 @@ jobs:
             installer\heap.iss
 
       # Sign the finished installer .exe (the portable binaries it wraps were
-      # already signed above). Same gate — no-op without the cert secret.
-      - name: Sign installer (optional)
-        if: ${{ env.WINDOWS_CERT_PFX != '' }}
-        shell: msys2 {0}
-        run: |
-          set -eu
-          pacman -S --noconfirm --needed mingw-w64-ucrt-x86_64-osslsigncode
-          printf '%s' "$WINDOWS_CERT_PFX" | base64 -d > cert.pfx
-          SETUP="installer/Output/heap-${{ needs.meta.outputs.tag }}-windows-setup.exe"
-          osslsigncode sign \
-            -pkcs12 cert.pfx -pass "$WINDOWS_CERT_PASSWORD" \
-            -n "heap. installer" -i "https://github.com/sectapunterx/heap" \
-            -ts http://timestamp.digicert.com -h sha256 \
-            -in "$SETUP" -out "$SETUP.signed"
-          mv -f "$SETUP.signed" "$SETUP"
-          rm -f cert.pfx
+      # already signed above). Same SignPath flow, second artifact config — the
+      # signed setup.exe is written back over installer/Output. Same gate — no-op
+      # without the token secret.
+      - name: Upload unsigned installer
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        id: upload-installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-installer
+          path: installer/Output/heap-${{ needs.meta.outputs.tag }}-windows-setup.exe
+
+      - name: Sign installer (SignPath)
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORG_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_POLICY_SLUG }}
+          artifact-configuration-slug: installer
+          github-artifact-id: ${{ steps.upload-installer.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: installer/Output
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4
@@ -461,6 +471,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist
+          # Only the packaged per-platform bundles — NOT the unsigned-* SignPath
+          # transport artifacts, which would otherwise pollute the release with
+          # unsigned duplicates.
+          pattern: dist-*
           merge-multiple: true
 
       - name: List artifacts

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -76,22 +76,49 @@ Qt's JS engine needs):
 ## Windows signing
 
 Windows binaries and the installer are **unsigned** by default, so SmartScreen
-shows an *"Unknown publisher"* warning on first download/run. To Authenticode-sign
-`heap.exe`, the bundled Qt DLLs and the setup `.exe` automatically, add these repo
-secrets — the workflow's optional signing steps activate when `WINDOWS_CERT_PFX`
-is present (mirrors the macOS pattern):
+shows an *"Unknown publisher"* warning on first download/run. Signing is wired to
+[**SignPath Foundation**](https://signpath.org) — free Authenticode code signing
+for qualifying open-source projects — and activates when `SIGNPATH_API_TOKEN` is
+present (mirrors the macOS optional-signing pattern). Unsigned builds still ship
+when it is absent.
 
-| Secret | Meaning |
-|--------|---------|
-| `WINDOWS_CERT_PFX` | base64 of an Authenticode code-signing `.pfx`/`.p12` certificate (OV or EV) |
-| `WINDOWS_CERT_PASSWORD` | password for that `.pfx` |
+**What signing does — and does not — do.** As of 2024 **no certificate removes
+the SmartScreen warning instantly** ([Microsoft
+Learn](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/smartscreen-reputation);
+EV lost its instant bypass). Signing (1) replaces *"Unknown publisher"* with the
+verified publisher **"SignPath Foundation"** (the certificate is issued to the
+Foundation, not to heap), and (2) lets SmartScreen reputation accumulate on that
+certificate so the warning fades over downloads. The Foundation cert is shared by
+many OSS projects, so it already carries some reputation — a head start over a
+fresh cert. The only way to a zero-warning first launch is Microsoft Store (MSIX)
+distribution, which is not used here.
 
-Signing uses [`osslsigncode`](https://github.com/mtrojnar/osslsigncode) with an
-RFC-3161 SHA-256 timestamp, so signatures stay valid after the certificate
-expires. An **EV** certificate earns SmartScreen reputation instantly; an **OV**
-certificate builds it up over downloads. The uninstaller (`unins000.exe`, which
-Inno generates on the target machine) is not signed — add Inno's
-`SignedUninstaller` directive later if that warning needs to go too.
+Post-2023 CA rules forbid downloadable `.pfx` keys for publicly-trusted
+certificates (keys must live on an HSM/token or a managed service), which is why
+signing goes through SignPath's cloud service rather than a `.pfx` secret. The
+flow: CI uploads the unsigned artifact as a GitHub workflow artifact,
+[`signpath/github-action-submit-signing-request`](https://docs.signpath.io/trusted-build-systems/github)
+submits a signing request, SignPath verifies the build origin, signs the
+configured PE files (with an RFC-3161 timestamp, so signatures outlive the cert),
+and returns the signed files. `heap.exe` + the bundled Qt DLLs are signed before
+packaging, then the setup `.exe` is signed after Inno builds it.
+
+Configure it after the SignPath Foundation application is approved:
+
+| Repo setting | Kind | Meaning |
+|--------------|------|---------|
+| `SIGNPATH_API_TOKEN` | secret | SignPath API token with submitter permission |
+| `SIGNPATH_ORG_ID` | variable | SignPath organization ID |
+| `SIGNPATH_PROJECT_SLUG` | variable | SignPath project slug (e.g. `heap`) |
+| `SIGNPATH_POLICY_SLUG` | variable | signing policy slug (e.g. `release-signing`) |
+
+In the SignPath console the project needs the **GitHub.com** trusted build system
+(with the SignPath GitHub App installed on the repo) and two **artifact
+configurations**: `portable` (recursively signs `*.exe`/`*.dll` in the bundle) and
+`installer` (signs the setup `.exe`). SignPath's OSS program requires every job up
+to the signing request to run on GitHub-hosted runners — `package-windows` already
+does. The uninstaller (`unins000.exe`, which Inno generates on the target machine)
+is not signed.
 
 ## Follow-ups (not yet automated)
 


### PR DESCRIPTION
## What

Sign the Windows portable bundle and installer via **SignPath Foundation** (free Authenticode code signing for open-source projects), replacing the unusable `osslsigncode` + `WINDOWS_CERT_PFX` path.

## Why

Windows artifacts ship unsigned → SmartScreen shows *"Unknown publisher"*. The existing signing scaffolding is a dead end: post-2023 CA/Browser Forum rules forbid downloadable `.pfx` keys for publicly-trusted certificates (keys must live on HSM/token or a managed service), so no real cert can be delivered as a base64 file secret.

heap is public + MIT + actively maintained → qualifies for SignPath Foundation. Worldwide (works outside US/Canada, unlike Azure Artifact Signing).

## Reality check on SmartScreen

No certificate removes the SmartScreen warning instantly anymore — EV lost its instant bypass in 2024 ([Microsoft Learn](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/smartscreen-reputation)). Signing (1) replaces *"Unknown publisher"* with the verified publisher **"SignPath Foundation"**, and (2) lets reputation accrue on the cert so the warning fades over downloads. The Foundation cert is shared across many OSS projects → some reputation head start. Zero-warning first launch would require Microsoft Store (MSIX) — out of scope.

## Changes

- **`.github/workflows/release.yml`** (`package-windows`):
  - Removed the two `osslsigncode` steps + `WINDOWS_CERT_PFX`/`WINDOWS_CERT_PASSWORD` job env.
  - Portable bundle: `upload-artifact` → `signpath/github-action-submit-signing-request@v2` (`portable` config) → signed files written back to `build/heap-portable` before zip + installer.
  - Installer exe: same flow (`installer` config), signed back to `installer/Output`.
  - Every SignPath step gated on `SIGNPATH_API_TOKEN` → unsigned builds still ship when unset (fallback preserved).
  - `publish` download scoped to `pattern: dist-*` so the `unsigned-*` transport artifacts don't leak into the release.
- **`docs/PACKAGING.md`**: rewrote the Windows signing section — SignPath flow, `SIGNPATH_*` secret/vars, publisher name, no-instant-SmartScreen caveat.

## Follow-up (external, gates activation)

CI is inert (unsigned builds ship as before) until:
1. SignPath Foundation application approved.
2. SignPath console: project linked to repo, GitHub.com trusted build system + GitHub App, `release-signing` policy, `portable` + `installer` artifact configurations, API token.
3. Repo settings: secret `SIGNPATH_API_TOKEN`; variables `SIGNPATH_ORG_ID`, `SIGNPATH_PROJECT_SLUG`, `SIGNPATH_POLICY_SLUG`.

## Verify (post-approval)

- Trigger *Release* via `workflow_dispatch`; confirm both SignPath steps run.
- `Get-AuthenticodeSignature heap.exe` → Status `Valid`, subject `SignPath Foundation`; RFC-3161 timestamp present.
- With `SIGNPATH_API_TOKEN` unset, the job still builds unsigned artifacts and stays green.
