### PR TITLE
ci: bump first-party actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
@@ -95,7 +95,7 @@ jobs:
   #   runs-on: ubuntu-24.04
   #   timeout-minutes: 10
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v7
   #       with: { fetch-depth: 0 }
   #     - name: Install Qt6 declarative tools
   #       run: |
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: raven-actions/actionlint@v2
         with:
           files: ".github/workflows/*.yml"
@@ -148,7 +148,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
@@ -227,7 +227,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, windows-latest, macos-14]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Ubuntu 24.04's apt ships Qt 6.4.2, which has a static-QML-module
       # qmlcachegen bug: file-based .qml components ("SideRail is not a type")
@@ -333,7 +333,7 @@ jobs:
 
       - name: Upload build artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-${{ matrix.os }}
           path: build-${{ matrix.os }}.tar
@@ -352,7 +352,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, windows-latest, macos-14]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Same Qt (install-qt-action 6.8.1) as the build job so the tarred build
       # tree matches the runtime. Qt's own QML modules ship with the install, so
@@ -395,7 +395,7 @@ jobs:
           modules: qtnetworkauth
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-${{ matrix.os }}
 
@@ -434,7 +434,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.os }}
           path: build/tests/ctest-${{ matrix.os }}.xml
@@ -456,7 +456,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install build tools + system libs
         run: |
@@ -514,7 +514,7 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Qt6
         uses: jurplel/install-qt-action@v4
@@ -618,7 +618,7 @@ jobs:
   #   timeout-minutes: 20
   #   needs: test
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v7
   #
   #     - name: Install toolchain
   #       run: |
@@ -652,7 +652,7 @@ jobs:
   #
   #     - name: Upload coverage artifact
   #       if: always()
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v7
   #       with:
   #         name: coverage-lcov
   #         path: coverage.lcov

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,23 +35,23 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # enablement: true flips the repo Pages source from the legacy builder to
       # GitHub Actions on first run, so no manual Settings → Pages toggle.
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         with:
           enablement: true
 
       - name: Upload docs/ as the Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       # Every publish mints a new github-pages deployment record; only the newest
       # is live. Left alone they pile up in the Environments view (one per docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       release: ${{ steps.tag.outputs.release }}
       prerelease: ${{ steps.tag.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Resolve version & release kind
@@ -90,7 +90,7 @@ jobs:
     env:
       SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -154,7 +154,7 @@ jobs:
       - name: Upload unsigned portable bundle
         if: ${{ env.SIGNPATH_API_TOKEN != '' }}
         id: upload-portable
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unsigned-portable
           path: build/heap-portable
@@ -200,7 +200,7 @@ jobs:
       - name: Upload unsigned installer
         if: ${{ env.SIGNPATH_API_TOKEN != '' }}
         id: upload-installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unsigned-installer
           path: installer/Output/heap-${{ needs.meta.outputs.tag }}-windows-setup.exe
@@ -219,7 +219,7 @@ jobs:
           output-artifact-directory: installer/Output
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-windows
           path: |
@@ -236,7 +236,7 @@ jobs:
     needs: meta
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install toolchain
         run: |
@@ -305,7 +305,7 @@ jobs:
             --plugin qt --output appimage
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-linux
           path: |
@@ -336,7 +336,7 @@ jobs:
       MACOS_NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
       MACOS_NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Ninja
         run: brew install ninja
@@ -464,7 +464,7 @@ jobs:
           spctl -a -t open --context context:primary-signature -vv "$DMG"
 
       - name: Upload macOS artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-macos
           path: heap-${{ needs.meta.outputs.tag }}-macos.dmg
@@ -490,7 +490,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           # Only the packaged per-platform bundles — NOT the unsigned-* SignPath


### PR DESCRIPTION
## Why

GitHub is force-migrating `actions/*` off the deprecated Node 20 runtime (warning surfaced on the last Pages deploy). Bump to the current majors that ship on Node 24.

## Changes

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/configure-pages | v5 | v6 |
| actions/deploy-pages | v4 | v5 |
| actions/upload-pages-artifact | v3 | v5 |

## Notes

- Artifact up/download stay on the shared v4+ backend, so cross-job artifact passing in `ci.yml` / `release.yml` is unaffected.
- The Pages trio (configure-pages / upload-pages-artifact / deploy-pages) is bumped together to mutually-compatible latest majors.
- Third-party actions (jurplel, msys2, codecov, dorny, signpath, softprops, stefanzweifel, raven-actions) were not flagged by the deprecation notice and are left untouched.