### PR TITLE
feat(dist): Scoop bucket + winget and Flathub manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ CMakeFiles/
 /design/*
 !design/brand-export/
 cmake*
+# Local SignPath setup notes / artifact configs (do not commit)
+/signpath-setup/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ fires deadline + standup reminders; respects quiet hours).
 **Prebuilt binaries** — a Windows installer, a Linux AppImage, and a portable zip are attached to each
 [**GitHub release**](https://github.com/sectapunterx/heap/releases). Download and run; nothing else to install.
 
+**Package managers** — Windows via [Scoop](https://scoop.sh):
+
+```powershell
+scoop bucket add heap https://github.com/sectapunterx/heap
+scoop install heap
+```
+
+winget and Flathub (Linux) manifests are prepared and pending submission — see
+[`docs/DISTRIBUTION.md`](docs/DISTRIBUTION.md).
+
 **Build from source** — three commands, any platform (Qt 6.4+ and a C++20 toolchain):
 
 ```sh

--- a/bucket/heap.json
+++ b/bucket/heap.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.4.2",
+    "description": "Native desktop kanban, calendar and docs for engineers. Qt 6 / QML / C++20, single binary.",
+    "homepage": "https://github.com/sectapunterx/heap",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/sectapunterx/heap/releases/download/v0.4.2/heap-v0.4.2-windows-portable.zip",
+            "hash": "070a61a39db7e50413a150d6060f8ecff9da9aea10afcc786bec2ac5b814034e"
+        }
+    },
+    "bin": "heap.exe",
+    "shortcuts": [
+        [
+            "heap.exe",
+            "heap"
+        ]
+    ],
+    "persist": [],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/sectapunterx/heap/releases/download/v$version/heap-v$version-windows-portable.zip"
+            }
+        }
+    }
+}

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,0 +1,94 @@
+# Distribution channels
+
+`heap.` ships from [GitHub Releases](https://github.com/sectapunterx/heap/releases).
+Package-manager manifests reuse those same release assets. This doc tracks each
+free channel, the manifest that feeds it, and the exact steps to submit/update.
+
+| Channel | Manifest | Status | Submission |
+|---------|----------|--------|------------|
+| **Scoop** (Windows) | [`bucket/heap.json`](../bucket/heap.json) | ✅ live in this repo | none — this repo *is* the bucket |
+| **winget** (Windows) | [`packaging/winget/`](../packaging/winget/) | 📝 ready to PR | PR to `microsoft/winget-pkgs` |
+| **Flathub** (Linux) | [`packaging/flatpak/`](../packaging/flatpak/) | 📝 draft, test then PR | PR to `flathub/flathub` |
+
+Other channels (AUR, Snap, Chocolatey, Homebrew) are not set up yet — they need
+external accounts. See "Not yet done" below.
+
+---
+
+## Scoop — works now
+
+This repository is a Scoop bucket (`bucket/heap.json`). Users install with:
+
+```powershell
+scoop bucket add heap https://github.com/sectapunterx/heap
+scoop install heap
+```
+
+`checkver: github` + `autoupdate` mean the manifest tracks the latest GitHub
+release automatically; on a new release update `version`/`url`/`hash` (or run
+`scoop update`/`checkver -u` from a Scoop clone).
+
+To also get into the shared **Extras** bucket (more discoverable), open a PR to
+[`ScoopInstaller/Extras`](https://github.com/ScoopInstaller/Extras) with a copy
+of `bucket/heap.json`.
+
+## winget — ready to PR
+
+Manifests live in `packaging/winget/` (schema 1.6.0):
+`sectapunterx.heap.yaml`, `.installer.yaml`, `.locale.en-US.yaml`.
+
+1. Validate + test locally (Windows):
+   ```powershell
+   winget validate --manifest packaging\winget
+   winget install --manifest packaging\winget   # optional smoke install
+   ```
+2. Submit — easiest with wingetcreate:
+   ```powershell
+   winget install Microsoft.WingetCreate
+   wingetcreate submit --token <gh-token> packaging\winget
+   ```
+   or manually fork [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs),
+   copy the three files to
+   `manifests/s/sectapunterx/heap/0.4.2/`, and open a PR.
+3. On each release, bump `PackageVersion` + `InstallerUrl` + `InstallerSha256`
+   (`sha256sum heap-<ver>-windows-setup.exe`) and repeat. `wingetcreate update`
+   automates this.
+
+> The installer is currently **unsigned**; winget's automated validation still
+> accepts it, but signing (see [PACKAGING.md](PACKAGING.md)) is recommended.
+
+## Flathub — draft, test before PR
+
+Files in `packaging/flatpak/`: manifest `io.github.sectapunterx.heap.yaml`,
+`io.github.sectapunterx.heap.metainfo.xml`, `io.github.sectapunterx.heap.desktop`.
+The manifest builds from the `v0.4.2` git tag against the KDE 6 runtime.
+
+1. Build + run locally:
+   ```bash
+   flatpak install flathub org.kde.Platform//6.8 org.kde.Sdk//6.8
+   flatpak-builder --user --install --force-clean build-dir \
+     packaging/flatpak/io.github.sectapunterx.heap.yaml
+   flatpak run io.github.sectapunterx.heap
+   ```
+2. Validate metadata:
+   ```bash
+   flatpak run org.freedesktop.appstream.cli validate \
+     packaging/flatpak/io.github.sectapunterx.heap.metainfo.xml
+   ```
+   (If `post-install` install paths fail, adjust them relative to the build cwd.)
+3. Submit: fork [`flathub/flathub`](https://github.com/flathub/flathub), create a
+   branch off `new-pr`, add the manifest, open a PR. A reviewer runs the build and
+   may request tweaks. On approval you get a dedicated `flathub/io.github.sectapunterx.heap`
+   repo; bump the `tag`/`commit` there for each release.
+
+---
+
+## Not yet done (need external accounts)
+
+| Channel | What's needed |
+|---------|---------------|
+| **Homebrew Cask** (macOS) | own tap repo `homebrew-heap` with a cask pointing at the `.dmg`, or PR to `homebrew/homebrew-cask` (has a notability bar) |
+| **AUR** (Arch) | AUR account + SSH key; push a `PKGBUILD` |
+| **Snap Store** | Snapcraft account; `snapcraft.yaml` + `snapcraft upload` |
+| **Chocolatey** | community account + API key; `.nuspec` + `choco push` |
+| **Microsoft Store** | $19 one-time dev account + MSIX packaging (removes SmartScreen entirely) |

--- a/packaging/flatpak/io.github.sectapunterx.heap.desktop
+++ b/packaging/flatpak/io.github.sectapunterx.heap.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=heap.
+GenericName=Task & schedule planner
+Comment=Work, in one place — tasks, calendar, notes, and docs
+Exec=heap
+Icon=io.github.sectapunterx.heap
+Terminal=false
+Categories=Office;ProjectManagement;Utility;
+Keywords=tasks;todo;kanban;calendar;notes;planner;
+StartupWMClass=heap

--- a/packaging/flatpak/io.github.sectapunterx.heap.metainfo.xml
+++ b/packaging/flatpak/io.github.sectapunterx.heap.metainfo.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Flathub AppStream metainfo — DRAFT.
+     TODO before PR: replace the screenshot URL with a real, reachable image
+     (Flathub requires at least one). Validate with:
+       flatpak run org.freedesktop.appstream.cli validate \
+         packaging/flatpak/io.github.sectapunterx.heap.metainfo.xml -->
+<component type="desktop-application">
+  <id>io.github.sectapunterx.heap</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>heap.</name>
+  <summary>Native kanban, calendar and docs for engineers</summary>
+  <description>
+    <p>
+      heap. keeps tasks, calendar, notes and docs in one place. It is a native
+      desktop app built with Qt 6 / QML / C++20 — a single binary with a
+      per-profile JSON workspace, no accounts and no cloud required.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Kanban board for tasks</li>
+      <li>Calendar and schedule planning</li>
+      <li>Notes and documents</li>
+      <li>Local, per-profile JSON workspace</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">io.github.sectapunterx.heap.desktop</launchable>
+  <developer id="io.github.sectapunterx">
+    <name>sectapunterx</name>
+  </developer>
+  <url type="homepage">https://github.com/sectapunterx/heap</url>
+  <url type="bugtracker">https://github.com/sectapunterx/heap/issues</url>
+  <url type="vcs-browser">https://github.com/sectapunterx/heap</url>
+  <content_rating type="oars-1.1" />
+  <screenshots>
+    <screenshot type="default">
+      <caption>Board view — kanban columns, pinned calendar and people pane</caption>
+      <image>https://raw.githubusercontent.com/sectapunterx/heap/master/docs/assets/img/screens/board-full.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Week view — 7-day grid with drag/resize events</caption>
+      <image>https://raw.githubusercontent.com/sectapunterx/heap/master/docs/assets/img/screens/board-week.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Day calendar — drag-to-create and focus blocks</caption>
+      <image>https://raw.githubusercontent.com/sectapunterx/heap/master/docs/assets/img/screens/calendar-focus.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Docs — custom sections, snippets and contact cards</caption>
+      <image>https://raw.githubusercontent.com/sectapunterx/heap/master/docs/assets/img/screens/board-docs.png</image>
+    </screenshot>
+  </screenshots>
+  <categories>
+    <category>Office</category>
+    <category>ProjectManagement</category>
+  </categories>
+  <keywords>
+    <keyword>kanban</keyword>
+    <keyword>tasks</keyword>
+    <keyword>todo</keyword>
+    <keyword>calendar</keyword>
+    <keyword>notes</keyword>
+    <keyword>planner</keyword>
+  </keywords>
+  <releases>
+    <release version="0.4.2" date="2026-07-07" />
+  </releases>
+</component>

--- a/packaging/flatpak/io.github.sectapunterx.heap.yaml
+++ b/packaging/flatpak/io.github.sectapunterx.heap.yaml
@@ -1,0 +1,53 @@
+# Flathub manifest for heap. — DRAFT.
+#
+# Build/test locally BEFORE opening the Flathub PR:
+#   flatpak install flathub org.kde.Platform//6.8 org.kde.Sdk//6.8
+#   flatpak-builder --user --install --force-clean build-dir \
+#     packaging/flatpak/io.github.sectapunterx.heap.yaml
+#   flatpak run io.github.sectapunterx.heap
+#
+# Then submit: fork github.com/flathub/flathub (branch `new-pr`), add this repo,
+# open a PR. See docs/DISTRIBUTION.md.
+#
+# TODO before PR:
+#   - Confirm the latest org.kde.Platform runtime-version on Flathub (6.8/6.9).
+#   - If post-install paths fail, prefix with the source-checkout root.
+# (Screenshots already wired to docs/assets/img/screens/* in the .metainfo.xml.)
+id: io.github.sectapunterx.heap
+runtime: org.kde.Platform
+runtime-version: '6.8'
+sdk: org.kde.Sdk
+command: heap
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - '*.a'
+modules:
+  - name: heap
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DHEAP_BUILD_TESTS=OFF
+    sources:
+      - type: git
+        url: https://github.com/sectapunterx/heap.git
+        tag: v0.4.2
+        commit: b3006e0b06bc373c540eec44f8f37e9d0e6f1492
+    # install(TARGETS heap RUNTIME DESTINATION bin) puts the binary in /app/bin.
+    # The desktop/icon/metainfo are shipped under the app-id name, as Flathub
+    # requires.
+    post-install:
+      - install -Dm644 packaging/flatpak/io.github.sectapunterx.heap.desktop
+          /app/share/applications/io.github.sectapunterx.heap.desktop
+      - install -Dm644 packaging/flatpak/io.github.sectapunterx.heap.metainfo.xml
+          /app/share/metainfo/io.github.sectapunterx.heap.metainfo.xml
+      - install -Dm644 design/brand-export/icon/heap-icon.svg
+          /app/share/icons/hicolor/scalable/apps/io.github.sectapunterx.heap.svg

--- a/packaging/winget/sectapunterx.heap.installer.yaml
+++ b/packaging/winget/sectapunterx.heap.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: sectapunterx.heap
+PackageVersion: 0.4.2
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/sectapunterx/heap/releases/download/v0.4.2/heap-v0.4.2-windows-setup.exe
+    InstallerSha256: D8D3F75B1D2247115D1769397933E243DFAEDE32E5C4A8318F47907E8E91F9AA
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/sectapunterx.heap.locale.en-US.yaml
+++ b/packaging/winget/sectapunterx.heap.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: sectapunterx.heap
+PackageVersion: 0.4.2
+PackageLocale: en-US
+Publisher: sectapunterx
+PublisherUrl: https://github.com/sectapunterx
+PublisherSupportUrl: https://github.com/sectapunterx/heap/issues
+PackageName: heap.
+PackageUrl: https://github.com/sectapunterx/heap
+License: MIT
+LicenseUrl: https://github.com/sectapunterx/heap/blob/master/LICENSE
+Copyright: Copyright (c) sectapunterx
+ShortDescription: Native desktop kanban, calendar and docs for engineers.
+Description: |-
+  heap. is a native desktop kanban, calendar, and docs app for engineers.
+  Built with Qt 6 / QML / C++20, it ships as a single binary with a
+  per-profile JSON workspace — tasks, calendar, notes and docs in one place.
+Moniker: heap
+Tags:
+  - kanban
+  - todo
+  - calendar
+  - notes
+  - planner
+  - productivity
+  - qt
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/sectapunterx.heap.yaml
+++ b/packaging/winget/sectapunterx.heap.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: sectapunterx.heap
+PackageVersion: 0.4.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## What

Add free distribution channels beyond GitHub Releases. Top-3 chosen: **Scoop**
(live now), **winget** and **Flathub** (manifests prepared, ready to submit).

## Changes

- **Scoop** — `bucket/heap.json`. This repo is now a usable Scoop bucket:
  ```powershell
  scoop bucket add heap https://github.com/sectapunterx/heap
  scoop install heap
  ```
  `checkver: github` + `autoupdate` track the latest release. Real SHA256 of the
  v0.4.2 portable zip.
- **winget** — `packaging/winget/` (manifest schema 1.6.0): version + installer
  (inno, real SHA256 of the setup .exe) + en-US locale. Ready to PR to
  `microsoft/winget-pkgs`.
- **Flathub** — `packaging/flatpak/`: manifest (KDE 6 runtime, builds from the
  `v0.4.2` tag/commit) + AppStream metainfo (real screenshots from
  `docs/assets/img/screens/`) + app-id desktop file. **Draft** — test with
  `flatpak-builder` before the `flathub/flathub` PR.
- **Docs** — `docs/DISTRIBUTION.md` with per-channel submit/update steps; README
  "Get it" gains the Scoop one-liner.
- `.gitignore` ignores local `/signpath-setup/` notes.

## Not in scope (need external accounts)

AUR, Snap, Chocolatey, Homebrew tap, Microsoft Store — listed in DISTRIBUTION.md.

## Notes

- Binaries/installer are still **unsigned** (SignPath dormant); winget accepts
  them, signing is a separate follow-up.
- No code touched — manifests + docs only.

## Verify

- Scoop (Windows), after merge to master:
  `scoop bucket add heap https://github.com/sectapunterx/heap && scoop install heap`
- winget: `winget validate --manifest packaging\winget`
- Flathub: `flatpak-builder --user --install --force-clean build-dir packaging/flatpak/io.github.sectapunterx.heap.yaml`
