### PR TITLE
fix(build): resolve heap_core link-feature clash in QML tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -938,8 +938,17 @@ target_compile_definitions(heap_qml_tests PRIVATE
 # initializer. Nothing in the test references a symbol from it, so a normal link
 # lets the linker drop the whole archive (works on Windows by luck, stripped on
 # Linux → "SideRail is not a type" at runtime). WHOLE_ARCHIVE keeps the init.
+# heap_core reaches this target twice: once explicitly here (WHOLE_ARCHIVE, so
+# the backing library's file-based QML component registrations are not stripped)
+# and once more as a DEFAULT-feature interface dependency that heap_coreplugin
+# propagates. CMake refuses the same library linked with two different link
+# features ("heap_core ... has already occurred with the feature
+# 'WHOLE_ARCHIVE'"), which fails configure on stock Ubuntu (apt Qt 6.4 /
+# CMake 3.28). Pin WHOLE_ARCHIVE for every occurrence of heap_core in this
+# target — including the propagated one — so both agree. (CMake >= 3.24)
+set_property(TARGET heap_qml_tests PROPERTY LINK_LIBRARY_OVERRIDE_heap_core WHOLE_ARCHIVE)
 target_link_libraries(heap_qml_tests PRIVATE
-        "$<LINK_LIBRARY:WHOLE_ARCHIVE,heap_core>"
+        heap_core
         "$<LINK_LIBRARY:WHOLE_ARCHIVE,heap_coreplugin>"
         Qt6::QuickTest
 )


### PR DESCRIPTION
## Problem

Configuring on a clean Ubuntu box (apt Qt 6.4.2 / CMake 3.28) fails at the generate step:

```
Impossible to link target 'heap_qml_tests' because the link item
'heap_core', specified without any feature or 'DEFAULT' feature, has
already occurred with the feature 'WHOLE_ARCHIVE', which is not allowed.
```
(`tests/CMakeLists.txt`, `qt_add_executable(heap_qml_tests ...)`)

## Cause

`heap_qml_tests` reaches `heap_core` **twice** with conflicting link features:

- **explicitly** via `$<LINK_LIBRARY:WHOLE_ARCHIVE,heap_core>` — needed so the backing library's file-based QML component registrations (SideRail, ArchiveView, …) are not stripped on Linux;
- **implicitly** as a `DEFAULT`-feature interface dependency propagated by `heap_coreplugin`.

CMake refuses the same library linked with two different features. Newer Qt (6.8+, provisioned on CI via install-qt-action) wires the plugin differently and doesn't surface the clash, so CI never caught it — only stock-Qt distros hit it.

## Fix

Pin `WHOLE_ARCHIVE` for **every** occurrence of `heap_core` in the target via the [`LINK_LIBRARY_OVERRIDE_heap_core`](https://cmake.org/cmake/help/latest/prop_tgt/LINK_LIBRARY_OVERRIDE_LIBRARY.html) target property (CMake ≥ 3.24). Per the docs it overrides the propagated no-feature occurrence too, so both agree and the conflict disappears. `WHOLE_ARCHIVE` semantics for the tests are unchanged.

## Verification

- Configure + generate pass locally (ucrt64, newer Qt) with no regression.
- The stock-Qt path (Ubuntu apt 6.4.2 / CMake 3.28) is the one that surfaced the clash; re-run `cmake -S . -B build` there to confirm the generate step now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)