### PR TITLE
HEAP-104: harden the task data model for lossless, time-aware persistence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,9 @@ qt_add_library(heap_core STATIC
     src/AppController.cpp
     src/Logger.cpp
     src/Models.cpp
+    src/RecoveryLog.cpp
     src/SampleData.cpp
+    src/StateSerializer.cpp
     src/CodeHighlighter.cpp
     src/NotesHighlighter.cpp
     src/chrono/ChronoTokenizer.cpp

--- a/qml/DayCalendar.qml
+++ b/qml/DayCalendar.qml
@@ -100,18 +100,41 @@ Item {
         _overlap = map;
     }
 
+    // ── Task blocks vs. their meeting events ──────────────────────────
+    // A "sync" capture creates both a task (with a scheduled time, HEAP-115)
+    // and a meeting event linked back to it via taskId. The event is the
+    // richer representation (attendees, duration), so the task's own block is
+    // suppressed on any day where a linked event already stands in for it —
+    // otherwise the same "синк с @hb" draws twice. Keyed by task id, recomputed
+    // with the overlaps on every events-model or day change.
+    property var _linkedTaskIds: ({})
+    function _recomputeLinkedTasks() {
+        const d = AppController.selectedDate;
+        const m = AppController.events;
+        const map = {};
+        for (let i = 0; i < m.rowCount(); i++) {
+            const idx = m.index(i, 0);
+            const ed = m.data(idx, Qt.UserRole + 7);   // DateRole
+            if (!root.isSameDay(ed, d)) continue;
+            const tid = String(m.data(idx, Qt.UserRole + 8) || "");  // TaskIdRole
+            if (tid.length > 0) map[tid] = true;
+        }
+        _linkedTaskIds = map;
+    }
+    function _recomputeDay() { _recountEventsToday(); _recomputeOverlaps(); _recomputeLinkedTasks(); }
+
     Connections {
         target: AppController.events
-        function onRowsInserted() { root._recountEventsToday(); root._recomputeOverlaps() }
-        function onRowsRemoved()  { root._recountEventsToday(); root._recomputeOverlaps() }
-        function onDataChanged()  { root._recountEventsToday(); root._recomputeOverlaps() }
-        function onModelReset()   { root._recountEventsToday(); root._recomputeOverlaps() }
+        function onRowsInserted() { root._recomputeDay() }
+        function onRowsRemoved()  { root._recomputeDay() }
+        function onDataChanged()  { root._recomputeDay() }
+        function onModelReset()   { root._recomputeDay() }
     }
     Connections {
         target: AppController
-        function onSelectedDateChanged() { root._recountEventsToday(); root._recomputeOverlaps() }
+        function onSelectedDateChanged() { root._recomputeDay() }
     }
-    Component.onCompleted: { _recountEventsToday(); _recomputeOverlaps() }
+    Component.onCompleted: root._recomputeDay()
 
     function isSameDay(a, b) {
         if (!a || !b || !a.getFullYear || !b.getFullYear) return false;
@@ -585,6 +608,7 @@ Item {
 
                                 visible: !archived && status !== "done" && startHour >= 0
                                          && root.isSameDay(scheduledAt, AppController.selectedDate)
+                                         && !root._linkedTaskIds[id]
                                 x: 0
                                 y: (startHour - root.hoursStart) * Theme.hourH
                                 width: Math.max(20, parent.width * 0.5 - 3)

--- a/qml/DayCalendar.qml
+++ b/qml/DayCalendar.qml
@@ -10,6 +10,7 @@ Item {
     readonly property real pxPerMin: Theme.hourH / 60.0
 
     signal eventClicked(string id)
+    signal taskClicked(string id)
 
     function snapHour(h)  {
         const step = Math.max(1, Theme.snapMinutes) / 60.0;
@@ -572,6 +573,7 @@ Item {
                                 id: taskBlock
                                 required property string id
                                 required property string title
+                                objectName: "taskblock-" + id
                                 required property var scheduledAt
                                 required property bool hasTime
                                 required property bool archived
@@ -588,8 +590,8 @@ Item {
                                 width: Math.max(20, parent.width * 0.5 - 3)
                                 height: Theme.hourH - 2
                                 radius: 6
-                                color: Theme.withAlpha(Theme.eventColor("focus"), 0.10)
-                                border.color: Theme.withAlpha(Theme.eventColor("focus"), 0.5)
+                                color: Theme.withAlpha(Theme.eventColor("focus"), openArea.containsMouse ? 0.18 : 0.10)
+                                border.color: Theme.withAlpha(Theme.eventColor("focus"), openArea.containsMouse ? 0.9 : 0.5)
                                 border.width: 1
                                 z: 4
 
@@ -600,6 +602,17 @@ Item {
                                     color: Theme.text
                                     font.pixelSize: 11
                                     elide: Text.ElideRight
+                                }
+
+                                // The block carried no MouseArea, so a click on it was
+                                // swallowed and the task never opened. Clicks must not
+                                // reach the create-an-event area underneath either.
+                                MouseArea {
+                                    id: openArea
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: root.taskClicked(taskBlock.id)
                                 }
                             }
                         }

--- a/qml/DayCalendar.qml
+++ b/qml/DayCalendar.qml
@@ -562,6 +562,48 @@ Item {
                             }
                         }
 
+                        // Layer 3b: tasks scheduled at a clock time (HEAP-115).
+                        // Before this, the only way a task's parsed time reached
+                        // the day view was a side focus-block event; now the
+                        // task's own scheduledAt puts it here.
+                        Repeater {
+                            model: AppController.tasks
+                            Rectangle {
+                                id: taskBlock
+                                required property string id
+                                required property string title
+                                required property var scheduledAt
+                                required property bool hasTime
+                                required property bool archived
+                                required property string status
+
+                                readonly property real startHour: hasTime && scheduledAt && scheduledAt.getHours
+                                    ? scheduledAt.getHours() + scheduledAt.getMinutes() / 60.0
+                                    : -1
+
+                                visible: !archived && status !== "done" && startHour >= 0
+                                         && root.isSameDay(scheduledAt, AppController.selectedDate)
+                                x: 0
+                                y: (startHour - root.hoursStart) * Theme.hourH
+                                width: Math.max(20, parent.width * 0.5 - 3)
+                                height: Theme.hourH - 2
+                                radius: 6
+                                color: Theme.withAlpha(Theme.eventColor("focus"), 0.10)
+                                border.color: Theme.withAlpha(Theme.eventColor("focus"), 0.5)
+                                border.width: 1
+                                z: 4
+
+                                Text {
+                                    anchors.fill: parent
+                                    anchors.margins: 6
+                                    text: "▸ " + taskBlock.title
+                                    color: Theme.text
+                                    font.pixelSize: 11
+                                    elide: Text.ElideRight
+                                }
+                            }
+                        }
+
                         // Now line
                         Rectangle {
                             visible: root.isSameDay(root.now, AppController.selectedDate)

--- a/qml/KanbanBoard.qml
+++ b/qml/KanbanBoard.qml
@@ -420,6 +420,9 @@ Item {
                                             required property int    trackedSeconds
                                             required property bool   isTiming
                                             required property string recurrence
+                                            required property var    labels
+                                            required property var    dueAt
+                                            required property bool   hasTime
                                             width: bodyCol.width
 
                                             readonly property var taskData: ({
@@ -431,7 +434,8 @@ Item {
                                                 gitAhead: tc.gitAhead, gitBehind: tc.gitBehind,
                                                 recentCommits: tc.recentCommits,
                                                 trackedSeconds: tc.trackedSeconds, isTiming: tc.isTiming,
-                                                recurrence: tc.recurrence
+                                                recurrence: tc.recurrence,
+                                                labels: tc.labels, dueAt: tc.dueAt, hasTime: tc.hasTime
                                             })
                                             task: taskData
                                             scheduled: root.scheduleMap[tc.id] || ""

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -400,6 +400,7 @@ ApplicationWindow {
                         SplitView.fillHeight: true
                         SplitView.minimumHeight: 120
                         onEventClicked: (id) => eventEditor.showForId(id)
+                        onTaskClicked: (id) => taskEditor.showFor(Object.assign({}, AppController.taskById(id)))
                     }
                     PeopleList {
                         SplitView.preferredHeight: 220

--- a/qml/QuickCapturePopup.qml
+++ b/qml/QuickCapturePopup.qml
@@ -152,8 +152,12 @@ Popup {
         if (_meta && _meta.desc && _meta.desc.length > 0) {
             draft.desc = _meta.desc;
         }
+        // The parsed datetime lands on the task itself — including the clock
+        // time, which used to survive only as a side calendar block (HEAP-115).
         if (_preview && _preview.ok && _preview.start) {
-            draft.deadline = _preview.start;
+            draft.scheduledAt = _preview.start;
+            draft.dueAt = _preview.start;
+            draft.hasTime = !!_preview.hasTime;
         }
         // Persist a parsed recurrence ("every weekday…") so completing the task
         // regenerates it (HEAP-77).
@@ -162,9 +166,10 @@ Popup {
         }
         AppController.saveTask(draft);
 
-        // Calendar entry rules:
+        // Calendar entry rules. A parsed time is already stored on the task and
+        // shows up on the Day view, so only a meeting still needs an event:
         //  - "ticket"/"задача" → never schedule (pure todo item)
-        //  - "focus"           → focus block (deep-work, left column on calendar)
+        //  - "focus"           → the task's own scheduled time is the block
         //  - "sync"/"созвон"   → meeting on calendar (right column with созвоны)
         //  - none of the above → no calendar entry even if a time was parsed
         const noTime = !(_preview && _preview.ok && _preview.hasTime && _preview.start);
@@ -178,7 +183,6 @@ Popup {
         const startHour = d.getHours() + d.getMinutes() / 60.0;
 
         if (kind === "focus") {
-            AppController.scheduleTask(draft.id, startHour, d);
             AppController.selectedDate = d;
         } else if (kind === "sync") {
             // Honour parsed range "12:00-13:00", else default 30 min.

--- a/qml/TaskCard.qml
+++ b/qml/TaskCard.qml
@@ -267,19 +267,28 @@ Rectangle {
                 property string dlText: {
                     if (!card.task || !card.task.deadline) return "";
                     const dl = card.task.deadline;
-                    if (!dl.getTime) return "";
+                    // An unset date arrives as an Invalid Date — truthy, but its
+                    // time is NaN, which used to render as "⏱ NaNd".
+                    if (!dl.getTime || isNaN(dl.getTime())) return "";
                     const t = AppController.today;
                     const ms = dl.getTime() - new Date(t.getFullYear(), t.getMonth(), t.getDate()).getTime();
                     const days = Math.round(ms / 86400000);
-                    if (days < 0) return "⏱ " + (-days) + "d overdue";
-                    if (days === 0) return "⏱ today";
-                    if (days === 1) return "⏱ tomorrow";
-                    return "⏱ " + days + "d";
+                    // A task due at a clock time shows it; a bare date does not.
+                    let clock = "";
+                    if (card.task.hasTime && card.task.dueAt && card.task.dueAt.getHours) {
+                        clock = " " + String(card.task.dueAt.getHours()).padStart(2, "0")
+                              + ":" + String(card.task.dueAt.getMinutes()).padStart(2, "0");
+                    }
+                    if (days < 0) return "⏱ " + (-days) + "d overdue" + clock;
+                    if (days === 0) return "⏱ today" + clock;
+                    if (days === 1) return "⏱ tomorrow" + clock;
+                    return "⏱ " + days + "d" + clock;
                 }
                 visible: dlText.length > 0
                 text: dlText
                 color: {
-                    if (!card.task || !card.task.deadline || !card.task.deadline.getTime) return Theme.textDim;
+                    if (!card.task || !card.task.deadline || !card.task.deadline.getTime
+                        || isNaN(card.task.deadline.getTime())) return Theme.textDim;
                     const dl = card.task.deadline;
                     const t = AppController.today;
                     const days = Math.round((dl.getTime() - new Date(t.getFullYear(), t.getMonth(), t.getDate()).getTime()) / 86400000);
@@ -289,6 +298,27 @@ Rectangle {
                 }
                 font.family: Theme.fontMono
                 font.pixelSize: 10
+            }
+            // Label chips (HEAP-124). Tracker-pulled labels carry no colour, so
+            // they fall back to the muted chip style.
+            Repeater {
+                model: card.task && card.task.labels ? card.task.labels : []
+                delegate: Rectangle {
+                    required property var modelData
+                    radius: 4
+                    color: Theme.withAlpha(modelData.color || Theme.textMuted, 0.14)
+                    border.color: modelData.color || Theme.border
+                    border.width: 1
+                    implicitWidth: labelT.implicitWidth + 10
+                    implicitHeight: labelT.implicitHeight + 2
+                    Text {
+                        id: labelT
+                        anchors.centerIn: parent
+                        text: modelData.id
+                        color: modelData.color || Theme.textMuted
+                        font.pixelSize: 10
+                    }
+                }
             }
             // Recurrence chip (HEAP-77).
             Rectangle {

--- a/qml/TaskEditor.qml
+++ b/qml/TaskEditor.qml
@@ -35,7 +35,11 @@ Popup {
         statusBox.currentIndex = Math.max(0, statusList().indexOf(draft.status));
         priBox.currentIndex = Math.max(0, ["P0", "P1", "P2", "P3"].indexOf(draft.priority || "P2"));
         branchField.text = draft.branch || "";
-        deadlineField.text = formatDate(draft.deadline);
+        deadlineField.text = formatWhen(draft.dueAt, draft.hasTime);
+        scheduledField.text = formatWhen(draft.scheduledAt, draft.hasTime);
+        labelsField.text = labelsToText(draft.labels);
+        estimateField.text = draft.estimateMinutes > 0 ? String(draft.estimateMinutes) : "";
+        somedayBox.checked = !!draft.someday;
         recurBox.currentIndex = Math.max(0, recurBox._vals.indexOf(draft.recurrence || ""));
         open();
         // Kick a one-shot PR/state refresh for this task's branch across all
@@ -63,13 +67,54 @@ Popup {
         return d.getFullYear() + "-" + (d.getMonth() + 1).toString().padStart(2, "0") + "-" + d.getDate().toString().padStart(2, "0");
     }
 
+    // Renders a stored datetime back into the field. The clock part is only
+    // shown when the task actually carries one — a bare date must not come back
+    // as "… 00:00" and turn itself into a timed task on the next save.
+    function formatWhen(d, hasTime) {
+        if (!d || !d.getFullYear || isNaN(d.getTime())) return "";
+        const iso = formatDate(d);
+        if (!hasTime) return iso;
+        return iso + " " + String(d.getHours()).padStart(2, "0") + ":" + String(d.getMinutes()).padStart(2, "0");
+    }
+
+    // "YYYY-MM-DD" or "YYYY-MM-DD HH:MM" — the shape formatWhen writes back into
+    // the field, parsed without going through the natural-language parser.
+    readonly property var _isoRe: /^(\d{4})-(\d{1,2})-(\d{1,2})(?:[ T](\d{1,2}):(\d{2}))?$/
+
     function parseDate(s) {
         if (!s) return undefined;
         const r = AppController.parseDateTime(s, new Date());
         if (r && r.ok && r.start) return r.start;
-        const parts = s.split("-");
-        if (parts.length !== 3) return undefined;
-        return new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2]));
+        const m = root._isoRe.exec(s.trim());
+        if (!m) return undefined;
+        return new Date(parseInt(m[1]), parseInt(m[2]) - 1, parseInt(m[3]),
+                        m[4] ? parseInt(m[4]) : 0, m[5] ? parseInt(m[5]) : 0);
+    }
+
+    // Does this field carry a clock time, as opposed to a bare date?
+    function parseHasTime(s) {
+        if (!s) return false;
+        const r = AppController.parseDateTime(s, new Date());
+        if (r && r.ok) return !!r.hasTime;
+        const m = root._isoRe.exec(s.trim());
+        return !!(m && m[4]);
+    }
+
+    function labelsToText(labels) {
+        if (!labels || !labels.length) return "";
+        const out = [];
+        for (let i = 0; i < labels.length; ++i) out.push(labels[i].id);
+        return out.join(", ");
+    }
+
+    function labelsFromText(s) {
+        const out = [];
+        const parts = (s || "").split(",");
+        for (let i = 0; i < parts.length; ++i) {
+            const id = parts[i].trim();
+            if (id.length > 0) out.push(id);
+        }
+        return out;
     }
 
     property var _deadlinePreview: ({ok: false})
@@ -283,7 +328,8 @@ Popup {
                     onEditingFinished: {
                         if (root._deadlinePreview && root._deadlinePreview.ok &&
                             root._deadlinePreview.start) {
-                            text = root.formatDate(root._deadlinePreview.start);
+                            text = root.formatWhen(root._deadlinePreview.start,
+                                                   root._deadlinePreview.hasTime);
                         }
                     }
                     ToolTip.visible: hovered && text.length > 0 &&
@@ -390,6 +436,50 @@ Popup {
                 }
             }
             Item {}
+
+            FieldLabel { text: "SCHEDULED" }
+            FieldLabel { text: "ESTIMATE (MIN)" }
+            TextField {
+                id: scheduledField
+                Layout.fillWidth: true
+                placeholderText: I18n.t("editor.ph.deadline")
+                font.family: Theme.fontMono
+                background: FieldBg {}
+                color: Theme.text
+                placeholderTextColor: Theme.textDim
+            }
+            TextField {
+                id: estimateField
+                Layout.fillWidth: true
+                placeholderText: "45"
+                font.family: Theme.fontMono
+                validator: IntValidator { bottom: 0; top: 100000 }
+                background: FieldBg {}
+                color: Theme.text
+                placeholderTextColor: Theme.textDim
+            }
+
+            FieldLabel { text: "LABELS" }
+            FieldLabel { text: "" }
+            TextField {
+                id: labelsField
+                Layout.fillWidth: true
+                placeholderText: "backlog, infra"
+                background: FieldBg {}
+                color: Theme.text
+                placeholderTextColor: Theme.textDim
+            }
+            CheckBox {
+                id: somedayBox
+                text: "Someday"
+                contentItem: Text {
+                    text: somedayBox.text
+                    color: Theme.text
+                    font.pixelSize: 12
+                    leftPadding: somedayBox.indicator.width + 6
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
         }
 
         RowLayout {
@@ -430,6 +520,15 @@ Popup {
                     const inlineDesc   = meta.desc;
                     const handleNames  = root._resolvePeopleNames(meta.handles);
 
+                    // Due and scheduled are typed independently; a task with only
+                    // a due date is scheduled for that day, which is what the
+                    // single deadline field always meant.
+                    const dueAt = root.parseDate(deadlineField.text);
+                    const schedTyped = root.parseDate(scheduledField.text);
+                    const scheduledAt = schedTyped || dueAt;
+                    const hasTime = root.parseHasTime(scheduledField.text)
+                                 || root.parseHasTime(deadlineField.text);
+
                     const d = {
                         _isNew: root.isNew,
                         // Pass the original id alongside the (possibly edited)
@@ -446,15 +545,19 @@ Popup {
                               : descField.text,
                         priority: priBox.currentText,
                         status: root.statusList()[statusBox.currentIndex],
-                        deadline: root.parseDate(deadlineField.text),
+                        scheduledAt: scheduledAt,
+                        dueAt: dueAt,
+                        hasTime: hasTime,
                         branch: branchField.text,
-                        recurrence: recurBox._vals[recurBox.currentIndex] || ""
+                        recurrence: recurBox._vals[recurBox.currentIndex] || "",
+                        labels: root.labelsFromText(labelsField.text),
+                        estimateMinutes: parseInt(estimateField.text || "0") || 0,
+                        someday: somedayBox.checked
                     };
                     AppController.saveTask(d);
-                    // Same classification rules as QuickCapturePopup — only
-                    // surface the parsed time on the calendar when the user
-                    // hinted at an event kind. "ticket"/"задача" wins over
-                    // everything (pure todo, never schedule).
+                    // The parsed clock time now lives on the task itself, so a
+                    // focus block is no longer needed to keep it. A "sync" still
+                    // means a meeting, and a meeting is a calendar event.
                     if (root.isNew
                         && root._deadlinePreview && root._deadlinePreview.ok
                         && root._deadlinePreview.hasTime
@@ -463,32 +566,26 @@ Popup {
                             (titleField.text || "") + " "
                           + (descField.text || "") + " "
                           + (deadlineField.text || ""));
-                        if (kind !== "ticket") {
-                            const dt = root._deadlinePreview.start;
+                        const dt = root._deadlinePreview.start;
+                        if (kind === "sync") {
                             const startHour = dt.getHours() + dt.getMinutes() / 60.0;
-                            if (kind === "focus") {
-                                AppController.scheduleTask(d.id, startHour, dt);
-                                AppController.selectedDate = dt;
-                            } else if (kind === "sync") {
-                                // Honour parsed range "12:00-13:00", else 30m.
-                                let endHour = startHour + 0.5;
-                                const pe = root._deadlinePreview.end;
-                                if (pe && pe.getTime && pe.getTime() > 0) {
-                                    const eh = pe.getHours() + pe.getMinutes() / 60.0;
-                                    if (eh > startHour) endHour = eh;
-                                }
-                                const ev = AppController.newEventDraft(startHour, dt);
-                                ev.type      = "sync";
-                                ev.title     = (cleanedTitle || "").substring(0, 40);
-                                ev.end       = endHour;
-                                ev.taskId    = d.id;
-                                ev.date      = dt;
-                                ev.attendees = handleNames.join(", ");
-                                AppController.saveEvent(ev);
-                                AppController.selectedDate = dt;
+                            // Honour parsed range "12:00-13:00", else 30m.
+                            let endHour = startHour + 0.5;
+                            const pe = root._deadlinePreview.end;
+                            if (pe && pe.getTime && pe.getTime() > 0) {
+                                const eh = pe.getHours() + pe.getMinutes() / 60.0;
+                                if (eh > startHour) endHour = eh;
                             }
-                            // kind === "none" → keep deadline date only.
+                            const ev = AppController.newEventDraft(startHour, dt);
+                            ev.type      = "sync";
+                            ev.title     = (cleanedTitle || "").substring(0, 40);
+                            ev.end       = endHour;
+                            ev.taskId    = d.id;
+                            ev.date      = dt;
+                            ev.attendees = handleNames.join(", ");
+                            AppController.saveEvent(ev);
                         }
+                        if (kind !== "ticket") AppController.selectedDate = dt;
                     }
                     root.close();
                 }

--- a/src/AppController.cpp
+++ b/src/AppController.cpp
@@ -1,6 +1,9 @@
 #include "AppController.h"
 #include "Logger.h"
+#include "RecoveryLog.h"
 #include "SampleData.h"
+#include "StateSerializer.h"
+#include "TaskDefer.h"
 
 #include "chrono/ChronoParser.h"
 #include "git/BranchTaskMatcher.h"
@@ -651,7 +654,7 @@ void AppController::moveTask(const QString& id, const QString& newStatus) {
   const QString prevStatus = t.status;
   // Capture before any upsert can invalidate the `t` reference (HEAP-77).
   const QString recurrence = t.recurrence;
-  const QDate recurBase = t.deadline;
+  const QDate recurBase = t.dueAt.isValid() ? t.dueAt.date() : t.scheduledAt.date();
   m_tasks.setStatus(id, newStatus);
 
   // Mirror the change back to the linked tracker issue (e.g. moving to Done
@@ -709,7 +712,12 @@ void AppController::moveTask(const QString& id, const QString& newStatus) {
       } while(m_tasks.indexOfId(newId) >= 0);
       copy.id = newId;
       copy.status = QStringLiteral("todo");
-      copy.deadline = next;
+      // Roll both datetimes onto the next occurrence, keeping the clock time the
+      // user set (a 09:00 standup recurs at 09:00, not at midnight).
+      const QTime dueTime = copy.dueAt.isValid() ? copy.dueAt.time() : QTime(0, 0);
+      const QTime schedTime = copy.scheduledAt.isValid() ? copy.scheduledAt.time() : QTime(0, 0);
+      copy.dueAt = QDateTime(next, dueTime);
+      copy.scheduledAt = QDateTime(next, schedTime);
       copy.statusChangedAt = QDateTime::currentDateTime();
       copy.trackedSeconds = 0;
       copy.timerStartedAt = QDateTime();
@@ -740,8 +748,13 @@ QVariantMap AppController::newTaskDraft(const QString& statusId) const {
   m["desc"] = QString();
   m["priority"] = priorityDefault.isEmpty() ? QStringLiteral("P2") : priorityDefault;
   m["status"] = statusId.isEmpty() ? (statusDefault.isEmpty() ? QStringLiteral("todo") : statusDefault) : statusId;
-  m["deadline"] = QDate();
+  m["scheduledAt"] = QDateTime();
+  m["dueAt"] = QDateTime();
+  m["hasTime"] = false;
   m["branch"] = QString();
+  m["labels"] = QVariantList();
+  m["estimateMinutes"] = 0;
+  m["someday"] = false;
   return m;
 }
 
@@ -833,9 +846,25 @@ void AppController::saveTask(const QVariantMap& draft) {
   t.desc = draft.value("desc").toString();
   t.priority = draft.value("priority").toString();
   t.status = draft.value("status").toString();
-  t.deadline = draft.value("deadline").toDate();
   t.branch = draft.value("branch").toString();
   t.recurrence = draft.value("recurrence").toString();
+  // Scheduling (HEAP-115). The editors hand over full datetimes and say whether
+  // the clock component is real; a caller that only knows a date may still send
+  // the legacy `deadline` key, which lands at midnight on both fields.
+  t.scheduledAt = draft.value("scheduledAt").toDateTime();
+  t.dueAt = draft.value("dueAt").toDateTime();
+  t.hasTime = draft.value("hasTime").toBool();
+  if(!t.scheduledAt.isValid() && !t.dueAt.isValid() && draft.contains("deadline")) {
+    const QDate legacy = draft.value("deadline").toDate();
+    if(legacy.isValid()) {
+      t.scheduledAt = QDateTime(legacy, QTime(0, 0));
+      t.dueAt = t.scheduledAt;
+      t.hasTime = false;
+    }
+  }
+  t.estimateMinutes = draft.value("estimateMinutes").toInt();
+  t.someday = draft.value("someday").toBool();
+  t.labels = labelsFromVariant(draft.value("labels").toList());
   const bool isNew = draft.value("_isNew").toBool();
   if(isNew && t.title.trimmed().isEmpty()) {
     return;
@@ -862,6 +891,18 @@ void AppController::saveTask(const QVariantMap& draft) {
       t.externalId = prev.externalId;
       t.externalUrl = prev.externalUrl;
       t.externalProvider = prev.externalProvider;
+      // The editor never shows the tracker-supplied assignee, and the planning
+      // fields are honoured only when the draft actually carries them.
+      t.assignee = prev.assignee;
+      if(!draft.contains("labels")) {
+        t.labels = prev.labels;
+      }
+      if(!draft.contains("estimateMinutes")) {
+        t.estimateMinutes = prev.estimateMinutes;
+      }
+      if(!draft.contains("someday")) {
+        t.someday = prev.someday;
+      }
     }
   }
 
@@ -1324,12 +1365,21 @@ QVariantMap AppController::taskById(const QString& id) const {
   m["desc"] = t.desc;
   m["priority"] = t.priority;
   m["status"] = t.status;
-  m["deadline"] = t.deadline;
+  m["scheduledAt"] = t.scheduledAt;
+  m["dueAt"] = t.dueAt;
+  m["hasTime"] = t.hasTime;
   m["branch"] = t.branch;
   m["archived"] = t.archived;
   m["trackedSeconds"] = t.trackedSeconds;
   m["isTiming"] = t.timerStartedAt.isValid();
   m["recurrence"] = t.recurrence;
+  m["labels"] = labelsToVariant(t.labels);
+  m["estimateMinutes"] = t.estimateMinutes;
+  m["someday"] = t.someday;
+  m["assignee"] = t.assignee;
+  m["externalKey"] = externalKeyOf(t);
+  m["externalUrl"] = t.externalUrl;
+  m["externalProvider"] = t.externalProvider;
   return m;
 }
 
@@ -1500,8 +1550,8 @@ void AppController::copyActiveProfileMarkdownToClipboard() {
     }
     line += t.title;
     QStringList meta;
-    if(t.deadline.isValid()) {
-      meta << QStringLiteral("deadline: ") + t.deadline.toString(Qt::ISODate);
+    if(t.dueAt.isValid()) {
+      meta << QStringLiteral("deadline: ") + (t.hasTime ? t.dueAt.toString(Qt::ISODate) : t.dueAt.date().toString(Qt::ISODate));
     }
     if(!t.branch.isEmpty()) {
       meta << QStringLiteral("branch: ") + t.branch;
@@ -1988,22 +2038,45 @@ void AppController::openLogsFolder() const {
   QDesktopServices::openUrl(QUrl::fromLocalFile(heap::logging::logDirPath()));
 }
 
+QString AppController::issueReportBody() const {
+  QString body = QStringLiteral(
+                     "<!-- Describe the problem above this line. The diagnostics below are "
+                     "filled in automatically — please keep them. -->\n\n"
+                     "---\n"
+                     "**Diagnostics**\n"
+                     "- heap version: %1\n"
+                     "- OS: %2 (%3)\n"
+                     "- Qt: %4\n\n"
+                     "<details><summary>Recent log tail</summary>\n\n"
+                     "```\n%5\n```\n</details>\n")
+                     .arg(QCoreApplication::applicationVersion(),
+                          QSysInfo::prettyProductName(),
+                          QSysInfo::currentCpuArchitecture(),
+                          QString::fromLatin1(qVersion()),
+                          heap::logging::logTail());
+
+  // Corruption recoveries are the failures nobody reports because nobody sees
+  // them. Attach them to the report the user is already writing (HEAP-156).
+  const QString recovery = heap::recovery::tail();
+  if(!recovery.isEmpty()) {
+    body += QStringLiteral("\n<details><summary>Recovery log</summary>\n\n```\n%1\n```\n</details>\n").arg(recovery);
+  }
+  return body;
+}
+
+QVariantList AppController::recoveryLog() const {
+  return heap::recovery::entries();
+}
+
+bool AppController::exportRecoveryLog(const QUrl& fileUrl) {
+  const QString path = fileUrl.isLocalFile() ? fileUrl.toLocalFile() : fileUrl.toString();
+  const bool ok = heap::recovery::exportTo(path);
+  emit toast(ok ? tr("Recovery log saved") : tr("No recovery log to export"));
+  return ok;
+}
+
 void AppController::reportAnIssue() const {
-  const QString body = QStringLiteral(
-                           "<!-- Describe the problem above this line. The diagnostics below are "
-                           "filled in automatically — please keep them. -->\n\n"
-                           "---\n"
-                           "**Diagnostics**\n"
-                           "- heap version: %1\n"
-                           "- OS: %2 (%3)\n"
-                           "- Qt: %4\n\n"
-                           "<details><summary>Recent log tail</summary>\n\n"
-                           "```\n%5\n```\n</details>\n")
-                           .arg(QCoreApplication::applicationVersion(),
-                                QSysInfo::prettyProductName(),
-                                QSysInfo::currentCpuArchitecture(),
-                                QString::fromLatin1(qVersion()),
-                                heap::logging::logTail());
+  const QString body = issueReportBody();
 
   QUrl url(QStringLiteral("https://github.com/sectapunterx/heap/issues/new"));
   QUrlQuery query;
@@ -2071,6 +2144,12 @@ void AppController::mergeExternalTasks(const QString& providerId,
     t.externalId = ext.externalId;
     t.externalUrl = ext.url;
     t.externalProvider = providerId;
+    // Pulled labels used to be parsed and thrown away (HEAP-124). Trackers hand
+    // us names only, so the chip colour stays empty.
+    t.labels.clear();
+    for(const QString& name : ext.labels) {
+      t.labels.append(Label{name, {}});
+    }
     m_tasks.upsert(t);
   }
   if(!issues.isEmpty()) {
@@ -2369,220 +2448,9 @@ void AppController::scheduleSave() {
 }
 
 // ───────────────── (de)serialisation helpers ─────────────────
-namespace {
-
-QJsonArray tasksToJson(const QVector<Task>& xs) {
-  QJsonArray a;
-  for(const Task& t : xs) {
-    QJsonObject o;
-    o["id"] = t.id;
-    o["title"] = t.title;
-    o["desc"] = t.desc;
-    o["priority"] = t.priority;
-    o["status"] = t.status;
-    o["deadline"] = t.deadline.isValid() ? t.deadline.toString(Qt::ISODate) : QString();
-    o["branch"] = t.branch;
-    o["statusChangedAt"] = t.statusChangedAt.isValid() ? t.statusChangedAt.toString(Qt::ISODate) : QString();
-    o["archived"] = t.archived;
-    // Time tracking (HEAP-78) — omitted when zero/stopped so untimed task JSON
-    // stays byte-identical.
-    if(t.trackedSeconds > 0) {
-      o["trackedSeconds"] = t.trackedSeconds;
-    }
-    if(t.timerStartedAt.isValid()) {
-      o["timerStartedAt"] = t.timerStartedAt.toString(Qt::ISODate);
-    }
-    // Recurrence (HEAP-77) — omitted for non-recurring tasks.
-    if(!t.recurrence.isEmpty()) {
-      o["recurrence"] = t.recurrence;
-    }
-    // Tracker-sync link — only emitted for synced tasks so locally-created
-    // task JSON stays byte-identical to before HEAP-74.
-    if(!t.externalId.isEmpty()) {
-      o["externalId"] = t.externalId;
-      o["externalUrl"] = t.externalUrl;
-      o["externalProvider"] = t.externalProvider;
-    }
-    a.append(o);
-  }
-  return a;
-}
-
-QVector<Task> tasksFromJson(const QJsonArray& a) {
-  QVector<Task> v;
-  v.reserve(a.size());
-  for(const auto& it : a) {
-    const QJsonObject o = it.toObject();
-    Task t;
-    t.id = o["id"].toString();
-    t.title = o["title"].toString();
-    t.desc = o["desc"].toString();
-    t.priority = o["priority"].toString();
-    t.status = o["status"].toString();
-    t.deadline = QDate::fromString(o["deadline"].toString(), Qt::ISODate);
-    t.branch = o["branch"].toString();
-    t.statusChangedAt = QDateTime::fromString(o["statusChangedAt"].toString(), Qt::ISODate);
-    if(!t.statusChangedAt.isValid()) {
-      t.statusChangedAt = QDateTime::currentDateTime();
-    }
-    t.archived = o["archived"].toBool(false);
-    t.trackedSeconds = o["trackedSeconds"].toInt(0);
-    t.timerStartedAt = QDateTime::fromString(o["timerStartedAt"].toString(), Qt::ISODate);
-    t.recurrence = o["recurrence"].toString();
-    t.externalId = o["externalId"].toString();
-    t.externalUrl = o["externalUrl"].toString();
-    t.externalProvider = o["externalProvider"].toString();
-    v.append(t);
-  }
-  return v;
-}
-
-QJsonArray eventsToJson(const QVector<CalEvent>& xs) {
-  QJsonArray a;
-  for(const CalEvent& e : xs) {
-    QJsonObject o;
-    o["id"] = e.id;
-    o["title"] = e.title;
-    o["type"] = e.type;
-    o["start"] = e.start;
-    o["end"] = e.end;
-    o["attendees"] = e.attendees;
-    o["date"] = e.date.isValid() ? e.date.toString(Qt::ISODate) : QString();
-    o["taskId"] = e.taskId;
-    o["profileId"] = e.profileId;
-    o["context"] = e.context;
-    a.append(o);
-  }
-  return a;
-}
-
-QVector<CalEvent> eventsFromJson(const QJsonArray& a, const QString& fallbackProfileId = QString()) {
-  QVector<CalEvent> v;
-  v.reserve(a.size());
-  for(const auto& it : a) {
-    const QJsonObject o = it.toObject();
-    CalEvent e;
-    e.id = o["id"].toString();
-    e.title = o["title"].toString();
-    e.type = o["type"].toString();
-    e.start = o["start"].toDouble();
-    e.end = o["end"].toDouble();
-    e.attendees = o["attendees"].toString();
-    e.date = QDate::fromString(o["date"].toString(), Qt::ISODate);
-    e.taskId = o["taskId"].toString();
-    e.profileId = o.contains("profileId") ? o["profileId"].toString() : fallbackProfileId;
-    e.context = o["context"].toString();
-    v.append(e);
-  }
-  return v;
-}
-
-QJsonArray peopleToJson(const QVector<Person>& xs) {
-  QJsonArray a;
-  for(const Person& p : xs) {
-    QJsonObject o;
-    o["id"] = p.id;
-    o["name"] = p.name;
-    o["role"] = p.role;
-    o["question"] = p.question;
-    o["state"] = p.state;
-    o["color"] = p.color.name();
-    a.append(o);
-  }
-  return a;
-}
-
-QVector<Person> peopleFromJson(const QJsonArray& a) {
-  QVector<Person> v;
-  v.reserve(a.size());
-  for(const auto& it : a) {
-    const QJsonObject o = it.toObject();
-    Person p;
-    p.id = o["id"].toString();
-    p.name = o["name"].toString();
-    p.role = o["role"].toString();
-    p.question = o["question"].toString();
-    p.state = o["state"].toString();
-    p.color = QColor(o["color"].toString());
-    v.append(p);
-  }
-  return v;
-}
-
-QJsonArray statusesToJson(const QVariantList& xs) {
-  QJsonArray a;
-  for(const QVariant& v : xs) {
-    const QVariantMap m = v.toMap();
-    QJsonObject o;
-    o["id"] = m.value("id").toString();
-    o["name"] = m.value("name").toString();
-    const QVariant col = m.value("color");
-    o["color"] = col.canConvert<QColor>() ? col.value<QColor>().name() : col.toString();
-    a.append(o);
-  }
-  return a;
-}
-
-QVariantList statusesFromJson(const QJsonArray& a) {
-  QVariantList v;
-  for(const auto& it : a) {
-    const QJsonObject o = it.toObject();
-    QVariantMap m;
-    m["id"] = o["id"].toString();
-    m["name"] = o["name"].toString();
-    m["color"] = QColor(o["color"].toString());
-    v.append(m);
-  }
-  return v;
-}
-
-QJsonObject profileToJson(const Profile& p) {
-  QJsonObject o;
-  o["id"] = p.id;
-  o["name"] = p.name;
-  o["color"] = p.color;
-  o["createdAt"] = p.createdAt.isValid() ? p.createdAt.toString(Qt::ISODate) : QString();
-  o["tasks"] = tasksToJson(p.tasks);
-  o["people"] = peopleToJson(p.people);
-  o["statuses"] = statusesToJson(p.statuses);
-  if(!p.docsState.isEmpty()) {
-    const QJsonDocument d = QJsonDocument::fromJson(p.docsState.toUtf8());
-    if(!d.isNull() && d.isObject()) {
-      o["docs"] = d.object();
-    }
-  }
-  if(!p.notesState.isEmpty()) {
-    o["notes"] = p.notesState;
-  }
-  return o;
-}
-
-// Returns the parsed Profile and pulls out any nested "events" array (legacy
-// schema v2) so the caller can hoist them into the global event pool with
-// fallback profileId = p.id.
-Profile profileFromJson(const QJsonObject& o, QVector<CalEvent>* outLegacyEvents = nullptr) {
-  Profile p;
-  p.id = o["id"].toString();
-  p.name = o["name"].toString();
-  p.color = o["color"].toString();
-  p.createdAt = QDateTime::fromString(o["createdAt"].toString(), Qt::ISODate);
-  p.tasks = tasksFromJson(o["tasks"].toArray());
-  p.people = peopleFromJson(o["people"].toArray());
-  p.statuses = statusesFromJson(o["statuses"].toArray());
-  if(o.contains("docs")) {
-    p.docsState = QJsonDocument(o["docs"].toObject()).toJson(QJsonDocument::Compact);
-  }
-  if(o.contains("notes")) {
-    p.notesState = o["notes"].toString();
-  }
-  if(outLegacyEvents && o.contains("events")) {
-    const QVector<CalEvent> v = eventsFromJson(o["events"].toArray(), p.id);
-    outLegacyEvents->append(v);
-  }
-  return p;
-}
-
-}  // namespace
+// Live state.json (de)serialisation now lives in src/StateSerializer.cpp
+// (namespace heap::state) so the round-trip + field-count guards can exercise
+// the real save path instead of a look-alike (HEAP-131).
 
 // ───────────────── Profile helpers (private) ─────────────────
 
@@ -2668,7 +2536,33 @@ Profile AppController::makeStartingProfile(const QString& name, const QString& c
   return p;
 }
 
-// ───────────────── Save / load (schema v2) ─────────────────
+// ───────────────── Save / load ─────────────────
+
+// The writer seam (HEAP-156). saveStateNow() never touches the filesystem
+// directly; it hands the serialized bytes to whatever is installed here. The
+// default is an atomic QSaveFile write; the fault-injection harness swaps in a
+// writer that truncates, corrupts or drops the rename.
+namespace {
+AppController::StateWriter g_stateWriter;
+
+bool defaultStateWriter(const QString& path, const QByteArray& bytes) {
+  QSaveFile f(path);
+  if(!f.open(QIODevice::WriteOnly)) {
+    qWarning("todocpp: cannot open state.json for writing: %s", qUtf8Printable(f.errorString()));
+    return false;
+  }
+  f.write(bytes);
+  if(!f.commit()) {
+    qWarning("todocpp: state.json commit failed: %s", qUtf8Printable(f.errorString()));
+    return false;
+  }
+  return true;
+}
+}  // namespace
+
+void AppController::setStateWriterForTesting(StateWriter writer) {
+  g_stateWriter = std::move(writer);
+}
 
 void AppController::rotateBackupIfDue() {
   const QVariantMap d = settingsMap().value("data").toMap();
@@ -2701,9 +2595,18 @@ void AppController::rotateBackupIfDue() {
 
 void AppController::pruneBackups(int keep) {
   QDir d(backupDirPath());
+  // Rotational snapshots only. The pre-migration copy retained by
+  // loadStateOnStart must survive retention: it is the only pre-v4 image of the
+  // user's data.
   const QStringList all = d.entryList({"state-*.json"}, QDir::Files | QDir::NoSymLinks, QDir::Time);
-  for(int i = keep; i < all.size(); ++i) {
-    d.remove(all[i]);
+  int kept = 0;
+  for(const QString& name : all) {
+    if(name.contains(QLatin1String("premigration"))) {
+      continue;
+    }
+    if(++kept > keep) {
+      d.remove(name);
+    }
   }
 }
 
@@ -2741,7 +2644,10 @@ void AppController::quarantineCorruptState(const QString& path) {
   }
   if(!QFile::rename(path, target)) {
     qWarning("todocpp: could not quarantine corrupt state.json to %s", qUtf8Printable(target));
+    return;
   }
+  heap::recovery::append(QString::fromLatin1(heap::recovery::kQuarantined),
+                         {{QStringLiteral("from"), path}, {QStringLiteral("to"), target}});
 }
 
 void AppController::saveStateNow() {
@@ -2753,17 +2659,17 @@ void AppController::saveStateNow() {
   snapshotActiveProfile();
 
   QJsonObject root;
-  root["schemaVersion"] = 3;
+  root["schemaVersion"] = heap::state::kSchemaVersion;
   root["activeProfileId"] = m_activeProfileId;
 
   QJsonArray profilesArr;
   for(const Profile& p : m_profiles) {
-    profilesArr.append(profileToJson(p));
+    profilesArr.append(heap::state::profileToJson(p));
   }
   root["profiles"] = profilesArr;
 
   // Events are global (shown across profiles in the calendar).
-  root["events"] = eventsToJson(m_events.items());
+  root["events"] = heap::state::eventsToJson(m_events.items());
 
   QJsonObject s;
   s["theme"] = m_theme;
@@ -2797,14 +2703,13 @@ void AppController::saveStateNow() {
 
   rotateBackupIfDue();
 
-  QSaveFile f(stateFilePath());
-  if(!f.open(QIODevice::WriteOnly)) {
-    qWarning("todocpp: cannot open state.json for writing: %s", qUtf8Printable(f.errorString()));
-    return;
-  }
-  f.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
-  if(!f.commit()) {
-    qWarning("todocpp: state.json commit failed: %s", qUtf8Printable(f.errorString()));
+  const QByteArray bytes = QJsonDocument(root).toJson(QJsonDocument::Indented);
+  const bool ok = g_stateWriter ? g_stateWriter(stateFilePath(), bytes) : defaultStateWriter(stateFilePath(), bytes);
+  if(!ok) {
+    // A failed write is the fault the user never sees. Leave a local record so
+    // "heap lost my edit" has evidence attached to the next bug report.
+    heap::recovery::append(QString::fromLatin1(heap::recovery::kWriteFailed),
+                           {{QStringLiteral("path"), stateFilePath()}, {QStringLiteral("bytes"), bytes.size()}});
   }
 }
 
@@ -2837,17 +2742,32 @@ void AppController::loadStateOnStart() {
       QFile::copy(recoveredFrom, path);
       doc = QJsonDocument(recovered);
       m_recoveryNotice = tr_("data.recovered").arg(QFileInfo(recoveredFrom).fileName());
+      heap::recovery::append(QString::fromLatin1(heap::recovery::kRecovered), {{QStringLiteral("from"), recoveredFrom}});
     } else {
       // No usable backup. Preserve the damaged file under a distinct name and
       // fall through to a fresh seed — the user keeps a recoverable copy and a
       // visible warning instead of a silent wipe.
       quarantineCorruptState(path);
       m_recoveryNotice = tr_("data.corruptKept");
+      heap::recovery::append(QString::fromLatin1(heap::recovery::kUnrecovered), {{QStringLiteral("path"), path}});
       return;
     }
   }
 
-  const QJsonObject root = doc.object();
+  QJsonObject root = doc.object();
+
+  // ----- schema ladder: field-level upgrades, before anything parses a task ---
+  // Version-gated and idempotent: a v4 document walks straight past this, so
+  // reopening the app never re-migrates. The original file is copied aside first
+  // — that copy is what a mid-migration failure reopens to, since it is the
+  // newest valid state-*.json in the backup dir.
+  const int onDiskSchema = root.value("schemaVersion").toInt(1);
+  if(onDiskSchema < heap::state::kSchemaVersion) {
+    retainPreMigrationBackup(path, onDiskSchema);
+    heap::state::migrateState(root, onDiskSchema);
+    heap::recovery::append(QString::fromLatin1(heap::recovery::kMigrated),
+                           {{QStringLiteral("from"), onDiskSchema}, {QStringLiteral("to"), heap::state::kSchemaVersion}});
+  }
 
   m_loading = true;
 
@@ -2908,7 +2828,8 @@ void AppController::loadStateOnStart() {
     }
   }
 
-  const int schema = root.value("schemaVersion").toInt(1);
+  // Structural decisions below key off what was on disk, not the migrated value.
+  const int schema = onDiskSchema;
   QVector<CalEvent> globalEvents;
 
   if(schema >= 2 && root.contains("profiles")) {
@@ -2917,7 +2838,7 @@ void AppController::loadStateOnStart() {
       // For v2, profiles still carried their own events — hoist them
       // into the global pool tagged with the source profile id.
       QVector<CalEvent> legacy;
-      m_profiles.push_back(profileFromJson(it.toObject(), schema < 3 ? &legacy : nullptr));
+      m_profiles.push_back(heap::state::profileFromJson(it.toObject(), schema < 3 ? &legacy : nullptr));
       if(!legacy.isEmpty()) {
         globalEvents.append(legacy);
       }
@@ -2928,7 +2849,7 @@ void AppController::loadStateOnStart() {
     }
     // schema v3 keeps events at top level.
     if(schema >= 3 && root.contains("events")) {
-      globalEvents = eventsFromJson(root["events"].toArray());
+      globalEvents = heap::state::eventsFromJson(root["events"].toArray());
     }
   } else {
     // ----- schema v1: flat fields → wrap into one "Example" profile -----
@@ -2938,20 +2859,20 @@ void AppController::loadStateOnStart() {
     p.color = "#5cc2dd";
     p.createdAt = QDateTime::currentDateTime();
     if(root.contains("tasks")) {
-      p.tasks = tasksFromJson(root["tasks"].toArray());
+      p.tasks = heap::state::tasksFromJson(root["tasks"].toArray());
     }
     if(root.contains("people")) {
-      p.people = peopleFromJson(root["people"].toArray());
+      p.people = heap::state::peopleFromJson(root["people"].toArray());
     }
     if(root.contains("statuses")) {
-      p.statuses = statusesFromJson(root["statuses"].toArray());
+      p.statuses = heap::state::statusesFromJson(root["statuses"].toArray());
     }
     if(root.contains("docs")) {
       p.docsState = QJsonDocument(root["docs"].toObject()).toJson(QJsonDocument::Compact);
     }
     // Hoist any legacy top-level events into the global pool.
     if(root.contains("events")) {
-      globalEvents = eventsFromJson(root["events"].toArray(), p.id);
+      globalEvents = heap::state::eventsFromJson(root["events"].toArray(), p.id);
     }
     m_profiles.push_back(p);
     m_activeProfileId = p.id;
@@ -2969,10 +2890,21 @@ void AppController::loadStateOnStart() {
   emit profilesChanged();
   emit activeProfileChanged();
 
-  // Force a rewrite to upgrade the on-disk file to v3 if we just migrated.
-  if(schema < 3) {
+  // Force a rewrite so the on-disk file lands at the current schema version.
+  if(schema < heap::state::kSchemaVersion) {
     scheduleSave();
   }
+}
+
+void AppController::retainPreMigrationBackup(const QString& path, int fromVersion) {
+  const QString dir = backupDirPath();
+  const QString stamp = QDateTime::currentDateTime().toString("yyyyMMdd-HHmmss");
+  const QString target = dir + "/state-premigration-v" + QString::number(fromVersion) + "-" + stamp + ".json";
+  if(QFile::exists(target) || !QFile::copy(path, target)) {
+    return;
+  }
+  heap::recovery::append(QString::fromLatin1(heap::recovery::kPreMigration),
+                         {{QStringLiteral("from"), path}, {QStringLiteral("to"), target}, {QStringLiteral("schema"), fromVersion}});
 }
 
 // ───────────────────────────────────────────────────── Profiles API ──
@@ -3393,7 +3325,7 @@ QString AppController::exportActiveProfileJson() const {
   p.statuses = m_statuses;
   p.docsState = m_docsState;
   p.notesState = m_notesState;
-  QJsonObject profObj = profileToJson(p);
+  QJsonObject profObj = heap::state::profileToJson(p);
 
   // Events live in the global pool, so profileToJson() cannot see them — a
   // profile export used to silently drop the whole calendar. Include the
@@ -3405,10 +3337,10 @@ QString AppController::exportActiveProfileJson() const {
       profileEvents.append(e);
     }
   }
-  profObj["events"] = eventsToJson(profileEvents);
+  profObj["events"] = heap::state::eventsToJson(profileEvents);
 
   QJsonObject root;
-  root["schemaVersion"] = 3;
+  root["schemaVersion"] = heap::state::kSchemaVersion;
   root["kind"] = "todocpp.profile";
   root["exportedAt"] = QDateTime::currentDateTime().toString(Qt::ISODate);
   root["profile"] = profObj;
@@ -3458,7 +3390,7 @@ QString AppController::importProfileFromJson(const QString& jsonText, bool activ
   }
 
   QVector<CalEvent> importedEvents;
-  Profile imported = profileFromJson(profileObj, &importedEvents);
+  Profile imported = heap::state::profileFromJson(profileObj, &importedEvents);
   if(imported.name.trimmed().isEmpty()) {
     imported.name = QStringLiteral("Imported");
   }
@@ -4149,13 +4081,15 @@ void AppController::runAutomation() {
       if(t.archived) {
         continue;
       }
-      if(!t.deadline.isValid()) {
+      if(!t.dueAt.isValid()) {
         continue;
       }
       if(t.status == QStringLiteral("done")) {
         continue;
       }
-      const QDateTime deadlineAt(t.deadline, QTime(23, 59));
+      // A task due at a parsed clock time fires then; a bare due date keeps the
+      // old end-of-day horizon.
+      const QDateTime deadlineAt = t.hasTime ? t.dueAt : QDateTime(t.dueAt.date(), QTime(23, 59));
       const qint64 hoursLeft = now.secsTo(deadlineAt) / 3600;
       if(hoursLeft < 0 || hoursLeft > leadHours) {
         continue;
@@ -4410,12 +4344,16 @@ void AppController::snoozeDeadline(const QString& taskId, int seconds) {
     return;
   }
   Task t = m_tasks.items().at(row);
-  if(!t.deadline.isValid()) {
+  if(!t.dueAt.isValid()) {
     return;
   }
   // Reminders are date-grained — bump to the next day so the dl: sentinel
-  // for "today" stops firing.
-  t.deadline = t.deadline.addDays((seconds + 86399) / 86400);
+  // for "today" stops firing. The clock time rides along.
+  const int days = (seconds + 86399) / 86400;
+  t.dueAt = t.dueAt.addDays(days);
+  if(t.scheduledAt.isValid()) {
+    t.scheduledAt = t.scheduledAt.addDays(days);
+  }
   m_tasks.upsert(t);
   // Forget the "already notified today" memo so the new horizon is honoured.
   m_lastReminderDay.remove(QStringLiteral("dl:") + taskId);

--- a/src/AppController.h
+++ b/src/AppController.h
@@ -12,6 +12,7 @@
 #include <QVariantList>
 #include <QVariantMap>
 
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -334,6 +335,28 @@ class AppController : public QObject {
   // version / recent-log-tail diagnostics, so a user can file a report in one
   // click.
   Q_INVOKABLE void reportAnIssue() const;
+  // The body reportAnIssue() pre-fills, built from purely local sources: app
+  // version, OS, Qt version, the log tail and the recovery log. Split out so the
+  // no-network-egress guarantee can be exercised without opening a browser.
+  Q_INVOKABLE QString issueReportBody() const;
+
+  // Fold a batch of pulled external tasks into the model. providerId tags the
+  // task's externalProvider; idPrefix seeds ids for newly-created local tasks.
+  // Public so the sync merge can be exercised without a live tracker.
+  void mergeExternalTasks(const QString& providerId, const QString& idPrefix, const QVector<heap::integrations::ExternalTask>& issues);
+
+  // ---- Durability audit (HEAP-156) ----
+  // Every quarantine / backup recovery / failed write, oldest first. Local file,
+  // never uploaded.
+  Q_INVOKABLE QVariantList recoveryLog() const;
+  // Copy the recovery log to `fileUrl` so it can be attached to a bug report.
+  Q_INVOKABLE bool exportRecoveryLog(const QUrl& fileUrl);
+
+  // Test seam: replaces the atomic QSaveFile write behind saveStateNow() so the
+  // fault-injection harness can truncate, corrupt, or drop the rename. Pass an
+  // empty std::function to restore the default writer.
+  using StateWriter = std::function<bool(const QString& path, const QByteArray& bytes)>;
+  static void setStateWriterForTesting(StateWriter writer);
 
   // ---- Auto-update (HEAP-63) ----
   // Manually trigger a GitHub-Releases check (Settings → About → "Check for
@@ -644,6 +667,10 @@ class AppController : public QObject {
   // state.json aside so a fresh seed can never silently overwrite it.
   bool recoverFromNewestBackup(QJsonObject& out, QString& fromPath);
   void quarantineCorruptState(const QString& path);
+  // Copies the pre-migration state.json into the backup dir before the schema
+  // ladder rewrites it. Exempt from retention pruning: it is the only pre-v4
+  // image of the user's data.
+  void retainPreMigrationBackup(const QString& path, int fromVersion);
   QString m_recoveryNotice;  // deferred toast shown once the UI is up
   int statusIndexOf(const QString& id) const;
 
@@ -708,9 +735,6 @@ class AppController : public QObject {
   void setIntegrationField(const QString& providerId, const QString& field, const QVariant& value);
   // One-time move of any plaintext tokens found in state.json into the keychain.
   void migrateLegacySecrets();
-  // Fold a batch of pulled external tasks into the model. providerId tags the
-  // task's externalProvider; idPrefix seeds ids for newly-created local tasks.
-  void mergeExternalTasks(const QString& providerId, const QString& idPrefix, const QVector<heap::integrations::ExternalTask>& issues);
   QString m_focusedTaskId, m_focusedBranch, m_focusedRepo;
   QVariantMap m_focusedRepoState;
   QSet<QString> m_dismissedBranches;  // in-memory only; per branch name

--- a/src/FieldCount.h
+++ b/src/FieldCount.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+// Compile-time aggregate field count. Used to pin the shape of Task and CalEvent
+// so that adding a field breaks the build of every serializer that has not been
+// taught about it (HEAP-131), instead of silently dropping the field on save.
+namespace heap::meta {
+
+namespace detail {
+
+// Converts to anything, so `T{Any{}, Any{}, …}` probes how many initialisers an
+// aggregate accepts. Never defined: it is only ever used unevaluated.
+struct Any {
+  template<class T>
+  constexpr operator T() const noexcept;  // NOLINT(google-explicit-constructor)
+};
+
+template<class T, class... Args>
+constexpr std::size_t countFields() {
+  if constexpr(requires { T{Args{}..., Any{}}; }) {
+    return countFields<T, Args..., Any>();
+  } else {
+    return sizeof...(Args);
+  }
+}
+
+}  // namespace detail
+
+// Number of direct data members of the aggregate T.
+template<class T>
+constexpr std::size_t fieldCount() {
+  return detail::countFields<T>();
+}
+
+}  // namespace heap::meta

--- a/src/Models.cpp
+++ b/src/Models.cpp
@@ -1,6 +1,49 @@
 #include "Models.h"
+#include "TaskDefer.h"
 
 #include <algorithm>
+
+QString externalKeyOf(const Task& t) {
+  if(t.externalId.isEmpty()) {
+    return {};
+  }
+  // Jira hands us the human key already ("PROJ-123"); the issue-number trackers
+  // hand us a bare number, which reads as "#123" everywhere they render it.
+  bool numeric = false;
+  t.externalId.toLongLong(&numeric);
+  return numeric ? QStringLiteral("#") + t.externalId : t.externalId;
+}
+
+QVariantList labelsToVariant(const QVector<Label>& labels) {
+  QVariantList out;
+  out.reserve(labels.size());
+  for(const Label& l : labels) {
+    out.append(QVariantMap{{QStringLiteral("id"), l.id}, {QStringLiteral("color"), l.color}});
+  }
+  return out;
+}
+
+QVector<Label> labelsFromVariant(const QVariantList& list) {
+  QVector<Label> out;
+  out.reserve(list.size());
+  for(const QVariant& v : list) {
+    // A plain string is accepted so the editor can hand over comma-separated
+    // text without inventing colours for it.
+    if(v.typeId() == QMetaType::QString) {
+      const QString id = v.toString().trimmed();
+      if(!id.isEmpty()) {
+        out.append(Label{id, {}});
+      }
+      continue;
+    }
+    const QVariantMap m = v.toMap();
+    const QString id = m.value(QStringLiteral("id")).toString().trimmed();
+    if(!id.isEmpty()) {
+      out.append(Label{id, m.value(QStringLiteral("color")).toString()});
+    }
+  }
+  return out;
+}
 
 QHash<int, QByteArray> TaskModel::roleNames() const {
   return {
@@ -23,6 +66,17 @@ QHash<int, QByteArray> TaskModel::roleNames() const {
       {TrackedSecondsRole, "trackedSeconds"},
       {IsTimingRole, "isTiming"},
       {RecurrenceRole, "recurrence"},
+      {ScheduledAtRole, "scheduledAt"},
+      {DueAtRole, "dueAt"},
+      {HasTimeRole, "hasTime"},
+      {EstimateMinutesRole, "estimateMinutes"},
+      {SomedayRole, "someday"},
+      {DeferStateRole, "deferState"},
+      {ExternalProviderRole, "externalProvider"},
+      {ExternalUrlRole, "externalUrl"},
+      {ExternalKeyRole, "externalKey"},
+      {LabelsRole, "labels"},
+      {AssigneeRole, "assignee"},
   };
 }
 
@@ -43,7 +97,9 @@ QVariant TaskModel::data(const QModelIndex& idx, int role) const {
     case StatusRole:
       return t.status;
     case DeadlineRole:
-      return t.deadline;
+      // Kept a QDate: every calendar/timeline view does whole-day arithmetic on
+      // it. The clock component lives on DueAtRole / ScheduledAtRole.
+      return t.dueAt.isValid() ? t.dueAt.date() : QDate();
     case BranchRole:
       return t.branch;
     case StatusChangedAtRole:
@@ -70,6 +126,28 @@ QVariant TaskModel::data(const QModelIndex& idx, int role) const {
       return t.timerStartedAt.isValid();
     case RecurrenceRole:
       return t.recurrence;
+    case ScheduledAtRole:
+      return t.scheduledAt;
+    case DueAtRole:
+      return t.dueAt;
+    case HasTimeRole:
+      return t.hasTime;
+    case EstimateMinutesRole:
+      return t.estimateMinutes;
+    case SomedayRole:
+      return t.someday;
+    case DeferStateRole:
+      return heap::model::deferState(t, QDate::currentDate());
+    case ExternalProviderRole:
+      return t.externalProvider;
+    case ExternalUrlRole:
+      return t.externalUrl;
+    case ExternalKeyRole:
+      return externalKeyOf(t);
+    case LabelsRole:
+      return labelsToVariant(t.labels);
+    case AssigneeRole:
+      return t.assignee;
   }
   return {};
 }

--- a/src/Models.h
+++ b/src/Models.h
@@ -12,13 +12,30 @@
 #include <QVariantMap>
 #include <QVector>
 
+// One tag on a task (HEAP-124). `id` is the label text — it is what a tracker
+// calls the label and what the user types. `color` is a "#rrggbb" string, empty
+// when the source gave none.
+struct Label {
+  QString id;
+  QString color;
+
+  bool operator==(const Label&) const = default;
+};
+
 struct Task {
   QString id;
   QString title;
   QString desc;
   QString priority;  // P0..P3
   QString status;    // backlog/todo/prog/half/blocked/review/done
-  QDate deadline;    // invalid = none
+  // Time-aware scheduling (HEAP-115). `scheduledAt` is when the work is meant
+  // to happen, `dueAt` is when it is owed; either may be invalid (= none).
+  // `hasTime` says whether the clock component of both is meaningful — a bare
+  // date lands at 00:00 with hasTime=false, which is how a legacy QDate
+  // deadline migrates in.
+  QDateTime scheduledAt;
+  QDateTime dueAt;
+  bool hasTime = false;
   QString branch;
   QDateTime statusChangedAt;  // last time `status` was mutated
   bool archived = false;      // hidden from Board/Timeline once auto-archived
@@ -36,6 +53,13 @@ struct Task {
   QString externalId;        // e.g. GitHub issue number as a string
   QString externalUrl;       // issue web URL
   QString externalProvider;  // "github" | "jira" | "gitlab"
+  // Planning fields (HEAP-124).
+  QVector<Label> labels;
+  int estimateMinutes = 0;
+  bool someday = false;  // parked: never surfaces in a "scheduled today" view
+  QString assignee;      // tracker-supplied owner, empty for local tasks
+
+  bool operator==(const Task&) const = default;
 };
 
 struct CalEvent {
@@ -49,7 +73,18 @@ struct CalEvent {
   QString taskId;     // optional link to task in same profile
   QString profileId;  // optional attribution to a feature profile (empty = global)
   QString context;    // free-form context label rendered before the title in calendar views
+
+  bool operator==(const CalEvent&) const = default;
 };
+
+// Tracker-native issue key for a task: Jira stores "PROJ-123" verbatim, the
+// issue-number trackers store a bare number that reads as "#123". Empty for
+// locally-created tasks.
+QString externalKeyOf(const Task& t);
+
+// Labels across the QML boundary: a list of { id, color } maps.
+QVariantList labelsToVariant(const QVector<Label>& labels);
+QVector<Label> labelsFromVariant(const QVariantList& list);
 
 struct Person {
   QString id;
@@ -101,6 +136,21 @@ class TaskModel : public QAbstractListModel {
     TrackedSecondsRole,
     IsTimingRole,
     RecurrenceRole,
+    // HEAP-115 / HEAP-124: the datetime pair behind DeadlineRole, plus planning
+    // fields. DeadlineRole stays a QDate (dueAt's date) so existing views keep
+    // their all-day arithmetic.
+    ScheduledAtRole,
+    DueAtRole,
+    HasTimeRole,
+    EstimateMinutesRole,
+    SomedayRole,
+    DeferStateRole,
+    // HEAP-140: read-only reflections of the tracker link.
+    ExternalProviderRole,
+    ExternalUrlRole,
+    ExternalKeyRole,
+    LabelsRole,
+    AssigneeRole,
   };
 
   explicit TaskModel(QObject* parent = nullptr) : QAbstractListModel(parent) {

--- a/src/RecoveryLog.cpp
+++ b/src/RecoveryLog.cpp
@@ -1,0 +1,76 @@
+#include "Logger.h"
+#include "RecoveryLog.h"
+
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+namespace heap::recovery {
+
+QString recoveryLogPath() {
+  return heap::logging::logDirPath() + "/recovery.log";
+}
+
+void append(const QString& kind, const QVariantMap& details) {
+  QVariantMap record = details;
+  record.insert(QStringLiteral("at"), QDateTime::currentDateTimeUtc().toString(Qt::ISODateWithMs));
+  record.insert(QStringLiteral("kind"), kind);
+  record.insert(QStringLiteral("version"), QCoreApplication::applicationVersion());
+
+  QFile f(recoveryLogPath());
+  if(!f.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
+    return;
+  }
+  f.write(QJsonDocument(QJsonObject::fromVariantMap(record)).toJson(QJsonDocument::Compact));
+  f.write("\n");
+}
+
+QVariantList entries() {
+  QFile f(recoveryLogPath());
+  if(!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    return {};
+  }
+  QVariantList out;
+  while(!f.atEnd()) {
+    const QByteArray line = f.readLine().trimmed();
+    if(line.isEmpty()) {
+      continue;
+    }
+    const QJsonDocument doc = QJsonDocument::fromJson(line);
+    if(doc.isObject()) {
+      out.append(doc.object().toVariantMap());
+    }
+  }
+  return out;
+}
+
+bool exportTo(const QString& destPath) {
+  QFile src(recoveryLogPath());
+  if(!src.exists() || destPath.isEmpty()) {
+    return false;
+  }
+  QFile::remove(destPath);  // QFile::copy refuses to overwrite
+  return src.copy(destPath);
+}
+
+QString tail(int maxBytes) {
+  QFile f(recoveryLogPath());
+  if(!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    return {};
+  }
+  const qint64 size = f.size();
+  const bool truncated = size > maxBytes;
+  if(truncated) {
+    f.seek(size - maxBytes);
+  }
+  QString out = QString::fromUtf8(f.readAll());
+  if(truncated) {
+    const int nl = out.indexOf('\n');
+    out = nl >= 0 ? out.mid(nl + 1) : out;
+  }
+  return out;
+}
+
+}  // namespace heap::recovery

--- a/src/RecoveryLog.h
+++ b/src/RecoveryLog.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QString>
+#include <QVariantList>
+#include <QVariantMap>
+
+// Durability audit trail (HEAP-156). Every time the app quarantines a damaged
+// state.json, recovers from a backup, or fails to write state, one JSON line is
+// appended to …/AppDataLocation/logs/recovery.log. The file is the evidence a
+// solo maintainer otherwise never gets: with no telemetry, a recovery that fires
+// on a user's machine is invisible.
+//
+// Strictly local. Nothing in this module opens a socket; the only way a record
+// leaves the machine is the user pasting an exported copy into a bug report.
+namespace heap::recovery {
+
+// Record kinds, written verbatim into the "kind" field.
+inline constexpr auto kQuarantined = "quarantined";    // state.json was damaged and moved aside
+inline constexpr auto kRecovered = "recovered";        // a backup was promoted to live state
+inline constexpr auto kUnrecovered = "unrecovered";    // damaged, and no usable backup existed
+inline constexpr auto kWriteFailed = "write-failed";   // a save could not be committed
+inline constexpr auto kMigrated = "migrated";          // the schema ladder upgraded the file
+inline constexpr auto kPreMigration = "premigration";  // a pre-migration copy was retained
+
+QString recoveryLogPath();
+
+// Appends one record. `details` is merged into the line alongside a UTC
+// timestamp, the app version and `kind`. Best-effort: a log that cannot be
+// written must never take the app down with it.
+void append(const QString& kind, const QVariantMap& details = {});
+
+// Every record, oldest first. Unparseable lines are skipped.
+QVariantList entries();
+
+// Writes the whole log to `destPath`. Returns false if there is nothing to
+// export or the copy fails.
+bool exportTo(const QString& destPath);
+
+// Last `maxBytes` of the log, trimmed to whole lines — for the bug-report body.
+QString tail(int maxBytes = 2000);
+
+}  // namespace heap::recovery

--- a/src/SampleData.cpp
+++ b/src/SampleData.cpp
@@ -8,7 +8,10 @@ Task mkTask(const char* id, const char* title, const char* desc, const char* pri
   t.desc = QString::fromUtf8(desc);
   t.priority = pri;
   t.status = status;
-  t.deadline = dl;
+  if(dl.isValid()) {
+    t.scheduledAt = QDateTime(dl, QTime(0, 0));
+    t.dueAt = t.scheduledAt;
+  }
   t.branch = branch;
   return t;
 }

--- a/src/StateSerializer.cpp
+++ b/src/StateSerializer.cpp
@@ -1,0 +1,390 @@
+#include "FieldCount.h"
+#include "StateSerializer.h"
+
+#include <QColor>
+#include <QJsonDocument>
+#include <QJsonValue>
+#include <QTime>
+
+namespace heap::state {
+
+namespace {
+
+// Every declared field of Task and CalEvent has to survive toJson→fromJson. The
+// counts below are the guard: add a field and this build fails until the
+// serializers here, the ones in sync/SyncSerializer.cpp, and the round-trip
+// fixture in tests/test_roundtrip.cpp all learn about it.
+static_assert(heap::meta::fieldCount<Task>() == 21,
+              "Task gained or lost a field. Update taskToJson/taskFromJson here AND in "
+              "src/sync/SyncSerializer.cpp, extend makeFullTask() in tests/test_roundtrip.cpp, "
+              "then bump this count.");
+static_assert(heap::meta::fieldCount<CalEvent>() == 10,
+              "CalEvent gained or lost a field. Update eventToJson/eventFromJson here AND in "
+              "src/sync/SyncSerializer.cpp, extend makeFullEvent() in tests/test_roundtrip.cpp, "
+              "then bump this count.");
+
+// Milliseconds are written so a QDateTime round-trips exactly; Qt::ISODate on the
+// read side accepts both the fractional and the whole-second form, so files
+// written before this change still parse.
+QString dtToStr(const QDateTime& dt) {
+  return dt.isValid() ? dt.toString(Qt::ISODateWithMs) : QString();
+}
+
+QDateTime dtFromStr(const QString& s) {
+  return s.isEmpty() ? QDateTime() : QDateTime::fromString(s, Qt::ISODate);
+}
+
+QJsonArray labelsToJson(const QVector<Label>& labels) {
+  QJsonArray a;
+  for(const Label& l : labels) {
+    QJsonObject o;
+    o["id"] = l.id;
+    o["color"] = l.color;
+    a.append(o);
+  }
+  return a;
+}
+
+QVector<Label> labelsFromJson(const QJsonArray& a) {
+  QVector<Label> out;
+  out.reserve(a.size());
+  for(const auto& it : a) {
+    const QJsonObject o = it.toObject();
+    out.append(Label{o["id"].toString(), o["color"].toString()});
+  }
+  return out;
+}
+
+}  // namespace
+
+// ───────────────── Task ─────────────────
+
+QJsonObject taskToJson(const Task& t) {
+  QJsonObject o;
+  o["id"] = t.id;
+  o["title"] = t.title;
+  o["desc"] = t.desc;
+  o["priority"] = t.priority;
+  o["status"] = t.status;
+  o["branch"] = t.branch;
+  o["statusChangedAt"] = dtToStr(t.statusChangedAt);
+  o["archived"] = t.archived;
+  // Scheduling (HEAP-115) — omitted when unset so an undated task's JSON stays
+  // as small as it was when `deadline` was a bare date.
+  if(t.scheduledAt.isValid()) {
+    o["scheduledAt"] = dtToStr(t.scheduledAt);
+  }
+  if(t.dueAt.isValid()) {
+    o["dueAt"] = dtToStr(t.dueAt);
+  }
+  if(t.hasTime) {
+    o["hasTime"] = true;
+  }
+  // Time tracking (HEAP-78) — omitted when zero/stopped so untimed task JSON
+  // stays byte-identical.
+  if(t.trackedSeconds > 0) {
+    o["trackedSeconds"] = t.trackedSeconds;
+  }
+  if(t.timerStartedAt.isValid()) {
+    o["timerStartedAt"] = dtToStr(t.timerStartedAt);
+  }
+  // Recurrence (HEAP-77) — omitted for non-recurring tasks.
+  if(!t.recurrence.isEmpty()) {
+    o["recurrence"] = t.recurrence;
+  }
+  // Tracker-sync link — only emitted for synced tasks so locally-created
+  // task JSON stays byte-identical to before HEAP-74.
+  if(!t.externalId.isEmpty()) {
+    o["externalId"] = t.externalId;
+    o["externalUrl"] = t.externalUrl;
+    o["externalProvider"] = t.externalProvider;
+  }
+  // Planning fields (HEAP-124).
+  if(!t.labels.isEmpty()) {
+    o["labels"] = labelsToJson(t.labels);
+  }
+  if(t.estimateMinutes > 0) {
+    o["estimateMinutes"] = t.estimateMinutes;
+  }
+  if(t.someday) {
+    o["someday"] = true;
+  }
+  if(!t.assignee.isEmpty()) {
+    o["assignee"] = t.assignee;
+  }
+  return o;
+}
+
+Task taskFromJson(const QJsonObject& o) {
+  Task t;
+  t.id = o["id"].toString();
+  t.title = o["title"].toString();
+  t.desc = o["desc"].toString();
+  t.priority = o["priority"].toString();
+  t.status = o["status"].toString();
+  t.branch = o["branch"].toString();
+  t.statusChangedAt = dtFromStr(o["statusChangedAt"].toString());
+  if(!t.statusChangedAt.isValid()) {
+    t.statusChangedAt = QDateTime::currentDateTime();
+  }
+  t.archived = o["archived"].toBool(false);
+  t.scheduledAt = dtFromStr(o["scheduledAt"].toString());
+  t.dueAt = dtFromStr(o["dueAt"].toString());
+  t.hasTime = o["hasTime"].toBool(false);
+  // Legacy bare-date deadline (schema ≤ 3, and any profile exported by an older
+  // build). state.json itself is migrated by migrateState() before it reaches
+  // here; this covers imports, which carry no schema ladder.
+  if(!t.scheduledAt.isValid() && !t.dueAt.isValid()) {
+    const QDate legacy = QDate::fromString(o["deadline"].toString(), Qt::ISODate);
+    if(legacy.isValid()) {
+      t.scheduledAt = QDateTime(legacy, QTime(0, 0));
+      t.dueAt = t.scheduledAt;
+      t.hasTime = false;
+    }
+  }
+  t.trackedSeconds = o["trackedSeconds"].toInt(0);
+  t.timerStartedAt = dtFromStr(o["timerStartedAt"].toString());
+  t.recurrence = o["recurrence"].toString();
+  t.externalId = o["externalId"].toString();
+  t.externalUrl = o["externalUrl"].toString();
+  t.externalProvider = o["externalProvider"].toString();
+  t.labels = labelsFromJson(o["labels"].toArray());
+  t.estimateMinutes = o["estimateMinutes"].toInt(0);
+  t.someday = o["someday"].toBool(false);
+  t.assignee = o["assignee"].toString();
+  return t;
+}
+
+QJsonArray tasksToJson(const QVector<Task>& xs) {
+  QJsonArray a;
+  for(const Task& t : xs) {
+    a.append(taskToJson(t));
+  }
+  return a;
+}
+
+QVector<Task> tasksFromJson(const QJsonArray& a) {
+  QVector<Task> v;
+  v.reserve(a.size());
+  for(const auto& it : a) {
+    v.append(taskFromJson(it.toObject()));
+  }
+  return v;
+}
+
+// ───────────────── CalEvent ─────────────────
+
+QJsonObject eventToJson(const CalEvent& e) {
+  QJsonObject o;
+  o["id"] = e.id;
+  o["title"] = e.title;
+  o["type"] = e.type;
+  o["start"] = e.start;
+  o["end"] = e.end;
+  o["attendees"] = e.attendees;
+  o["date"] = e.date.isValid() ? e.date.toString(Qt::ISODate) : QString();
+  o["taskId"] = e.taskId;
+  o["profileId"] = e.profileId;
+  o["context"] = e.context;
+  return o;
+}
+
+CalEvent eventFromJson(const QJsonObject& o, const QString& fallbackProfileId) {
+  CalEvent e;
+  e.id = o["id"].toString();
+  e.title = o["title"].toString();
+  e.type = o["type"].toString();
+  e.start = o["start"].toDouble();
+  e.end = o["end"].toDouble();
+  e.attendees = o["attendees"].toString();
+  e.date = QDate::fromString(o["date"].toString(), Qt::ISODate);
+  e.taskId = o["taskId"].toString();
+  e.profileId = o.contains("profileId") ? o["profileId"].toString() : fallbackProfileId;
+  e.context = o["context"].toString();
+  return e;
+}
+
+QJsonArray eventsToJson(const QVector<CalEvent>& xs) {
+  QJsonArray a;
+  for(const CalEvent& e : xs) {
+    a.append(eventToJson(e));
+  }
+  return a;
+}
+
+QVector<CalEvent> eventsFromJson(const QJsonArray& a, const QString& fallbackProfileId) {
+  QVector<CalEvent> v;
+  v.reserve(a.size());
+  for(const auto& it : a) {
+    v.append(eventFromJson(it.toObject(), fallbackProfileId));
+  }
+  return v;
+}
+
+// ───────────────── Person / statuses ─────────────────
+
+QJsonArray peopleToJson(const QVector<Person>& xs) {
+  QJsonArray a;
+  for(const Person& p : xs) {
+    QJsonObject o;
+    o["id"] = p.id;
+    o["name"] = p.name;
+    o["role"] = p.role;
+    o["question"] = p.question;
+    o["state"] = p.state;
+    o["color"] = p.color.name();
+    a.append(o);
+  }
+  return a;
+}
+
+QVector<Person> peopleFromJson(const QJsonArray& a) {
+  QVector<Person> v;
+  v.reserve(a.size());
+  for(const auto& it : a) {
+    const QJsonObject o = it.toObject();
+    Person p;
+    p.id = o["id"].toString();
+    p.name = o["name"].toString();
+    p.role = o["role"].toString();
+    p.question = o["question"].toString();
+    p.state = o["state"].toString();
+    p.color = QColor(o["color"].toString());
+    v.append(p);
+  }
+  return v;
+}
+
+QJsonArray statusesToJson(const QVariantList& xs) {
+  QJsonArray a;
+  for(const QVariant& v : xs) {
+    const QVariantMap m = v.toMap();
+    QJsonObject o;
+    o["id"] = m.value("id").toString();
+    o["name"] = m.value("name").toString();
+    const QVariant col = m.value("color");
+    o["color"] = col.canConvert<QColor>() ? col.value<QColor>().name() : col.toString();
+    a.append(o);
+  }
+  return a;
+}
+
+QVariantList statusesFromJson(const QJsonArray& a) {
+  QVariantList v;
+  for(const auto& it : a) {
+    const QJsonObject o = it.toObject();
+    QVariantMap m;
+    m["id"] = o["id"].toString();
+    m["name"] = o["name"].toString();
+    m["color"] = QColor(o["color"].toString());
+    v.append(m);
+  }
+  return v;
+}
+
+// ───────────────── Profile ─────────────────
+
+QJsonObject profileToJson(const Profile& p) {
+  QJsonObject o;
+  o["id"] = p.id;
+  o["name"] = p.name;
+  o["color"] = p.color;
+  o["createdAt"] = dtToStr(p.createdAt);
+  o["tasks"] = tasksToJson(p.tasks);
+  o["people"] = peopleToJson(p.people);
+  o["statuses"] = statusesToJson(p.statuses);
+  if(!p.docsState.isEmpty()) {
+    const QJsonDocument d = QJsonDocument::fromJson(p.docsState.toUtf8());
+    if(!d.isNull() && d.isObject()) {
+      o["docs"] = d.object();
+    }
+  }
+  if(!p.notesState.isEmpty()) {
+    o["notes"] = p.notesState;
+  }
+  return o;
+}
+
+Profile profileFromJson(const QJsonObject& o, QVector<CalEvent>* outLegacyEvents) {
+  Profile p;
+  p.id = o["id"].toString();
+  p.name = o["name"].toString();
+  p.color = o["color"].toString();
+  p.createdAt = dtFromStr(o["createdAt"].toString());
+  p.tasks = tasksFromJson(o["tasks"].toArray());
+  p.people = peopleFromJson(o["people"].toArray());
+  p.statuses = statusesFromJson(o["statuses"].toArray());
+  if(o.contains("docs")) {
+    p.docsState = QJsonDocument(o["docs"].toObject()).toJson(QJsonDocument::Compact);
+  }
+  if(o.contains("notes")) {
+    p.notesState = o["notes"].toString();
+  }
+  if(outLegacyEvents && o.contains("events")) {
+    outLegacyEvents->append(eventsFromJson(o["events"].toArray(), p.id));
+  }
+  return p;
+}
+
+// ───────────────── Migration ─────────────────
+
+namespace {
+
+// v3→v4: a bare `deadline` date becomes a scheduledAt/dueAt pair at midnight
+// with no clock component. Both are set so the task keeps showing up wherever a
+// due date used to put it while also being schedulable.
+void migrateTaskV3ToV4(QJsonObject& task) {
+  if(!task.contains("deadline")) {
+    return;
+  }
+  const QDate legacy = QDate::fromString(task["deadline"].toString(), Qt::ISODate);
+  task.remove("deadline");
+  if(!legacy.isValid()) {
+    return;  // an empty "" deadline: dropping the dead key is the whole migration
+  }
+  if(!task.contains("scheduledAt") && !task.contains("dueAt")) {
+    const QString at = dtToStr(QDateTime(legacy, QTime(0, 0)));
+    task["scheduledAt"] = at;
+    task["dueAt"] = at;
+    task["hasTime"] = false;
+  }
+}
+
+// Rebuilds the array rather than writing back through an index: QJsonArray's
+// subscript hands out a reference proxy, and in-place index mutation is exactly
+// the shape a well-meaning "modernize to a range-for" rewrite would break.
+QJsonArray migratedTaskArrayV3ToV4(const QJsonArray& tasks) {
+  QJsonArray out;
+  for(const QJsonValue& v : tasks) {
+    QJsonObject t = v.toObject();
+    migrateTaskV3ToV4(t);
+    out.append(t);
+  }
+  return out;
+}
+
+}  // namespace
+
+bool migrateState(QJsonObject& root, int fromVersion) {
+  if(fromVersion >= kSchemaVersion) {
+    return false;  // the version gate: a v4 document is never re-migrated
+  }
+
+  // Tasks live under profiles[].tasks from v2 on, and at the top level in v1.
+  if(root.contains("profiles")) {
+    QJsonArray profiles;
+    for(const QJsonValue& v : root["profiles"].toArray()) {
+      QJsonObject p = v.toObject();
+      p["tasks"] = migratedTaskArrayV3ToV4(p["tasks"].toArray());
+      profiles.append(p);
+    }
+    root["profiles"] = profiles;
+  } else if(root.contains("tasks")) {
+    root["tasks"] = migratedTaskArrayV3ToV4(root["tasks"].toArray());
+  }
+
+  root["schemaVersion"] = kSchemaVersion;
+  return true;
+}
+
+}  // namespace heap::state

--- a/src/StateSerializer.h
+++ b/src/StateSerializer.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "Models.h"
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QVariantList>
+#include <QVector>
+
+// The live state.json (de)serializer: what AppController::saveStateNow writes,
+// what loadStateOnStart reads, and what profile export/import uses. Extracted
+// from AppController's anonymous namespace so the round-trip and field-count
+// guards can exercise the real save path rather than a look-alike (HEAP-131).
+namespace heap::state {
+
+// Bumped whenever the on-disk shape changes; migrateState() knows how to walk a
+// document from any older version up to this one.
+//   v2  profiles array, events nested per profile
+//   v3  events hoisted to the top level
+//   v4  Task.deadline (QDate) split into scheduledAt/dueAt (QDateTime) + hasTime
+inline constexpr int kSchemaVersion = 4;
+
+QJsonObject taskToJson(const Task& t);
+Task taskFromJson(const QJsonObject& o);
+QJsonArray tasksToJson(const QVector<Task>& xs);
+QVector<Task> tasksFromJson(const QJsonArray& a);
+
+QJsonObject eventToJson(const CalEvent& e);
+CalEvent eventFromJson(const QJsonObject& o, const QString& fallbackProfileId = QString());
+QJsonArray eventsToJson(const QVector<CalEvent>& xs);
+QVector<CalEvent> eventsFromJson(const QJsonArray& a, const QString& fallbackProfileId = QString());
+
+QJsonArray peopleToJson(const QVector<Person>& xs);
+QVector<Person> peopleFromJson(const QJsonArray& a);
+
+QJsonArray statusesToJson(const QVariantList& xs);
+QVariantList statusesFromJson(const QJsonArray& a);
+
+QJsonObject profileToJson(const Profile& p);
+
+// Returns the parsed Profile and pulls out any nested "events" array (legacy
+// schema v2) so the caller can hoist them into the global event pool with
+// fallback profileId = p.id.
+Profile profileFromJson(const QJsonObject& o, QVector<CalEvent>* outLegacyEvents = nullptr);
+
+// Upgrades a whole state document in place from `fromVersion` to kSchemaVersion.
+// Idempotent: a document already at kSchemaVersion is left untouched and false
+// is returned. Only the field-level rewrites live here — the structural v1→v2→v3
+// moves (wrapping flat fields into a profile, hoisting events) stay in
+// AppController::loadStateOnStart, which is the only caller that has the models.
+bool migrateState(QJsonObject& root, int fromVersion);
+
+}  // namespace heap::state

--- a/src/TaskDefer.h
+++ b/src/TaskDefer.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "Models.h"
+
+#include <QDate>
+#include <QString>
+
+// Defer state (HEAP-124). Derived, never stored: the only persisted bit is
+// Task::someday, everything else follows from scheduledAt. A parked task is
+// someday regardless of the date it once carried.
+namespace heap::model {
+
+inline bool isSomeday(const Task& t) {
+  return t.someday;
+}
+
+inline bool isScheduledForToday(const Task& t, const QDate& today) {
+  return !t.someday && t.scheduledAt.isValid() && t.scheduledAt.date() <= today;
+}
+
+// "today" | "scheduled" | "anytime" | "someday"
+inline QString deferState(const Task& t, const QDate& today) {
+  if(t.someday) {
+    return QStringLiteral("someday");
+  }
+  if(!t.scheduledAt.isValid()) {
+    return QStringLiteral("anytime");
+  }
+  return t.scheduledAt.date() <= today ? QStringLiteral("today") : QStringLiteral("scheduled");
+}
+
+}  // namespace heap::model

--- a/src/sync/SyncSerializer.cpp
+++ b/src/sync/SyncSerializer.cpp
@@ -1,7 +1,10 @@
+#include "FieldCount.h"
+
 #include "sync/SyncSerializer.h"
 
 #include <QJsonDocument>
 #include <QJsonValue>
+#include <QTime>
 
 #include <algorithm>
 
@@ -9,18 +12,55 @@ namespace heap::sync {
 
 namespace {
 
+// Kept in lockstep with src/StateSerializer.cpp: a field that only one of the
+// two serializers knows about is a field the sync transport will drop (HEAP-131).
+static_assert(heap::meta::fieldCount<Task>() == 21,
+              "Task gained or lost a field. Update taskToJson/taskFromJson here AND in "
+              "src/StateSerializer.cpp, extend makeFullTask() in tests/test_roundtrip.cpp, "
+              "then bump this count.");
+static_assert(heap::meta::fieldCount<CalEvent>() == 10,
+              "CalEvent gained or lost a field. Update eventToJson/eventFromJson here AND in "
+              "src/StateSerializer.cpp, extend makeFullEvent() in tests/test_roundtrip.cpp, "
+              "then bump this count.");
+
 // QDate/QDateTime ↔ ISO string, with invalid mapping to "" (round-trip safe).
+// Datetimes carry milliseconds out; Qt::ISODate parses them back and still
+// accepts the whole-second form written by older builds.
 QString dateToStr(const QDate& d) {
   return d.isValid() ? d.toString(Qt::ISODate) : QString();
 }
+
 QDate dateFromStr(const QString& s) {
   return s.isEmpty() ? QDate() : QDate::fromString(s, Qt::ISODate);
 }
+
 QString dateTimeToStr(const QDateTime& dt) {
-  return dt.isValid() ? dt.toString(Qt::ISODate) : QString();
+  return dt.isValid() ? dt.toString(Qt::ISODateWithMs) : QString();
 }
+
 QDateTime dateTimeFromStr(const QString& s) {
   return s.isEmpty() ? QDateTime() : QDateTime::fromString(s, Qt::ISODate);
+}
+
+QJsonArray labelsToJson(const QVector<Label>& labels) {
+  QJsonArray a;
+  for(const Label& l : labels) {
+    QJsonObject o;
+    o[QStringLiteral("id")] = l.id;
+    o[QStringLiteral("color")] = l.color;
+    a.append(o);
+  }
+  return a;
+}
+
+QVector<Label> labelsFromJson(const QJsonArray& a) {
+  QVector<Label> out;
+  out.reserve(a.size());
+  for(const QJsonValue& v : a) {
+    const QJsonObject o = v.toObject();
+    out.append(Label{o.value(QStringLiteral("id")).toString(), o.value(QStringLiteral("color")).toString()});
+  }
+  return out;
 }
 
 }  // namespace
@@ -42,6 +82,9 @@ QJsonArray SyncSerializer::sortedById(const QJsonArray& arr) {
 }
 
 // ── Task ──
+// Every field is emitted unconditionally: this file feeds a 3-way merge, and a
+// key that disappears when its value is default is a key the merger reads as
+// "deleted on the other side".
 QJsonObject SyncSerializer::taskToJson(const Task& t) {
   QJsonObject o;
   o[QStringLiteral("id")] = t.id;
@@ -49,10 +92,22 @@ QJsonObject SyncSerializer::taskToJson(const Task& t) {
   o[QStringLiteral("desc")] = t.desc;
   o[QStringLiteral("priority")] = t.priority;
   o[QStringLiteral("status")] = t.status;
-  o[QStringLiteral("deadline")] = dateToStr(t.deadline);
+  o[QStringLiteral("scheduledAt")] = dateTimeToStr(t.scheduledAt);
+  o[QStringLiteral("dueAt")] = dateTimeToStr(t.dueAt);
+  o[QStringLiteral("hasTime")] = t.hasTime;
   o[QStringLiteral("branch")] = t.branch;
   o[QStringLiteral("statusChangedAt")] = dateTimeToStr(t.statusChangedAt);
   o[QStringLiteral("archived")] = t.archived;
+  o[QStringLiteral("trackedSeconds")] = t.trackedSeconds;
+  o[QStringLiteral("timerStartedAt")] = dateTimeToStr(t.timerStartedAt);
+  o[QStringLiteral("recurrence")] = t.recurrence;
+  o[QStringLiteral("externalId")] = t.externalId;
+  o[QStringLiteral("externalUrl")] = t.externalUrl;
+  o[QStringLiteral("externalProvider")] = t.externalProvider;
+  o[QStringLiteral("labels")] = labelsToJson(t.labels);
+  o[QStringLiteral("estimateMinutes")] = t.estimateMinutes;
+  o[QStringLiteral("someday")] = t.someday;
+  o[QStringLiteral("assignee")] = t.assignee;
   return o;
 }
 
@@ -63,10 +118,30 @@ Task SyncSerializer::taskFromJson(const QJsonObject& o) {
   t.desc = o.value(QStringLiteral("desc")).toString();
   t.priority = o.value(QStringLiteral("priority")).toString();
   t.status = o.value(QStringLiteral("status")).toString();
-  t.deadline = dateFromStr(o.value(QStringLiteral("deadline")).toString());
+  t.scheduledAt = dateTimeFromStr(o.value(QStringLiteral("scheduledAt")).toString());
+  t.dueAt = dateTimeFromStr(o.value(QStringLiteral("dueAt")).toString());
+  t.hasTime = o.value(QStringLiteral("hasTime")).toBool();
+  // A document written before HEAP-115 carries a bare date instead.
+  if(!t.scheduledAt.isValid() && !t.dueAt.isValid()) {
+    const QDate legacy = dateFromStr(o.value(QStringLiteral("deadline")).toString());
+    if(legacy.isValid()) {
+      t.scheduledAt = QDateTime(legacy, QTime(0, 0));
+      t.dueAt = t.scheduledAt;
+    }
+  }
   t.branch = o.value(QStringLiteral("branch")).toString();
   t.statusChangedAt = dateTimeFromStr(o.value(QStringLiteral("statusChangedAt")).toString());
   t.archived = o.value(QStringLiteral("archived")).toBool();
+  t.trackedSeconds = o.value(QStringLiteral("trackedSeconds")).toInt();
+  t.timerStartedAt = dateTimeFromStr(o.value(QStringLiteral("timerStartedAt")).toString());
+  t.recurrence = o.value(QStringLiteral("recurrence")).toString();
+  t.externalId = o.value(QStringLiteral("externalId")).toString();
+  t.externalUrl = o.value(QStringLiteral("externalUrl")).toString();
+  t.externalProvider = o.value(QStringLiteral("externalProvider")).toString();
+  t.labels = labelsFromJson(o.value(QStringLiteral("labels")).toArray());
+  t.estimateMinutes = o.value(QStringLiteral("estimateMinutes")).toInt();
+  t.someday = o.value(QStringLiteral("someday")).toBool();
+  t.assignee = o.value(QStringLiteral("assignee")).toString();
   return t;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1265,6 +1265,56 @@ endif ()
 
 add_test(NAME heap_appcontroller_tests COMMAND heap_appcontroller_tests)
 
+# ─── Lossless serialization round-trip + field-count guard (HEAP-131) ───
+# Pure: exercises heap::state (the live save path) and heap::sync::SyncSerializer
+# side by side. No AppController, no QApplication.
+add_executable(heap_roundtrip_tests
+        test_roundtrip.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/StateSerializer.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/Models.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/sync/SyncSerializer.cpp
+)
+set_target_properties(heap_roundtrip_tests PROPERTIES AUTOMOC ON)
+target_include_directories(heap_roundtrip_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+target_link_libraries(heap_roundtrip_tests PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        GTest::gtest
+        GTest::gtest_main
+)
+add_test(NAME heap_roundtrip_tests COMMAND heap_roundtrip_tests)
+
+# ─── Schema migration (HEAP-146) and fault injection (HEAP-156) ───
+# Both boot a real AppController headless, so they reuse the AppController source
+# set above (each brings its own main()).
+foreach (_suite migration fault_injection save_bench)
+    set(_srcs ${HEAP_APPCTRL_SOURCES})
+    list(REMOVE_ITEM _srcs test_appcontroller.cpp)
+    list(APPEND _srcs test_${_suite}.cpp)
+
+    add_executable(heap_${_suite}_tests ${_srcs})
+    set_target_properties(heap_${_suite}_tests PROPERTIES AUTOMOC ON)
+    target_include_directories(heap_${_suite}_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+    target_link_libraries(heap_${_suite}_tests PRIVATE
+            Qt6::Core
+            Qt6::Gui
+            Qt6::Network
+            Qt6::NetworkAuth
+            Qt6::Widgets
+            Qt6::Qml
+            Qt6::Test
+            GTest::gtest
+    )
+    if (UNIX AND NOT APPLE)
+        find_package(Qt6 QUIET COMPONENTS DBus)
+        if (TARGET Qt6::DBus)
+            target_link_libraries(heap_${_suite}_tests PRIVATE Qt6::DBus)
+        endif ()
+    endif ()
+    add_test(NAME heap_${_suite}_tests COMMAND heap_${_suite}_tests)
+endforeach ()
+
 # ─── Aggregate target ───
 # Build target that depends on every executable defined in this directory.
 # CI builds `heap_all_tests`; adding a new test exe via add_executable() in

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -131,6 +131,8 @@ set(HEAP_SELECTION_SOURCES
         test_selection.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/RecoveryLog.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/StateSerializer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
@@ -224,6 +226,8 @@ set(HEAP_NOTES_SOURCES
         test_notes.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/RecoveryLog.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/StateSerializer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
@@ -355,6 +359,8 @@ set(HEAP_PERSISTENCE_SOURCES
         test_persistence.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/RecoveryLog.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/StateSerializer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
@@ -446,6 +452,8 @@ set(HEAP_EXPORT_SOURCES
         test_export_markdown.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/RecoveryLog.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/StateSerializer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
@@ -536,6 +544,8 @@ set(HEAP_PROFILE_IO_SOURCES
         test_profile_io.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/RecoveryLog.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/StateSerializer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
@@ -625,6 +635,8 @@ set(HEAP_ONBOARDING_SOURCES
         test_onboarding.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/RecoveryLog.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/StateSerializer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
@@ -733,6 +745,8 @@ set(HEAP_UNDO_SOURCES
         test_undo.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/RecoveryLog.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/StateSerializer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
@@ -824,6 +838,8 @@ set(HEAP_VIEW_SOURCES
         test_view.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/RecoveryLog.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/StateSerializer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h
@@ -1165,6 +1181,8 @@ set(HEAP_APPCTRL_SOURCES
         test_appcontroller.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/AppController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/Logger.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/RecoveryLog.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/StateSerializer.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/update/Updater.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../src/integrations/StatusMap.h

--- a/tests/qml/tst_interactions.qml
+++ b/tests/qml/tst_interactions.qml
@@ -68,6 +68,56 @@ TestCase {
         compare(AppController.focusedStatus, "blocked");
     }
 
+    // DayCalendar: a task scheduled at a clock time renders a block in the grid,
+    // and clicking it opens the task. The block shipped as a bare Rectangle, so
+    // the click was swallowed and nothing happened (HEAP-115 regression). The
+    // second compare pins the other half: the click must not reach the
+    // create-an-event MouseArea layered underneath.
+    //
+    // Event rectangles are stacked above task blocks and would eat the click, so
+    // the probe day is emptied of events first. Test-mode AppDataLocation is not
+    // wiped between runs, so a leftover event on that day is a real hazard.
+    function test_daycalendar_click_task_block() {
+        const day = new Date();
+        day.setDate(day.getDate() + 400);
+        day.setHours(0, 0, 0, 0);
+
+        const evs = AppController.events;
+        for (let i = evs.rowCount() - 1; i >= 0; i--) {
+            const idx = evs.index(i, 0);
+            const d = evs.data(idx, Qt.UserRole + 7);   // date role
+            if (d && d.getFullYear
+                && d.getFullYear() === day.getFullYear()
+                && d.getMonth() === day.getMonth()
+                && d.getDate() === day.getDate())
+                AppController.deleteEvent(String(evs.data(idx, Qt.UserRole + 1)));
+        }
+
+        const at = new Date(day);
+        at.setHours(AppController.workdayStart, 0, 0, 0);
+
+        const draft = AppController.newTaskDraft("todo");
+        draft.title = "day-block click probe";
+        draft.scheduledAt = at;
+        draft.dueAt = at;
+        draft.hasTime = true;
+        AppController.saveTask(draft);
+
+        AppController.selectedDate = day;
+        const dc = make('import TodoCpp; DayCalendar { anchors.fill: parent }');
+        const block = findChild(dc, "taskblock-" + draft.id);
+        verify(block !== null, "scheduled task did not render a day-grid block");
+
+        let got = "";
+        dc.taskClicked.connect(function(tid) { got = tid; });
+        const eventsBefore = evs.rowCount();
+
+        mouseClick(block);
+
+        compare(got, draft.id);
+        compare(evs.rowCount(), eventsBefore);
+    }
+
     // SideRail: clicking Code Review focuses the review column.
     function test_siderail_click_review() {
         AppController.currentView = "week";

--- a/tests/qml/tst_interactions.qml
+++ b/tests/qml/tst_interactions.qml
@@ -118,6 +118,57 @@ TestCase {
         compare(evs.rowCount(), eventsBefore);
     }
 
+    // DayCalendar: a task scheduled at a clock time draws its own block, but a
+    // "sync" capture also creates a meeting event linked to that task. The event
+    // stands in for the task, so the task's own block must be suppressed on that
+    // day — otherwise "синк с @hb" renders twice (HEAP-115 regression).
+    function test_daycalendar_hides_task_block_with_linked_event() {
+        const day = new Date();
+        day.setDate(day.getDate() + 402);
+        day.setHours(0, 0, 0, 0);
+
+        const evs = AppController.events;
+        for (let i = evs.rowCount() - 1; i >= 0; i--) {
+            const idx = evs.index(i, 0);
+            const ed = evs.data(idx, Qt.UserRole + 7);
+            if (ed && ed.getFullYear
+                && ed.getFullYear() === day.getFullYear()
+                && ed.getMonth() === day.getMonth()
+                && ed.getDate() === day.getDate())
+                AppController.deleteEvent(String(evs.data(idx, Qt.UserRole + 1)));
+        }
+
+        const at = new Date(day);
+        at.setHours(AppController.workdayStart + 1, 0, 0, 0);
+
+        const draft = AppController.newTaskDraft("todo");
+        draft.title = "синк dedup probe";
+        draft.scheduledAt = at;
+        draft.dueAt = at;
+        draft.hasTime = true;
+        AppController.saveTask(draft);
+
+        AppController.selectedDate = day;
+        const dc = make('import TodoCpp; DayCalendar { anchors.fill: parent }');
+        const block = findChild(dc, "taskblock-" + draft.id);
+
+        // Control: with no linked event, the block is visible.
+        verify(block !== null, "scheduled task did not render a day-grid block");
+        verify(block.visible, "task block should be visible before a linked event exists");
+
+        // Add the meeting event that links back to the task.
+        const ev = AppController.newEventDraft(AppController.workdayStart + 1, day);
+        ev.type = "sync";
+        ev.title = "синк dedup probe";
+        ev.taskId = draft.id;
+        ev.date = day;
+        AppController.saveEvent(ev);
+        wait(50);
+
+        // The linked event now stands in for the task → its block is hidden.
+        verify(!block.visible, "task block must be hidden once a linked meeting event exists");
+    }
+
     // SideRail: clicking Code Review focuses the review column.
     function test_siderail_click_review() {
         AppController.currentView = "week";

--- a/tests/test_appcontroller.cpp
+++ b/tests/test_appcontroller.cpp
@@ -8,6 +8,8 @@
 #include "AppController.h"
 #include "Models.h"
 
+#include "integrations/IntegrationTypes.h"
+
 #include <QApplication>
 #include <QDate>
 #include <QDateTime>
@@ -321,7 +323,8 @@ TEST_F(AppControllerTest, CompletingRecurringTaskSpawnsNext) {
   Task t = mkTask(QStringLiteral("REC-1"), QStringLiteral("Daily standup"));
   t.status = QStringLiteral("todo");
   t.recurrence = QStringLiteral("every:day");
-  t.deadline = QDate(2026, 7, 4);
+  t.dueAt = QDateTime(QDate(2026, 7, 4), QTime(0, 0));
+  t.scheduledAt = t.dueAt;
   app_->tasks()->reset({t});
   const int before = app_->tasks()->rowCount();
 
@@ -332,7 +335,7 @@ TEST_F(AppControllerTest, CompletingRecurringTaskSpawnsNext) {
   for(const Task& x : app_->tasks()->items()) {
     if(x.id != QStringLiteral("REC-1") && x.recurrence == QStringLiteral("every:day")) {
       EXPECT_EQ(x.status, QString("todo"));
-      EXPECT_EQ(x.deadline, QDate(2026, 7, 5));  // next day
+      EXPECT_EQ(x.dueAt.date(), QDate(2026, 7, 5));  // next day
       foundNext = true;
     }
   }
@@ -393,6 +396,160 @@ TEST_F(AppControllerTest, GitPrefixChangeRematchesFocusedBranch) {
 }
 
 // ─── headless boot ────────────────────────────────────────────────────
+
+// ─── Time-aware save/edit (HEAP-115) ───
+
+// The isNew guard used to drop the parsed clock time on every edit of an
+// existing task. Editing one now keeps 09:00.
+TEST_F(AppControllerTest, EditingAnExistingTaskKeepsTheParsedClockTime) {
+  Task t = mkTask(QStringLiteral("EDIT-1"), QStringLiteral("standup"));
+  t.scheduledAt = QDateTime(QDate(2026, 7, 10), QTime(0, 0));
+  t.dueAt = t.scheduledAt;
+  app_->tasks()->reset({t});
+
+  QVariantMap draft = app_->taskById(QStringLiteral("EDIT-1"));
+  draft["_isNew"] = false;
+  draft["_originalId"] = QStringLiteral("EDIT-1");
+  draft["scheduledAt"] = QDateTime(QDate(2026, 7, 10), QTime(9, 0));
+  draft["dueAt"] = QDateTime(QDate(2026, 7, 10), QTime(9, 0));
+  draft["hasTime"] = true;
+  app_->saveTask(draft);
+
+  const int row = app_->tasks()->indexOfId(QStringLiteral("EDIT-1"));
+  ASSERT_GE(row, 0);
+  const Task& after = app_->tasks()->items().at(row);
+  EXPECT_EQ(after.scheduledAt, QDateTime(QDate(2026, 7, 10), QTime(9, 0)));
+  EXPECT_EQ(after.dueAt, QDateTime(QDate(2026, 7, 10), QTime(9, 0)));
+  EXPECT_TRUE(after.hasTime);
+}
+
+// A caller that only knows a date (an old draft, an import) still works.
+TEST_F(AppControllerTest, ALegacyDeadlineDraftKeyLandsAtMidnight) {
+  QVariantMap draft = app_->newTaskDraft(QStringLiteral("todo"));
+  draft["_isNew"] = true;
+  draft["id"] = QStringLiteral("OLD-1");
+  draft["title"] = QStringLiteral("bare date");
+  draft["deadline"] = QDate(2026, 7, 8);
+  app_->saveTask(draft);
+
+  const int row = app_->tasks()->indexOfId(QStringLiteral("OLD-1"));
+  ASSERT_GE(row, 0);
+  const Task& t = app_->tasks()->items().at(row);
+  EXPECT_EQ(t.dueAt, QDateTime(QDate(2026, 7, 8), QTime(0, 0)));
+  EXPECT_FALSE(t.hasTime);
+}
+
+// snoozeDeadline shifts by whole days and keeps the clock time.
+TEST_F(AppControllerTest, SnoozeShiftsBothDatetimesAndKeepsTheTime) {
+  Task t = mkTask(QStringLiteral("SNZ-1"), QStringLiteral("ship"));
+  t.dueAt = QDateTime(QDate(2026, 7, 10), QTime(16, 0));
+  t.scheduledAt = t.dueAt;
+  t.hasTime = true;
+  app_->tasks()->reset({t});
+
+  app_->snoozeDeadline(QStringLiteral("SNZ-1"), 3600);
+
+  const Task& after = app_->tasks()->items().at(app_->tasks()->indexOfId(QStringLiteral("SNZ-1")));
+  EXPECT_EQ(after.dueAt, QDateTime(QDate(2026, 7, 11), QTime(16, 0)));
+  EXPECT_EQ(after.scheduledAt, QDateTime(QDate(2026, 7, 11), QTime(16, 0)));
+}
+
+// ─── Pulled labels (HEAP-124) ───
+
+TEST_F(AppControllerTest, PulledIssueLabelsArePersistedOntoTheTask) {
+  heap::integrations::ExternalTask issue;
+  issue.providerId = QStringLiteral("github");
+  issue.externalId = QStringLiteral("68");
+  issue.url = QStringLiteral("https://github.com/sectapunterx/heap/issues/68");
+  issue.title = QStringLiteral("Portable build misses a DLL");
+  issue.status = QStringLiteral("open");
+  issue.labels = {QStringLiteral("bug"), QStringLiteral("windows")};
+
+  app_->tasks()->reset({});
+  app_->mergeExternalTasks(QStringLiteral("github"), QStringLiteral("github-"), {issue});
+
+  const int row = app_->tasks()->indexOfId(QStringLiteral("github-68"));
+  ASSERT_GE(row, 0);
+  const Task& t = app_->tasks()->items().at(row);
+  ASSERT_EQ(t.labels.size(), 2);
+  EXPECT_EQ(t.labels.at(0).id, QStringLiteral("bug"));
+  EXPECT_EQ(t.labels.at(1).id, QStringLiteral("windows"));
+  EXPECT_EQ(t.externalProvider, QStringLiteral("github"));
+
+  // …and they survive a save/reload of the editor draft.
+  QVariantMap draft = app_->taskById(QStringLiteral("github-68"));
+  draft["_isNew"] = false;
+  draft["_originalId"] = QStringLiteral("github-68");
+  app_->saveTask(draft);
+  const Task& after = app_->tasks()->items().at(app_->tasks()->indexOfId(QStringLiteral("github-68")));
+  ASSERT_EQ(after.labels.size(), 2);
+  EXPECT_EQ(after.labels.at(0).id, QStringLiteral("bug"));
+}
+
+TEST_F(AppControllerTest, EstimateAndSomedayRoundTripThroughTheEditorDraft) {
+  QVariantMap draft = app_->newTaskDraft(QStringLiteral("todo"));
+  draft["_isNew"] = true;
+  draft["id"] = QStringLiteral("EST-1");
+  draft["title"] = QStringLiteral("plan the epic");
+  draft["estimateMinutes"] = 480;
+  draft["someday"] = true;
+  draft["labels"] = QVariantList{QStringLiteral("infra")};
+  app_->saveTask(draft);
+
+  const Task& t = app_->tasks()->items().at(app_->tasks()->indexOfId(QStringLiteral("EST-1")));
+  EXPECT_EQ(t.estimateMinutes, 480);
+  EXPECT_TRUE(t.someday);
+  ASSERT_EQ(t.labels.size(), 1);
+  EXPECT_EQ(t.labels.at(0).id, QStringLiteral("infra"));
+}
+
+// The epic-level contract (HEAP-104): "review PR tomorrow 3pm" keeps its 3pm
+// through capture, an edit of the existing task, save, reload and export.
+TEST_F(AppControllerTest, ThreePmSurvivesCaptureEditSaveReloadAndExport) {
+  const QDateTime reference(QDate(2026, 7, 9), QTime(10, 0));
+  const QVariantMap parsed = app_->parseDateTime(QStringLiteral("review PR tomorrow 3pm"), reference);
+  ASSERT_TRUE(parsed.value(QStringLiteral("ok")).toBool());
+  ASSERT_TRUE(parsed.value(QStringLiteral("hasTime")).toBool());
+  const QDateTime at = parsed.value(QStringLiteral("start")).toDateTime();
+  ASSERT_EQ(at, QDateTime(QDate(2026, 7, 10), QTime(15, 0)));
+
+  // Capture, exactly as QuickCapturePopup does.
+  QVariantMap draft = app_->newQuickTaskDraft();
+  draft["_isNew"] = true;
+  draft["title"] = QStringLiteral("review PR");
+  draft["scheduledAt"] = at;
+  draft["dueAt"] = at;
+  draft["hasTime"] = true;
+  app_->saveTask(draft);
+  const QString id = draft.value("id").toString();
+
+  // Edit the existing task without touching the time (the old isNew guard's bug).
+  QVariantMap edit = app_->taskById(id);
+  edit["_isNew"] = false;
+  edit["_originalId"] = id;
+  edit["title"] = QStringLiteral("review PR (urgent)");
+  app_->saveTask(edit);
+
+  const Task& afterEdit = app_->tasks()->items().at(app_->tasks()->indexOfId(id));
+  EXPECT_EQ(afterEdit.dueAt, at) << "the edit dropped the clock time";
+  EXPECT_TRUE(afterEdit.hasTime);
+
+  // Save, then reload from disk in a fresh controller.
+  app_->flushSave();
+  {
+    AppController reloaded;
+    const int row = reloaded.tasks()->indexOfId(id);
+    ASSERT_GE(row, 0);
+    const Task& t = reloaded.tasks()->items().at(row);
+    EXPECT_EQ(t.dueAt, at) << "the clock time did not survive a reload";
+    EXPECT_EQ(t.scheduledAt, at);
+    EXPECT_TRUE(t.hasTime);
+  }
+
+  // Export carries it too.
+  const QString exported = app_->exportActiveProfileJson();
+  EXPECT_TRUE(exported.contains(QStringLiteral("2026-07-10T15:00:00"))) << exported.left(400).toStdString();
+}
 
 int main(int argc, char** argv) {
   qputenv("QT_QPA_PLATFORM", "offscreen");

--- a/tests/test_fault_injection.cpp
+++ b/tests/test_fault_injection.cpp
@@ -1,0 +1,299 @@
+// Durability under injected write faults (HEAP-156).
+//
+// Killing the process at a byte offset proves nothing here: saveStateNow() goes
+// through QSaveFile, which writes a temp file and atomically renames, so an
+// interrupted write leaves state.json untouched. The interesting faults live at
+// the serializer/writer seam, so that is where they are injected — via
+// AppController::setStateWriterForTesting:
+//
+//   truncate      the first N bytes reach disk, the rest do not
+//   garbage       the bytes reach disk with trailing junk appended
+//   dropped rename the bytes never reach state.json at all
+//
+// For each of 100 deterministic cases the app must reopen to a valid state,
+// quarantine anything damaged, and leave a recovery-log record. It must never
+// reopen to a fresh demo seed on top of the user's data.
+
+#include "AppController.h"
+#include "RecoveryLog.h"
+
+#include <QApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+QString appDataDir() {
+  return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+}
+
+QString statePath() {
+  return appDataDir() + "/state.json";
+}
+
+QString backupDir() {
+  return appDataDir() + "/backups";
+}
+
+void writeRaw(const QString& path, const QByteArray& bytes) {
+  QDir().mkpath(QFileInfo(path).absolutePath());
+  QFile f(path);
+  ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+  f.write(bytes);
+}
+
+QByteArray readRaw(const QString& path) {
+  QFile f(path);
+  return f.open(QIODevice::ReadOnly) ? f.readAll() : QByteArray();
+}
+
+bool isValidJsonObject(const QByteArray& bytes) {
+  const QJsonDocument d = QJsonDocument::fromJson(bytes);
+  return !d.isNull() && d.isObject();
+}
+
+void clearAppData() {
+  QDir(appDataDir()).removeRecursively();
+  QDir().mkpath(appDataDir());
+}
+
+enum class Fault { Truncate, Garbage, DroppedRename };
+
+// The three injected writers. Each is a pure function of (bytes, seed), so a
+// failing case number reproduces exactly.
+AppController::StateWriter faultyWriter(Fault fault, int seed) {
+  return [fault, seed](const QString& path, const QByteArray& bytes) -> bool {
+    switch(fault) {
+      case Fault::Truncate: {
+        const int cut = bytes.isEmpty() ? 0 : (seed * 7919) % bytes.size();
+        QFile f(path);
+        if(f.open(QIODevice::WriteOnly)) {
+          f.write(bytes.left(cut));
+        }
+        return false;
+      }
+      case Fault::Garbage: {
+        QFile f(path);
+        if(f.open(QIODevice::WriteOnly)) {
+          f.write(bytes);
+          f.write(QByteArray(" <<<garbage\xff>>> ").repeated(1 + (seed % 3)));
+        }
+        return false;
+      }
+      case Fault::DroppedRename:
+        // QSaveFile wrote its temp file and then never committed: state.json is
+        // whatever it was before. Nothing to do.
+        return false;
+    }
+    return false;
+  };
+}
+
+// One good save, so a valid backup exists to recover from.
+void seedGoodProfile() {
+  AppController app;
+  QVariantMap draft = app.newTaskDraft(QStringLiteral("todo"));
+  draft["_isNew"] = true;
+  draft["id"] = QStringLiteral("SEED-1");
+  draft["title"] = QStringLiteral("survivor");
+  app.saveTask(draft);
+  app.flushSave();
+  // Promote the good file into the backup dir: rotateBackupIfDue() only fires
+  // once per interval, and a fresh AppController has no backup history.
+  QDir().mkpath(backupDir());
+  QFile::copy(statePath(), backupDir() + "/state-20260101-000000.json");
+}
+
+class FaultInjectionTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    clearAppData();
+    seedGoodProfile();
+    good_ = readRaw(statePath());
+    ASSERT_TRUE(isValidJsonObject(good_));
+  }
+
+  void TearDown() override {
+    AppController::setStateWriterForTesting({});
+  }
+
+  QByteArray good_;
+};
+
+}  // namespace
+
+// 100 deterministic cases: every one must reopen to a valid state with the
+// seeded task intact, and never to a demo seed.
+TEST_F(FaultInjectionTest, HundredDeterministicFaultsAllRecover) {
+  const Fault faults[] = {Fault::Truncate, Fault::Garbage, Fault::DroppedRename};
+
+  for(int i = 0; i < 100; ++i) {
+    const Fault fault = faults[i % 3];
+    SCOPED_TRACE(::testing::Message() << "case " << i << " fault " << static_cast<int>(fault));
+
+    clearAppData();
+    writeRaw(statePath(), good_);
+    QDir().mkpath(backupDir());
+    writeRaw(backupDir() + "/state-20260101-000000.json", good_);
+
+    {
+      AppController::setStateWriterForTesting(faultyWriter(fault, i));
+      AppController app;
+      QVariantMap draft = app.newTaskDraft(QStringLiteral("todo"));
+      draft["_isNew"] = true;
+      draft["id"] = QStringLiteral("DOOMED-1");
+      draft["title"] = QStringLiteral("written during the fault");
+      app.saveTask(draft);
+      app.flushSave();
+      AppController::setStateWriterForTesting({});
+    }
+
+    // Reopen. Whatever the writer left behind, the app must come up on data.
+    AppController reopened;
+    EXPECT_GE(reopened.tasks()->rowCount(), 1) << "reopened with no tasks — the seed was lost";
+    bool foundSeed = false;
+    for(const Task& t : reopened.tasks()->items()) {
+      foundSeed = foundSeed || t.id == QStringLiteral("SEED-1");
+    }
+    EXPECT_TRUE(foundSeed) << "the pre-fault task did not survive";
+
+    // The live file must parse after recovery.
+    EXPECT_TRUE(isValidJsonObject(readRaw(statePath()))) << "state.json left unparseable";
+  }
+}
+
+TEST_F(FaultInjectionTest, TruncatedStateIsQuarantinedAndTheNewestBackupIsLoaded) {
+  writeRaw(backupDir() + "/state-20260101-000000.json", good_);
+  writeRaw(statePath(), good_.left(good_.size() / 2));  // truncated: unparseable
+
+  AppController app;
+
+  EXPECT_FALSE(QDir(appDataDir()).entryList({"state.corrupt-*.json"}, QDir::Files).isEmpty()) << "damaged file was not quarantined";
+  bool foundSeed = false;
+  for(const Task& t : app.tasks()->items()) {
+    foundSeed = foundSeed || t.id == QStringLiteral("SEED-1");
+  }
+  EXPECT_TRUE(foundSeed) << "the newest valid backup was not loaded";
+}
+
+TEST_F(FaultInjectionTest, GarbageStateIsQuarantinedAndRecorded) {
+  writeRaw(backupDir() + "/state-20260101-000000.json", good_);
+  writeRaw(statePath(), good_ + "\n<<<not json>>>");
+
+  AppController app;
+
+  EXPECT_FALSE(QDir(appDataDir()).entryList({"state.corrupt-*.json"}, QDir::Files).isEmpty());
+
+  bool sawQuarantine = false;
+  bool sawRecovery = false;
+  for(const QVariant& v : app.recoveryLog()) {
+    const QString kind = v.toMap().value(QStringLiteral("kind")).toString();
+    sawQuarantine = sawQuarantine || kind == QLatin1String(heap::recovery::kQuarantined);
+    sawRecovery = sawRecovery || kind == QLatin1String(heap::recovery::kRecovered);
+  }
+  EXPECT_TRUE(sawQuarantine) << "no quarantine record in the recovery log";
+  EXPECT_TRUE(sawRecovery) << "no recovery record in the recovery log";
+}
+
+TEST_F(FaultInjectionTest, CorruptWithNoBackupKeepsTheDamagedFileAndSaysSo) {
+  QDir(backupDir()).removeRecursively();
+  writeRaw(statePath(), QByteArray("{ truncated"));
+
+  AppController app;
+
+  EXPECT_FALSE(QDir(appDataDir()).entryList({"state.corrupt-*.json"}, QDir::Files).isEmpty());
+  bool sawUnrecovered = false;
+  for(const QVariant& v : app.recoveryLog()) {
+    sawUnrecovered = sawUnrecovered || v.toMap().value(QStringLiteral("kind")).toString() == QLatin1String(heap::recovery::kUnrecovered);
+  }
+  EXPECT_TRUE(sawUnrecovered);
+}
+
+TEST_F(FaultInjectionTest, AFailedWriteIsRecordedInTheFaultLog) {
+  AppController::setStateWriterForTesting([](const QString&, const QByteArray&) {
+    return false;
+  });
+  AppController app;
+  QVariantMap draft = app.newTaskDraft(QStringLiteral("todo"));
+  draft["_isNew"] = true;
+  draft["id"] = QStringLiteral("LOST-1");
+  draft["title"] = QStringLiteral("edit that never reached disk");
+  app.saveTask(draft);  // arms the debounced save
+  app.flushSave();
+  AppController::setStateWriterForTesting({});
+
+  bool sawWriteFailure = false;
+  for(const QVariant& v : app.recoveryLog()) {
+    sawWriteFailure = sawWriteFailure || v.toMap().value(QStringLiteral("kind")).toString() == QLatin1String(heap::recovery::kWriteFailed);
+  }
+  EXPECT_TRUE(sawWriteFailure) << "a failed save left no local record";
+}
+
+// The bug-report capture must read only local files. The controller owns a
+// QNetworkAccessManager for the update check, so the assertion is not "no
+// manager exists" but "capture creates no manager and issues no request": every
+// QNetworkReply is a child of the manager that created it, so a request made
+// during capture would show up here.
+TEST_F(FaultInjectionTest, CaptureForABugReportMakesNoNetworkRequest) {
+  writeRaw(statePath(), QByteArray("{ truncated"));
+  AppController app;  // fires a recovery, so there is something to attach
+
+  const auto managerCount = [&app] {
+    return app.findChildren<QNetworkAccessManager*>().size();
+  };
+  const auto replyCount = [&app] {
+    return app.findChildren<QNetworkReply*>().size();
+  };
+  const int managersBefore = managerCount();
+  ASSERT_EQ(replyCount(), 0) << "a request was already in flight before capture";
+
+  const QString body = app.issueReportBody();
+  const QString dest = appDataDir() + "/exported-recovery.log";
+  const bool exported = app.exportRecoveryLog(QUrl::fromLocalFile(dest));
+  QCoreApplication::processEvents();
+
+  EXPECT_EQ(managerCount(), managersBefore) << "capture created a network manager";
+  EXPECT_EQ(replyCount(), 0) << "capture issued a network request";
+  EXPECT_TRUE(body.contains(QStringLiteral("Diagnostics")));
+  EXPECT_TRUE(body.contains(QStringLiteral("Recovery log"))) << "the recovery record was not attached";
+  EXPECT_TRUE(exported);
+  EXPECT_TRUE(QFile::exists(dest));
+  EXPECT_FALSE(readRaw(dest).isEmpty());
+}
+
+TEST_F(FaultInjectionTest, RecoveryIsSurfacedToTheUser) {
+  writeRaw(backupDir() + "/state-20260101-000000.json", good_);
+  writeRaw(statePath(), QByteArray("{ truncated"));
+
+  AppController app;
+  // The controller defers the banner to the event loop so the QML toast bar
+  // exists; drain it and check the user is actually told.
+  QString shown;
+  QObject::connect(&app, &AppController::toast, [&shown](const QString& msg) {
+    shown = msg;
+  });
+  QCoreApplication::processEvents();
+  EXPECT_FALSE(shown.isEmpty()) << "recovery happened silently";
+}
+
+int main(int argc, char** argv) {
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+  QStandardPaths::setTestModeEnabled(true);
+  QTemporaryDir scratch;
+  scratch.setAutoRemove(true);
+  qputenv("XDG_CONFIG_HOME", scratch.path().toUtf8());
+  qputenv("XDG_DATA_HOME", scratch.path().toUtf8());
+
+  QApplication qapp(argc, argv);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/test_migration.cpp
+++ b/tests/test_migration.cpp
@@ -1,0 +1,239 @@
+// Schema migration on load (HEAP-146).
+//
+// A v3 profile carries `deadline` as a bare date. Opening it must upgrade the
+// file to v4 in place, retain a pre-migration copy, and never re-migrate on the
+// next launch. Runs headless against QStandardPaths test mode, so it never
+// touches the user's real AppDataLocation.
+
+#include "AppController.h"
+#include "StateSerializer.h"
+
+#include <QApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+QString appDataDir() {
+  return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+}
+
+QString statePath() {
+  return appDataDir() + "/state.json";
+}
+
+QString backupDir() {
+  return appDataDir() + "/backups";
+}
+
+void writeFile(const QString& path, const QByteArray& bytes) {
+  QDir().mkpath(QFileInfo(path).absolutePath());
+  QFile f(path);
+  ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+  f.write(bytes);
+}
+
+QJsonObject readJson(const QString& path) {
+  QFile f(path);
+  if(!f.open(QIODevice::ReadOnly)) {
+    return {};
+  }
+  return QJsonDocument::fromJson(f.readAll()).object();
+}
+
+// A schema-v3 document with one dated task, one undated task, and one task whose
+// deadline is the empty string the app used to write for "no deadline".
+QByteArray v3Document() {
+  return R"({
+  "schemaVersion": 3,
+  "activeProfileId": "default",
+  "events": [],
+  "profiles": [
+    {
+      "id": "default",
+      "name": "Example",
+      "color": "#5cc2dd",
+      "createdAt": "2026-01-01T00:00:00",
+      "people": [],
+      "statuses": [{"id": "todo", "name": "To Do", "color": "#888888"}],
+      "tasks": [
+        {"id": "T-1", "title": "dated", "priority": "P1", "status": "todo",
+         "deadline": "2026-07-08", "statusChangedAt": "2026-07-01T09:00:00", "archived": false},
+        {"id": "T-2", "title": "undated", "priority": "P2", "status": "todo",
+         "deadline": "", "statusChangedAt": "2026-07-01T09:00:00", "archived": false},
+        {"id": "T-3", "title": "timed ticket", "priority": "P0", "status": "prog",
+         "deadline": "2026-07-09", "trackedSeconds": 90, "recurrence": "every:day",
+         "externalId": "68", "externalUrl": "https://x.invalid/68", "externalProvider": "github",
+         "statusChangedAt": "2026-07-01T09:00:00", "archived": false}
+      ]
+    }
+  ]
+})";
+}
+
+void clearAppData() {
+  QDir(appDataDir()).removeRecursively();
+  QDir().mkpath(appDataDir());
+}
+
+const Task* taskById(AppController& app, const QString& id) {
+  for(const Task& t : app.tasks()->items()) {
+    if(t.id == id) {
+      return &t;
+    }
+  }
+  return nullptr;
+}
+
+class MigrationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    clearAppData();
+  }
+};
+
+}  // namespace
+
+TEST_F(MigrationTest, V3DeadlineBecomesMidnightScheduledAndDue) {
+  writeFile(statePath(), v3Document());
+
+  AppController app;
+  const Task* dated = taskById(app, QStringLiteral("T-1"));
+  ASSERT_NE(dated, nullptr);
+  EXPECT_EQ(dated->scheduledAt, QDateTime(QDate(2026, 7, 8), QTime(0, 0)));
+  EXPECT_EQ(dated->dueAt, QDateTime(QDate(2026, 7, 8), QTime(0, 0)));
+  EXPECT_FALSE(dated->hasTime);
+
+  const Task* undated = taskById(app, QStringLiteral("T-2"));
+  ASSERT_NE(undated, nullptr);
+  EXPECT_FALSE(undated->scheduledAt.isValid());
+  EXPECT_FALSE(undated->dueAt.isValid());
+}
+
+TEST_F(MigrationTest, MigrationPreservesEveryOtherField) {
+  writeFile(statePath(), v3Document());
+
+  AppController app;
+  const Task* t = taskById(app, QStringLiteral("T-3"));
+  ASSERT_NE(t, nullptr);
+  EXPECT_EQ(t->trackedSeconds, 90);
+  EXPECT_EQ(t->recurrence, QString("every:day"));
+  EXPECT_EQ(t->externalId, QString("68"));
+  EXPECT_EQ(t->externalProvider, QString("github"));
+  EXPECT_EQ(t->status, QString("prog"));
+}
+
+TEST_F(MigrationTest, OpeningAV3ProfileRetainsAPreMigrationBackup) {
+  const QByteArray original = v3Document();
+  writeFile(statePath(), original);
+
+  AppController app;
+  const QStringList kept = QDir(backupDir()).entryList({"state-premigration-*.json"}, QDir::Files);
+  ASSERT_EQ(kept.size(), 1) << "expected exactly one retained pre-migration copy";
+
+  QFile f(backupDir() + "/" + kept.first());
+  ASSERT_TRUE(f.open(QIODevice::ReadOnly));
+  EXPECT_EQ(f.readAll(), original) << "the retained copy must be the untouched original";
+}
+
+TEST_F(MigrationTest, SaveUpgradesTheFileToV4) {
+  writeFile(statePath(), v3Document());
+
+  AppController app;
+  app.flushSave();
+
+  const QJsonObject root = readJson(statePath());
+  EXPECT_EQ(root.value("schemaVersion").toInt(), heap::state::kSchemaVersion);
+
+  const QJsonObject task = root.value("profiles").toArray().at(0).toObject().value("tasks").toArray().at(0).toObject();
+  EXPECT_FALSE(task.contains("deadline")) << "the legacy key must be gone";
+  EXPECT_EQ(task.value("scheduledAt").toString().left(10), QString("2026-07-08"));
+}
+
+TEST_F(MigrationTest, ReopeningAV4ProfileDoesNotReMigrate) {
+  writeFile(statePath(), v3Document());
+  {
+    AppController first;
+    first.flushSave();
+  }
+  const int afterFirst = QDir(backupDir()).entryList({"state-premigration-*.json"}, QDir::Files).size();
+  ASSERT_EQ(afterFirst, 1);
+
+  const QByteArray migrated = [] {
+    QFile f(statePath());
+    return f.open(QIODevice::ReadOnly) ? f.readAll() : QByteArray();
+  }();
+
+  {
+    AppController second;  // the version gate must hold
+    second.flushSave();
+  }
+
+  EXPECT_EQ(QDir(backupDir()).entryList({"state-premigration-*.json"}, QDir::Files).size(), 1)
+      << "a second launch must not retain another pre-migration copy";
+
+  QFile f(statePath());
+  ASSERT_TRUE(f.open(QIODevice::ReadOnly));
+  EXPECT_EQ(f.readAll(), migrated) << "re-saving a v4 profile must be a no-op on its content";
+}
+
+// migrateState is the ladder step itself: idempotent, and safe to call twice.
+TEST_F(MigrationTest, MigrateStateIsIdempotent) {
+  QJsonObject root = QJsonDocument::fromJson(v3Document()).object();
+
+  EXPECT_TRUE(heap::state::migrateState(root, 3));
+  const QJsonObject once = root;
+  EXPECT_FALSE(heap::state::migrateState(root, heap::state::kSchemaVersion));
+  EXPECT_EQ(root, once);
+}
+
+// A failed first write leaves a v3 state.json on disk (QSaveFile never renamed).
+// The next launch must find the retained pre-migration copy, not a partial file.
+TEST_F(MigrationTest, MidMigrationFailureReopensToThePreMigrationBackup) {
+  writeFile(statePath(), v3Document());
+
+  {
+    // The migration runs on load, then the debounced save is dropped on the
+    // floor — the exact shape of a crash between migrate and commit.
+    AppController::setStateWriterForTesting([](const QString&, const QByteArray&) {
+      return false;
+    });
+    AppController app;
+    app.flushSave();
+    AppController::setStateWriterForTesting({});
+  }
+
+  // Simulate the crash having also damaged the live file.
+  writeFile(statePath(), QByteArray("{ this is not json"));
+
+  AppController reopened;
+  ASSERT_EQ(reopened.tasks()->rowCount(), 3) << "must reopen to the pre-migration data, not a fresh seed";
+  const Task* t = taskById(reopened, QStringLiteral("T-1"));
+  ASSERT_NE(t, nullptr);
+  EXPECT_EQ(t->dueAt.date(), QDate(2026, 7, 8));
+
+  EXPECT_FALSE(QDir(appDataDir()).entryList({"state.corrupt-*.json"}, QDir::Files).isEmpty())
+      << "the damaged file must be quarantined, never deleted";
+}
+
+int main(int argc, char** argv) {
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+  QStandardPaths::setTestModeEnabled(true);
+  QTemporaryDir scratch;
+  scratch.setAutoRemove(true);
+  qputenv("XDG_CONFIG_HOME", scratch.path().toUtf8());
+  qputenv("XDG_DATA_HOME", scratch.path().toUtf8());
+
+  QApplication qapp(argc, argv);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/test_models.cpp
+++ b/tests/test_models.cpp
@@ -6,6 +6,7 @@
 // setTaskId). Pure and headless — no AppController, no QApplication needed.
 
 #include "Models.h"
+#include "TaskDefer.h"
 
 #include <QColor>
 #include <QDate>
@@ -50,7 +51,8 @@ TEST(TaskModelData, MapsEveryRole) {
   t.priority = QStringLiteral("P1");
   t.status = QStringLiteral("prog");
   t.branch = QStringLiteral("feat/x");
-  t.deadline = QDate(2030, 1, 2);
+  t.dueAt = QDateTime(QDate(2030, 1, 2), QTime(0, 0));
+  t.scheduledAt = t.dueAt;
   t.archived = true;
   t.statusChangedAt = QDateTime(QDate(2030, 1, 2), QTime(9, 0));
   m.reset({t});
@@ -101,8 +103,8 @@ TEST(TaskModelUpsert, InsertAppendsUpdateReplacesInPlace) {
   EXPECT_EQ(m.rowCount(), 3);
   EXPECT_EQ(m.indexOfId(QStringLiteral("B")), 1);  // not moved to end
   EXPECT_EQ(m.data(m.index(1, 0), TaskModel::TitleRole).toString(), QString("new"));
-  EXPECT_EQ(ins.count(), 3);   // no new insert
-  EXPECT_EQ(chg.count(), 1);   // one update
+  EXPECT_EQ(ins.count(), 3);  // no new insert
+  EXPECT_EQ(chg.count(), 1);  // one update
 }
 
 // ─── TaskModel::setStatus / setArchived / stampStatusChange ───────────
@@ -340,8 +342,10 @@ TEST(PersonModelCycle, StateMachineAndDefault) {
 
 TEST(PersonModelState, SetStateGuardAndTodoCount) {
   PersonModel m;
-  m.reset({mkPerson(QStringLiteral("p1"), QStringLiteral("todo")), mkPerson(QStringLiteral("p2"), QStringLiteral("pinged")),
-           mkPerson(QStringLiteral("p3"), QStringLiteral("todo")), mkPerson(QStringLiteral("p4"), QStringLiteral("replied"))});
+  m.reset({mkPerson(QStringLiteral("p1"), QStringLiteral("todo")),
+           mkPerson(QStringLiteral("p2"), QStringLiteral("pinged")),
+           mkPerson(QStringLiteral("p3"), QStringLiteral("todo")),
+           mkPerson(QStringLiteral("p4"), QStringLiteral("replied"))});
   EXPECT_EQ(m.todoCount(), 2);
 
   QSignalSpy chg(&m, &QAbstractItemModel::dataChanged);
@@ -355,4 +359,119 @@ TEST(PersonModelState, SetStateGuardAndTodoCount) {
 
   PersonModel empty;
   EXPECT_EQ(empty.todoCount(), 0);
+}
+
+// ─── External-identity + label roles (HEAP-140) ───
+
+TEST(TaskModelExternalRoles, RoleNamesExposeTheTrackerLink) {
+  const TaskModel m;
+  const QHash<int, QByteArray> names = m.roleNames();
+  const QList<QByteArray> values = names.values();
+  for(const char* expected : {"externalProvider", "externalUrl", "externalKey", "labels", "assignee"}) {
+    EXPECT_TRUE(values.contains(QByteArray(expected))) << "missing role: " << expected;
+  }
+}
+
+TEST(TaskModelExternalRoles, PulledJiraIssueExposesItsKeyAndLabels) {
+  Task t;
+  t.id = QStringLiteral("jira-PROJ-7");
+  t.externalId = QStringLiteral("PROJ-7");
+  t.externalUrl = QStringLiteral("https://x.atlassian.net/browse/PROJ-7");
+  t.externalProvider = QStringLiteral("jira");
+  t.labels = {Label{QStringLiteral("backend"), QStringLiteral("#ff0000")}, Label{QStringLiteral("p1"), QString()}};
+  t.assignee = QStringLiteral("ann");
+
+  TaskModel m;
+  m.reset({t});
+  const QModelIndex i = m.index(0, 0);
+
+  EXPECT_EQ(m.data(i, TaskModel::ExternalProviderRole).toString(), QStringLiteral("jira"));
+  EXPECT_EQ(m.data(i, TaskModel::ExternalKeyRole).toString(), QStringLiteral("PROJ-7"));
+  EXPECT_EQ(m.data(i, TaskModel::ExternalUrlRole).toString(), t.externalUrl);
+  EXPECT_EQ(m.data(i, TaskModel::AssigneeRole).toString(), QStringLiteral("ann"));
+
+  const QVariantList labels = m.data(i, TaskModel::LabelsRole).toList();
+  ASSERT_EQ(labels.size(), 2);
+  EXPECT_EQ(labels.at(0).toMap().value(QStringLiteral("id")).toString(), QStringLiteral("backend"));
+  EXPECT_EQ(labels.at(0).toMap().value(QStringLiteral("color")).toString(), QStringLiteral("#ff0000"));
+  EXPECT_TRUE(labels.at(1).toMap().value(QStringLiteral("color")).toString().isEmpty());
+}
+
+// An issue-number tracker's key reads as "#123"; a purely local card has none.
+TEST(TaskModelExternalRoles, IssueNumberBecomesAHashKeyAndLocalCardsAreEmpty) {
+  Task gh;
+  gh.id = QStringLiteral("github-68");
+  gh.externalId = QStringLiteral("68");
+  gh.externalProvider = QStringLiteral("github");
+
+  Task local;
+  local.id = QStringLiteral("LTE-1");
+
+  TaskModel m;
+  m.reset({gh, local});
+  EXPECT_EQ(m.data(m.index(0, 0), TaskModel::ExternalKeyRole).toString(), QStringLiteral("#68"));
+
+  const QModelIndex li = m.index(1, 0);
+  EXPECT_TRUE(m.data(li, TaskModel::ExternalKeyRole).toString().isEmpty());
+  EXPECT_TRUE(m.data(li, TaskModel::ExternalProviderRole).toString().isEmpty());
+  EXPECT_TRUE(m.data(li, TaskModel::ExternalUrlRole).toString().isEmpty());
+  EXPECT_TRUE(m.data(li, TaskModel::LabelsRole).toList().isEmpty());
+  EXPECT_TRUE(m.data(li, TaskModel::AssigneeRole).toString().isEmpty());
+}
+
+// ─── Defer state (HEAP-124) ───
+
+TEST(DeferState, SomedayIsExcludedFromScheduledForTodayAndOnlyItsOwnPredicate) {
+  const QDate today(2026, 7, 9);
+
+  Task parked;
+  parked.scheduledAt = QDateTime(today, QTime(9, 0));  // scheduled, but parked
+  parked.someday = true;
+
+  EXPECT_FALSE(heap::model::isScheduledForToday(parked, today));
+  EXPECT_TRUE(heap::model::isSomeday(parked));
+  EXPECT_EQ(heap::model::deferState(parked, today), QStringLiteral("someday"));
+}
+
+TEST(DeferState, DerivesTodayScheduledAndAnytime) {
+  const QDate today(2026, 7, 9);
+
+  Task dueToday;
+  dueToday.scheduledAt = QDateTime(today, QTime(16, 0));
+  EXPECT_TRUE(heap::model::isScheduledForToday(dueToday, today));
+  EXPECT_EQ(heap::model::deferState(dueToday, today), QStringLiteral("today"));
+
+  Task overdue;
+  overdue.scheduledAt = QDateTime(today.addDays(-3), QTime(9, 0));
+  EXPECT_TRUE(heap::model::isScheduledForToday(overdue, today)) << "an overdue task is still on today's plate";
+
+  Task later;
+  later.scheduledAt = QDateTime(today.addDays(2), QTime(9, 0));
+  EXPECT_FALSE(heap::model::isScheduledForToday(later, today));
+  EXPECT_EQ(heap::model::deferState(later, today), QStringLiteral("scheduled"));
+
+  Task unscheduled;
+  EXPECT_FALSE(heap::model::isScheduledForToday(unscheduled, today));
+  EXPECT_EQ(heap::model::deferState(unscheduled, today), QStringLiteral("anytime"));
+}
+
+// The deadline role stays a QDate so every calendar view keeps its day math.
+TEST(TaskModelScheduling, DeadlineRoleIsTheDueDateWithoutItsClockTime) {
+  Task t;
+  t.dueAt = QDateTime(QDate(2026, 7, 11), QTime(16, 0));
+  t.scheduledAt = QDateTime(QDate(2026, 7, 10), QTime(9, 30));
+  t.hasTime = true;
+
+  TaskModel m;
+  m.reset({t});
+  const QModelIndex i = m.index(0, 0);
+
+  EXPECT_EQ(m.data(i, TaskModel::DeadlineRole).toDate(), QDate(2026, 7, 11));
+  EXPECT_EQ(m.data(i, TaskModel::DueAtRole).toDateTime(), t.dueAt);
+  EXPECT_EQ(m.data(i, TaskModel::ScheduledAtRole).toDateTime(), t.scheduledAt);
+  EXPECT_TRUE(m.data(i, TaskModel::HasTimeRole).toBool());
+
+  Task undated;
+  m.reset({undated});
+  EXPECT_FALSE(m.data(m.index(0, 0), TaskModel::DeadlineRole).toDate().isValid());
 }

--- a/tests/test_roundtrip.cpp
+++ b/tests/test_roundtrip.cpp
@@ -1,0 +1,305 @@
+// Lossless serialization guard (HEAP-131).
+//
+// Two serializers write Task/CalEvent: heap::state (the live save + export path
+// behind AppController::saveStateNow) and heap::sync::SyncSerializer (the sync
+// transport). A field that only one of them knows about is a field that gets
+// silently dropped. This suite pins both:
+//
+//   1. A property test: 1000 randomized Tasks and CalEvents must satisfy
+//      x == fromJson(toJson(x)) through EACH serializer.
+//   2. A field-count guard: makeFullTask/makeFullEvent set every declared field
+//      to a non-default value, and the emitted JSON must carry one key per
+//      field. Add a field without serializing it and this fails. Add a field
+//      without extending the fixtures and the static_asserts in
+//      src/StateSerializer.cpp and src/sync/SyncSerializer.cpp fail the build.
+
+#include "FieldCount.h"
+#include "Models.h"
+#include "StateSerializer.h"
+
+#include "sync/SyncSerializer.h"
+
+#include <QDate>
+#include <QDateTime>
+#include <QJsonObject>
+#include <QTime>
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+namespace {
+
+// Every declared field of Task, set to something that is not its default.
+Task makeFullTask() {
+  Task t;
+  t.id = QStringLiteral("HEAP-104");
+  t.title = QStringLiteral("Harden the task data model");
+  t.desc = QStringLiteral("lossless, time-aware persistence");
+  t.priority = QStringLiteral("P0");
+  t.status = QStringLiteral("prog");
+  t.scheduledAt = QDateTime(QDate(2026, 7, 10), QTime(9, 0, 0, 250));
+  t.dueAt = QDateTime(QDate(2026, 7, 11), QTime(16, 0, 0, 750));
+  t.hasTime = true;
+  t.branch = QStringLiteral("heap-104-lossless-task-model");
+  t.statusChangedAt = QDateTime(QDate(2026, 7, 9), QTime(14, 30, 5, 125));
+  t.archived = true;
+  t.trackedSeconds = 4242;
+  t.timerStartedAt = QDateTime(QDate(2026, 7, 9), QTime(15, 0, 1, 5));
+  t.recurrence = QStringLiteral("every:weekday");
+  t.externalId = QStringLiteral("104");
+  t.externalUrl = QStringLiteral("https://github.com/sectapunterx/heap/issues/104");
+  t.externalProvider = QStringLiteral("github");
+  t.labels = {Label{QStringLiteral("infra"), QStringLiteral("#5cc2dd")}, Label{QStringLiteral("trust"), QString()}};
+  t.estimateMinutes = 480;
+  t.someday = true;
+  t.assignee = QStringLiteral("sectapunterx");
+  return t;
+}
+
+CalEvent makeFullEvent() {
+  CalEvent e;
+  e.id = QStringLiteral("ev-1");
+  e.title = QStringLiteral("Design review");
+  e.type = QStringLiteral("sync");
+  e.start = 10.5;
+  e.end = 11.25;
+  e.attendees = QStringLiteral("Ann, Bob");
+  e.date = QDate(2026, 7, 10);
+  e.taskId = QStringLiteral("HEAP-104");
+  e.profileId = QStringLiteral("default");
+  e.context = QStringLiteral("heap");
+  return e;
+}
+
+// Deterministic generator: the same seed produces the same 1000 cases on every
+// platform, so a CI failure is reproducible locally.
+class Gen {
+ public:
+  explicit Gen(quint32 seed) : rng_(seed) {
+  }
+
+  bool boolean() {
+    return pick(0, 1) == 1;
+  }
+
+  int pick(int lo, int hi) {
+    return std::uniform_int_distribution<int>(lo, hi)(rng_);
+  }
+
+  QString text() {
+    static const QStringList kWords = {QStringLiteral(""),
+                                       QStringLiteral("a"),
+                                       QStringLiteral("ship it"),
+                                       QStringLiteral("émoji ✅日本語"),
+                                       QStringLiteral("quote\"and\\slash"),
+                                       QStringLiteral("line\nbreak")};
+    return kWords.at(pick(0, kWords.size() - 1));
+  }
+
+  // Milliseconds included: ISODateWithMs must carry them through.
+  QDateTime dateTime(bool allowInvalid = true) {
+    if(allowInvalid && pick(0, 3) == 0) {
+      return {};
+    }
+    const QDate d(pick(1970, 2200), pick(1, 12), pick(1, 28));
+    const QTime t(pick(0, 23), pick(0, 59), pick(0, 59), pick(0, 999));
+    return QDateTime(d, t);
+  }
+
+  QDate date() {
+    return pick(0, 3) == 0 ? QDate() : QDate(pick(1970, 2200), pick(1, 12), pick(1, 28));
+  }
+
+  Task task() {
+    Task t;
+    t.id = QStringLiteral("T-") + QString::number(pick(1, 10000));
+    t.title = text();
+    t.desc = text();
+    t.priority = QStringLiteral("P") + QString::number(pick(0, 3));
+    t.status = text();
+    t.scheduledAt = dateTime();
+    t.dueAt = dateTime();
+    t.hasTime = boolean();
+    t.branch = text();
+    // Never invalid: taskFromJson heals a missing status stamp to "now", which
+    // is deliberate (old files must not sort to the epoch) and unmatchable.
+    t.statusChangedAt = dateTime(false);
+    t.archived = boolean();
+    t.trackedSeconds = pick(0, 100000);
+    t.timerStartedAt = dateTime();
+    t.recurrence = boolean() ? QStringLiteral("every:week") : QString();
+    if(boolean()) {
+      t.externalId = QString::number(pick(1, 999));
+      t.externalUrl = QStringLiteral("https://example.invalid/") + t.externalId;
+      t.externalProvider = QStringLiteral("gitlab");
+    }
+    const int labelCount = pick(0, 3);
+    for(int i = 0; i < labelCount; ++i) {
+      t.labels.append(Label{QStringLiteral("l") + QString::number(pick(1, 20)), boolean() ? QStringLiteral("#ff0000") : QString()});
+    }
+    t.estimateMinutes = pick(0, 5000);
+    t.someday = boolean();
+    t.assignee = text();
+    return t;
+  }
+
+  CalEvent event() {
+    CalEvent e;
+    e.id = QStringLiteral("E-") + QString::number(pick(1, 10000));
+    e.title = text();
+    e.type = text();
+    e.start = pick(0, 47) / 2.0;
+    e.end = e.start + pick(1, 4) / 2.0;
+    e.attendees = text();
+    e.date = date();
+    e.taskId = text();
+    e.profileId = text();
+    e.context = text();
+    return e;
+  }
+
+ private:
+  std::mt19937 rng_;
+};
+
+constexpr int kCases = 1000;
+
+}  // namespace
+
+// ── The compile-time half of the guard ──
+// Mirrors the static_asserts inside both serializers. If the struct grows and
+// only one serializer is updated, that serializer's own static_assert fires.
+TEST(FieldCountGuard, TaskAndEventArityIsPinned) {
+  EXPECT_EQ(heap::meta::fieldCount<Task>(), 21u);
+  EXPECT_EQ(heap::meta::fieldCount<CalEvent>(), 10u);
+}
+
+// ── The runtime half: one emitted key per declared field ──
+// The live serializer omits keys whose value is the default, so a task with
+// every field set must emit exactly as many keys as the struct has fields.
+TEST(FieldCountGuard, LiveSerializerEmitsAKeyForEveryTaskField) {
+  const QJsonObject o = heap::state::taskToJson(makeFullTask());
+  EXPECT_EQ(static_cast<std::size_t>(o.keys().size()), heap::meta::fieldCount<Task>())
+      << "keys: " << o.keys().join(QStringLiteral(",")).toStdString();
+}
+
+TEST(FieldCountGuard, LiveSerializerEmitsAKeyForEveryEventField) {
+  const QJsonObject o = heap::state::eventToJson(makeFullEvent());
+  EXPECT_EQ(static_cast<std::size_t>(o.keys().size()), heap::meta::fieldCount<CalEvent>());
+}
+
+TEST(FieldCountGuard, SyncSerializerEmitsAKeyForEveryTaskField) {
+  const QJsonObject o = heap::sync::SyncSerializer::taskToJson(makeFullTask());
+  EXPECT_EQ(static_cast<std::size_t>(o.keys().size()), heap::meta::fieldCount<Task>())
+      << "keys: " << o.keys().join(QStringLiteral(",")).toStdString();
+}
+
+TEST(FieldCountGuard, SyncSerializerEmitsAKeyForEveryEventField) {
+  const QJsonObject o = heap::sync::SyncSerializer::eventToJson(makeFullEvent());
+  EXPECT_EQ(static_cast<std::size_t>(o.keys().size()), heap::meta::fieldCount<CalEvent>());
+}
+
+// ── Fully-populated round trips ──
+
+TEST(RoundTrip, FullTaskSurvivesLiveSerializer) {
+  const Task t = makeFullTask();
+  EXPECT_EQ(t, heap::state::taskFromJson(heap::state::taskToJson(t)));
+}
+
+TEST(RoundTrip, FullTaskSurvivesSyncSerializer) {
+  const Task t = makeFullTask();
+  EXPECT_EQ(t, heap::sync::SyncSerializer::taskFromJson(heap::sync::SyncSerializer::taskToJson(t)));
+}
+
+TEST(RoundTrip, FullEventSurvivesBothSerializers) {
+  const CalEvent e = makeFullEvent();
+  EXPECT_EQ(e, heap::state::eventFromJson(heap::state::eventToJson(e)));
+  EXPECT_EQ(e, heap::sync::SyncSerializer::eventFromJson(heap::sync::SyncSerializer::eventToJson(e)));
+}
+
+// A running timer, a recurrence rule and an external id in one task.
+TEST(RoundTrip, RunningTimerRecurrenceAndExternalIdAllSurvive) {
+  Task t;
+  t.id = QStringLiteral("X-1");
+  t.statusChangedAt = QDateTime(QDate(2026, 1, 1), QTime(1, 2, 3));
+  t.trackedSeconds = 61;
+  t.timerStartedAt = QDateTime(QDate(2026, 1, 1), QTime(2, 0));
+  t.recurrence = QStringLiteral("every:mon");
+  t.externalId = QStringLiteral("PROJ-9");
+  t.externalUrl = QStringLiteral("https://jira.invalid/browse/PROJ-9");
+  t.externalProvider = QStringLiteral("jira");
+
+  const Task live = heap::state::taskFromJson(heap::state::taskToJson(t));
+  EXPECT_EQ(live.trackedSeconds, 61);
+  EXPECT_EQ(live.timerStartedAt, t.timerStartedAt);
+  EXPECT_EQ(live.recurrence, QString("every:mon"));
+  EXPECT_EQ(live.externalId, QString("PROJ-9"));
+  EXPECT_EQ(live, t);
+
+  const Task synced = heap::sync::SyncSerializer::taskFromJson(heap::sync::SyncSerializer::taskToJson(t));
+  EXPECT_EQ(synced, t);
+}
+
+// ── Property test ──
+
+TEST(RoundTrip, ThousandRandomTasksSurviveBothSerializers) {
+  Gen gen(104u);
+  for(int i = 0; i < kCases; ++i) {
+    const Task t = gen.task();
+    const Task live = heap::state::taskFromJson(heap::state::taskToJson(t));
+    ASSERT_EQ(live, t) << "live serializer, case " << i;
+    const Task synced = heap::sync::SyncSerializer::taskFromJson(heap::sync::SyncSerializer::taskToJson(t));
+    ASSERT_EQ(synced, t) << "sync serializer, case " << i;
+  }
+}
+
+TEST(RoundTrip, ThousandRandomEventsSurviveBothSerializers) {
+  Gen gen(20260709);
+  for(int i = 0; i < kCases; ++i) {
+    const CalEvent e = gen.event();
+    ASSERT_EQ(heap::state::eventFromJson(heap::state::eventToJson(e)), e) << "live serializer, case " << i;
+    ASSERT_EQ(heap::sync::SyncSerializer::eventFromJson(heap::sync::SyncSerializer::eventToJson(e)), e) << "sync serializer, case " << i;
+  }
+}
+
+// ── Legacy read path ──
+
+TEST(RoundTrip, LegacyBareDateDeadlineLandsAtMidnightWithoutTime) {
+  QJsonObject o;
+  o["id"] = "OLD-1";
+  o["statusChangedAt"] = "2026-07-01T10:00:00";
+  o["deadline"] = "2026-07-08";
+
+  const Task live = heap::state::taskFromJson(o);
+  EXPECT_EQ(live.scheduledAt, QDateTime(QDate(2026, 7, 8), QTime(0, 0)));
+  EXPECT_EQ(live.dueAt, QDateTime(QDate(2026, 7, 8), QTime(0, 0)));
+  EXPECT_FALSE(live.hasTime);
+
+  const Task synced = heap::sync::SyncSerializer::taskFromJson(o);
+  EXPECT_EQ(synced.scheduledAt, QDateTime(QDate(2026, 7, 8), QTime(0, 0)));
+  EXPECT_FALSE(synced.hasTime);
+}
+
+TEST(RoundTrip, LegacyEmptyDeadlineStaysUnset) {
+  QJsonObject o;
+  o["id"] = "OLD-2";
+  o["statusChangedAt"] = "2026-07-01T10:00:00";
+  o["deadline"] = "";
+
+  const Task live = heap::state::taskFromJson(o);
+  EXPECT_FALSE(live.scheduledAt.isValid());
+  EXPECT_FALSE(live.dueAt.isValid());
+}
+
+// Whole-second ISO datetimes written by pre-HEAP-131 builds still parse.
+TEST(RoundTrip, DatetimesWrittenWithoutMillisecondsStillParse) {
+  QJsonObject o;
+  o["id"] = "OLD-3";
+  o["statusChangedAt"] = "2026-07-01T10:00:00";
+  o["timerStartedAt"] = "2026-07-01T11:30:00";
+
+  const Task t = heap::state::taskFromJson(o);
+  EXPECT_EQ(t.statusChangedAt, QDateTime(QDate(2026, 7, 1), QTime(10, 0)));
+  EXPECT_EQ(t.timerStartedAt, QDateTime(QDate(2026, 7, 1), QTime(11, 30)));
+}

--- a/tests/test_save_bench.cpp
+++ b/tests/test_save_bench.cpp
@@ -1,0 +1,120 @@
+// Save-latency budget for a large profile (HEAP-104 epic DoD).
+//
+// heap writes the whole profile as one JSON document on every debounced save. If
+// that write cannot hold a human-imperceptible budget at a realistic ceiling of
+// 10k tasks, the monolithic state file has to be segmented — a scope decision,
+// not something this test should paper over. So the budget is asserted, and the
+// measured number is always printed.
+//
+// The budget is deliberately loose relative to a developer machine: CI runners
+// have slow, contended disks, and this test must not flake. The number that
+// matters is the one printed to stdout.
+
+#include "AppController.h"
+
+#include <QApplication>
+#include <QDir>
+#include <QElapsedTimer>
+#include <QFile>
+#include <QFileInfo>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <iostream>
+#include <limits>
+
+namespace {
+
+constexpr int kTaskCount = 10000;
+constexpr qint64 kBudgetMs = 2000;
+
+QString appDataDir() {
+  return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+}
+
+QVector<Task> makeTasks(int n) {
+  QVector<Task> out;
+  out.reserve(n);
+  const QDateTime base(QDate(2026, 7, 9), QTime(9, 0));
+  for(int i = 0; i < n; ++i) {
+    Task t;
+    t.id = QStringLiteral("BENCH-") + QString::number(i);
+    t.title = QStringLiteral("Task number %1 with a realistic title length").arg(i);
+    t.desc = QStringLiteral("Several lines of description text, of the sort a real ticket carries.\nSecond line.");
+    t.priority = QStringLiteral("P%1").arg(i % 4);
+    t.status = (i % 3 == 0) ? QStringLiteral("todo") : QStringLiteral("prog");
+    t.scheduledAt = base.addDays(i % 90);
+    t.dueAt = base.addDays((i % 90) + 1);
+    t.hasTime = (i % 2) == 0;
+    t.branch = QStringLiteral("feature/bench-") + QString::number(i);
+    t.statusChangedAt = base;
+    t.trackedSeconds = i;
+    t.recurrence = (i % 10 == 0) ? QStringLiteral("every:weekday") : QString();
+    if(i % 5 == 0) {
+      t.externalId = QString::number(i);
+      t.externalUrl = QStringLiteral("https://example.invalid/") + t.externalId;
+      t.externalProvider = QStringLiteral("github");
+    }
+    t.labels = {Label{QStringLiteral("bench"), QStringLiteral("#5cc2dd")}, Label{QStringLiteral("p") + QString::number(i % 4), QString()}};
+    t.estimateMinutes = 30 + (i % 240);
+    out.append(t);
+  }
+  return out;
+}
+
+}  // namespace
+
+TEST(SaveLatency, TenThousandTasksSaveWithinBudget) {
+  QDir(appDataDir()).removeRecursively();
+  QDir().mkpath(appDataDir());
+
+  AppController app;
+  app.tasks()->reset(makeTasks(kTaskCount));
+
+  // flushSave() only writes when a save is pending, so each run arms the
+  // debounced save the way any edit would, then times the flush: snapshot the
+  // active profile, serialize the whole document, write it atomically.
+  const auto armAndTime = [&app](int i) {
+    app.setCrumbUser(QStringLiteral("bench-") + QString::number(i));
+    QElapsedTimer timer;
+    timer.start();
+    app.flushSave();
+    return timer.elapsed();
+  };
+
+  armAndTime(-1);  // warm the page cache and the profile snapshot
+
+  qint64 best = std::numeric_limits<qint64>::max();
+  qint64 total = 0;
+  constexpr int kRuns = 5;
+  for(int i = 0; i < kRuns; ++i) {
+    const qint64 elapsed = armAndTime(i);
+    ASSERT_GT(elapsed, -1);
+    best = std::min(best, elapsed);
+    total += elapsed;
+  }
+
+  const qint64 size = QFileInfo(appDataDir() + "/state.json").size();
+  std::cout << "[ save-latency ] tasks=" << kTaskCount << " state.json=" << (size / 1024) << " KiB"
+            << " best=" << best << "ms mean=" << (total / kRuns) << "ms budget=" << kBudgetMs << "ms" << std::endl;
+
+  EXPECT_LE(best, kBudgetMs) << "A 10k-task profile no longer saves within the budget. This is the signal to "
+                                "segment the state file — report it, do not raise the budget.";
+}
+
+int main(int argc, char** argv) {
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+  QStandardPaths::setTestModeEnabled(true);
+  QTemporaryDir scratch;
+  scratch.setAutoRemove(true);
+  qputenv("XDG_CONFIG_HOME", scratch.path().toUtf8());
+  qputenv("XDG_DATA_HOME", scratch.path().toUtf8());
+
+  QApplication qapp(argc, argv);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/test_save_bench.cpp
+++ b/tests/test_save_bench.cpp
@@ -98,8 +98,8 @@ TEST(SaveLatency, TenThousandTasksSaveWithinBudget) {
   }
 
   const qint64 size = QFileInfo(appDataDir() + "/state.json").size();
-  std::cout << "[ save-latency ] tasks=" << kTaskCount << " state.json=" << (size / 1024) << " KiB"
-            << " best=" << best << "ms mean=" << (total / kRuns) << "ms budget=" << kBudgetMs << "ms" << std::endl;
+  std::cout << "[ save-latency ] tasks=" << kTaskCount << " state.json=" << (size / 1024) << " KiB" << " best=" << best
+            << "ms mean=" << (total / kRuns) << "ms budget=" << kBudgetMs << "ms" << std::endl;
 
   EXPECT_LE(best, kBudgetMs) << "A 10k-task profile no longer saves within the budget. This is the signal to "
                                 "segment the state file — report it, do not raise the budget.";

--- a/tests/test_selection.cpp
+++ b/tests/test_selection.cpp
@@ -264,7 +264,8 @@ TEST_F(SelectionTest, SaveTaskPreservesArchivedFlag) {
   QVector<Task> items;
   Task t = makeTask("T-1");
   t.title = "kept";
-  t.deadline = QDate(2030, 5, 22);
+  t.dueAt = QDateTime(QDate(2030, 5, 22), QTime(0, 0));
+  t.scheduledAt = t.dueAt;
   t.archived = true;
   items.append(t);
   app_->tasks()->reset(items);
@@ -280,7 +281,7 @@ TEST_F(SelectionTest, SaveTaskPreservesArchivedFlag) {
   ASSERT_GE(row, 0);
   const Task& after = app_->tasks()->items().at(row);
   EXPECT_TRUE(after.archived);
-  EXPECT_EQ(after.deadline, QDate(2030, 5, 22));
+  EXPECT_EQ(after.dueAt, QDateTime(QDate(2030, 5, 22), QTime(0, 0)));
   EXPECT_EQ(after.title, QStringLiteral("kept"));
 }
 

--- a/tests/test_sync_serializer.cpp
+++ b/tests/test_sync_serializer.cpp
@@ -20,7 +20,8 @@ Task makeTask(const QString& id, const QString& title) {
   t.desc = QStringLiteral("desc of ") + id;
   t.priority = QStringLiteral("P1");
   t.status = QStringLiteral("prog");
-  t.deadline = QDate(2026, 7, 15);
+  t.dueAt = QDateTime(QDate(2026, 7, 15), QTime(0, 0));
+  t.scheduledAt = t.dueAt;
   t.branch = QStringLiteral("fix/") + id;
   t.statusChangedAt = QDateTime(QDate(2026, 7, 1), QTime(14, 30));
   t.archived = false;
@@ -84,7 +85,7 @@ TEST(SyncSerializer, TaskFieldsSurviveRoundTrip) {
   EXPECT_EQ(first.id, QString("T-1"));
   EXPECT_EQ(first.title, QString("first"));
   EXPECT_EQ(first.priority, QString("P1"));
-  EXPECT_EQ(first.deadline, QDate(2026, 7, 15));
+  EXPECT_EQ(first.dueAt, QDateTime(QDate(2026, 7, 15), QTime(0, 0)));
   EXPECT_EQ(first.statusChangedAt, QDateTime(QDate(2026, 7, 1), QTime(14, 30)));
   EXPECT_FALSE(first.archived);
   EXPECT_EQ(first.branch, QString("fix/T-1"));


### PR DESCRIPTION
Closes the HEAP-104 epic: `Task.deadline` becomes a time-aware `scheduledAt`/`dueAt` pair, tasks gain labels/estimate/defer state, the tracker link becomes readable from QML, both serializers are lossless and guarded, `state.json` migrates v3→v4 behind the existing version gate, and durability is proven by fault injection rather than asserted.

### HEAP-115 — `scheduledAt` / `dueAt`
`Task.deadline` was a bare `QDate`. The parsed clock time was dropped on edit of an existing task (the `isNew` guard in `TaskEditor`) and for plain todos and tickets. Now `scheduledAt` and `dueAt` are `QDateTime` and `hasTime` records whether the clock component is real. Deadline reminders fire at the parsed time instead of 23:59; a bare date keeps the old end-of-day horizon. The `deadline` model role still returns a `QDate` (`dueAt`'s date), so every calendar and timeline view keeps its whole-day arithmetic unchanged. The parsed time now lives on the task, so the focus-block `CalEvent` workaround is gone and the Day view renders scheduled tasks directly.

### HEAP-124 — labels, estimate, defer state
`labels[]` (id + colour), `estimateMinutes`, and a `someday` flag. Defer state (`today | scheduled | anytime | someday`) is derived in `src/TaskDefer.h`, never stored. Labels pulled from a tracker were parsed and thrown away by `mergeExternalTasks`; they are now persisted and rendered as chips on the card. A CSV export is out of scope and stays with HEAP-138.

### HEAP-131 — lossless, field-count guarded
The live save/export serializer moved out of `AppController`'s anonymous namespace into `heap::state` (`src/StateSerializer.cpp`) so the guards can exercise the real save path. `SyncSerializer` was silently dropping `trackedSeconds`, `timerStartedAt`, `recurrence` and `externalId/Url/Provider`; it is now at full-field parity. Both write milliseconds and both read the legacy bare-date `deadline`.

The guard has two halves. `static_assert` on the aggregate arity of `Task` and `CalEvent` lives inside **each** serializer, so adding a field fails the build of any serializer not taught about it. A fully-populated fixture then asserts the emitted JSON carries exactly one key per declared field. 1000 randomized round trips run through both serializers on every CI runner. Verified by adding a probe field: both `src/StateSerializer.cpp` and `src/sync/SyncSerializer.cpp` failed to compile.

### HEAP-140 — tracker identity as model roles
`externalProvider`, `externalUrl`, `externalKey`, `labels`, `assignee`. `externalKey` reads as the Jira key verbatim and as `#123` for the issue-number trackers. A purely local card returns empty roles.

### HEAP-146 — v3→v4 migration
A `v3→v4` step on the existing ladder in `loadStateOnStart`, gated by the existing `schemaVersion` so a v4 profile is never re-migrated. The original file is copied to `backups/state-premigration-v3-<stamp>.json` before the first write, and retention pruning now skips it. Because that copy is the newest valid `state-*.json`, a failure between migrate and commit reopens to it rather than to a partial state. The atomic-write and quarantine paths are unchanged.

### HEAP-156 — durability, proven and surfaced
A literal "kill at a byte offset" test is vacuous against `QSaveFile`, so faults are injected at the serializer/writer seam: truncation, trailing garbage, dropped rename, 100 deterministic cases. Every case reopens to valid state with the pre-fault task intact.

Recovery is no longer silent. `src/RecoveryLog.cpp` appends a local JSONL record for every quarantine, backup recovery, migration and failed write; the existing "Report an issue" action attaches it. **No automatic egress** — a test asserts that building the report body and exporting the log creates no network manager and issues no request.

### Save latency

A 10k-task profile serializes and writes in **277 ms** (best of 5; mean 282 ms) producing a 10.4 MiB `state.json`, measured on the maintainer's Windows machine. The asserted ceiling is 2000 ms, chosen loose so a contended CI disk cannot flake the check. The budget holds, so state-file segmentation is **not** forced. Worth knowing: the write is synchronous on the GUI thread, so at that ceiling a save is a perceptible stall.

### Also fixed

A task with no due date rendered `⏱ NaNd` on its card. An unset `QDate` reaches QML as an `Invalid Date`, which is truthy, so the existing guard never fired. Pre-existing on `master`; found by screenshotting the board during verification.

### Verification

31 test suites green locally on Windows (`ctest`). The migration was additionally run against a copy of a real `state.json` from this machine's profile — task count, ids and dates preserved, backup retained, file upgraded to v4 — with the original never opened for writing. The app was launched against a throwaway data directory and screenshotted: label chips render, the card shows `today 16:00`, the Day view shows the scheduled task at 16:00, and the QML engine emitted no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)