### PR TITLE
test(qml): full component coverage + 10 confirmed bug fixes

### DIFF
--- a/qml/ArchiveView.qml
+++ b/qml/ArchiveView.qml
@@ -98,7 +98,7 @@ Item {
             out.push(t);
         }
         const priRank = {P0: 0, P1: 1, P2: 2, P3: 3};
-        out.sort((a, b) => (priRank[a.priority] || 9) - (priRank[b.priority] || 9));
+        out.sort((a, b) => (priRank[a.priority] ?? 9) - (priRank[b.priority] ?? 9));
         return out;
     }
 

--- a/qml/CommandPalette.qml
+++ b/qml/CommandPalette.qml
@@ -49,7 +49,9 @@ Popup {
         }
         if (i < ql.length) return -1;
         score -= lastPos * 0.05;  // prefer early matches
-        return score;
+        // A late single-char match can push score below 0; clamp so a real match
+        // never collides with the -1 no-match sentinel the caller filters on.
+        return Math.max(0, score);
     }
 
     function _escapeHtml(s) {

--- a/qml/CommandPalette.qml
+++ b/qml/CommandPalette.qml
@@ -87,7 +87,11 @@ Popup {
             // Full-text (HEAP-80): match the body too, with a context snippet.
             if (trimmed.length >= 2 && e.body && e.body.toLowerCase().indexOf(ql) >= 0) {
                 snippet = _snippetFor(e.body, trimmed);
-                if (score < 0) score = 5;  // body-only hit — include below head matches
+                // Body hit floors the entry at tier 5 (below head matches). Use
+                // max, not `if (score < 0)`, so a weak-label match that _fuzzyScore
+                // now clamps to 0 still gets the body tier and isn't ranked below
+                // a pure body-only hit.
+                score = Math.max(score, 5);
             }
             if (score < 0) continue;
             // tiny boost so an entry in the active profile floats up

--- a/qml/DayCalendar.qml
+++ b/qml/DayCalendar.qml
@@ -510,7 +510,11 @@ Item {
                                     }
                                     onPositionChanged: (mouse) => {
                                         const pt = moveArea.mapToItem(eventsLayer, mouse.x, mouse.y);
-                                        const wantY = pt.y - grabY;
+                                        // grabY is moveArea-local; moveArea's origin sits topMargin
+                                        // below the event top, while pt/baseY are eventsLayer-absolute.
+                                        // Subtract the inset so a still pointer yields dy == 0 (else a
+                                        // constant +6px bias trips didDrag and drops events late).
+                                        const wantY = pt.y - grabY - moveArea.anchors.topMargin;
                                         const dy = wantY - baseY;
                                         if (!didDrag && Math.abs(dy) > 5) didDrag = true;
                                         if (didDrag) evRect.dragDy = dy;

--- a/qml/KanbanBoard.qml
+++ b/qml/KanbanBoard.qml
@@ -260,6 +260,11 @@ Item {
                                         visible: col.renaming
                                         anchors.fill: parent
                                         text: col.statusName
+                                        // Typing breaks the declarative binding above; re-sync to the
+                                        // authoritative name every time the field opens so an
+                                        // Escape-cancelled edit can't linger and be auto-committed by
+                                        // the blur handler on the next rename.
+                                        onVisibleChanged: if (visible) text = col.statusName
                                         color: Theme.text
                                         background: Rectangle { radius: 4; color: Theme.panel; border.color: Theme.accent; border.width: 1 }
                                         font.family: Theme.fontUi

--- a/qml/MonthView.qml
+++ b/qml/MonthView.qml
@@ -121,7 +121,7 @@ Item {
         }
         const priRank = { P0: 0, P1: 1, P2: 2, P3: 3 };
         for (let k = 0; k < cells.length; k++)
-            cells[k].tasks.sort((a, b) => (priRank[a.priority] || 9) - (priRank[b.priority] || 9));
+            cells[k].tasks.sort((a, b) => (priRank[a.priority] ?? 9) - (priRank[b.priority] ?? 9));
         return cells;
     }
     readonly property var cells: buildCells()

--- a/qml/NotesView.qml
+++ b/qml/NotesView.qml
@@ -64,7 +64,9 @@ Item {
         }
         if (i < ql.length) return -1;
         score -= lastPos * 0.05;
-        return score;
+        // Clamp: a late single-char match must not go negative and be dropped by
+        // the caller's `if (sc < 0) continue` as though the char were absent.
+        return Math.max(0, score);
     }
 
     function _peopleEntries() {

--- a/qml/SettingsView.qml
+++ b/qml/SettingsView.qml
@@ -1077,7 +1077,10 @@ Item {
                     SliderRow {
                         label: I18n.t("settings.notif.meetingLead")
                         unit: " min"; min: 0; max: 30; step: 1
-                        value: (root.settings.notifications && root.settings.notifications.meetingLead) || 5
+                        // Undefined-aware fallback: a stored 0 is a valid lead
+                        // (min is 0) and must not collapse to 5 via a falsy `||`.
+                        value: root.settings.notifications
+                               ? (root.settings.notifications.meetingLead ?? 5) : 5
                         onMoved: (value) => root.set("notifications", "meetingLead", value)
                     }
                 }

--- a/qml/TaskEditor.qml
+++ b/qml/TaskEditor.qml
@@ -210,6 +210,7 @@ Popup {
         }
         TextField {
             id: idField
+            objectName: "te-id"
             Layout.leftMargin: 18; Layout.rightMargin: 18
             Layout.fillWidth: true
             // New tasks: TODO placeholder — final id is generated on save.
@@ -422,11 +423,14 @@ Popup {
             FieldLabel { text: "" }
             ComboBox {
                 id: recurBox
+                objectName: "te-recurrence"
                 Layout.fillWidth: true
                 readonly property var _vals: ["", "every:day", "every:week", "every:weekday",
-                                              "every:mon", "every:tue", "every:wed", "every:thu", "every:fri"]
+                                              "every:mon", "every:tue", "every:wed", "every:thu", "every:fri",
+                                              "every:sat", "every:sun"]
                 model: ["None", "Daily", "Weekly", "Weekdays",
-                        "Every Mon", "Every Tue", "Every Wed", "Every Thu", "Every Fri"]
+                        "Every Mon", "Every Tue", "Every Wed", "Every Thu", "Every Fri",
+                        "Every Sat", "Every Sun"]
                 background: FieldBg {
                 }
                 contentItem: Text {
@@ -510,11 +514,15 @@ Popup {
             Layout.leftMargin: 18; Layout.rightMargin: 18; Layout.topMargin: 8; Layout.bottomMargin: 16
             spacing: 8
             PillButton {
+                objectName: "te-delete"
                 visible: !root.isNew
                 text: I18n.t("common.delete")
                 danger: true
                 onClicked: {
-                    AppController.deleteTask(idField.text);
+                    // Delete the row that was opened, keyed by the stable
+                    // open-time id — NOT the live idField, which the user may
+                    // have edited (Save threads _originalId for the same reason).
+                    AppController.deleteTask(root._originalId);
                     root.close();
                 }
             }

--- a/qml/TimelineView.qml
+++ b/qml/TimelineView.qml
@@ -126,7 +126,7 @@ Item {
                 const ad = a.deadline && a.deadline.getTime ? a.deadline.getTime() : 9e15;
                 const bd = b.deadline && b.deadline.getTime ? b.deadline.getTime() : 9e15;
                 if (ad !== bd) return ad - bd;
-                return (priRank[a.priority] || 9) - (priRank[b.priority] || 9);
+                return (priRank[a.priority] ?? 9) - (priRank[b.priority] ?? 9);
             });
         }
         return groups;

--- a/qml/WeekView.qml
+++ b/qml/WeekView.qml
@@ -335,6 +335,7 @@ Item {
                     model: root.days
                     delegate: Item {
                         id: headCol
+                        objectName: "wvHeadCol"
                         required property var modelData
                         required property int index
                         x: gridHost.gutterW + index * gridHost.dayW

--- a/qml/WeekView.qml
+++ b/qml/WeekView.qml
@@ -93,6 +93,14 @@ Item {
         const offset = sundayFirst ? -dow : (dow === 0 ? -6 : 1 - dow);
         return new Date(d.getFullYear(), d.getMonth(), d.getDate() + offset);
     }
+    // Weekend shading must track the real day-of-week, not the column position:
+    // under weekStart="sun" column 5 is Friday and column 0 is Sunday, so the
+    // old `index >= 5` tinted Friday and missed Sunday.
+    function isWeekendDate(d) {
+        if (!d || !d.getDay) return false;
+        const w = d.getDay();
+        return w === 0 || w === 6;
+    }
     function fmtShort(d) {
         return AppController.shortDate(d);
     }
@@ -334,7 +342,7 @@ Item {
                         width: gridHost.dayW
                         height: headerBand.height
                         readonly property bool isToday: root.isSameDay(modelData.date, AppController.today)
-                        readonly property bool isWeekend: index >= 5
+                        readonly property bool isWeekend: root.isWeekendDate(modelData.date)
 
                         Rectangle {
                             anchors.fill: parent
@@ -524,7 +532,7 @@ Item {
                             width: gridHost.dayW
                             height: (root.hoursEnd - root.hoursStart) * root.hourH
                             readonly property bool isToday: root.isSameDay(modelData.date, AppController.today)
-                            readonly property bool isWeekend: index >= 5
+                            readonly property bool isWeekend: root.isWeekendDate(modelData.date)
 
                             Rectangle {
                                 anchors.fill: parent
@@ -649,7 +657,11 @@ Item {
                                 onPositionChanged: (mouse) => {
                                     const pt = weMove.mapToItem(gridContent, mouse.x, mouse.y);
                                     const wantX = pt.x - grabX;
-                                    const wantY = pt.y - grabY;
+                                    // grabY is weMove-local; its origin sits topMargin below the event
+                                    // top while pt/baseY are gridContent-absolute. Subtract the inset so
+                                    // a still pointer yields dy == 0 (no constant +6px bias). No left
+                                    // margin, so wantX needs no such correction.
+                                    const wantY = pt.y - grabY - weMove.anchors.topMargin;
                                     const dx = wantX - baseX;
                                     const dy = wantY - baseY;
                                     if (!didDrag && (Math.abs(dx) > 5 || Math.abs(dy) > 5)) didDrag = true;

--- a/qml/WeekView.qml
+++ b/qml/WeekView.qml
@@ -188,7 +188,7 @@ Item {
         }
         const priRank = { P0: 0, P1: 1, P2: 2, P3: 3 };
         for (let k = 0; k < days.length; k++) {
-            days[k].tasks.sort((a, b) => (priRank[a.priority] || 9) - (priRank[b.priority] || 9));
+            days[k].tasks.sort((a, b) => (priRank[a.priority] ?? 9) - (priRank[b.priority] ?? 9));
         }
         return days;
     }

--- a/tests/qml/tst_ArchiveView.qml
+++ b/tests/qml/tst_ArchiveView.qml
@@ -1,0 +1,60 @@
+// ArchiveView: regression for the priority-sort falsy-zero bug. Archived tasks
+// are ordered by priority with P0 the top tier; `priRank[p] || 9` demoted P0's
+// rank 0 to the unknown fallback, sinking the most critical archived task to the
+// bottom of the list.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "ArchiveView"
+    when: windowShown
+    visible: true
+    width: 700
+    height: 500
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    function test_smoke_load() {
+        const av = make('import TodoCpp; ArchiveView { anchors.fill: parent }');
+        verify(av !== null);
+    }
+
+    // Archive a P1 then a P0 task; buildItems must place the P0 before the P1.
+    // Compares the two seeded ids by position (robust to previously archived
+    // tasks in the persistent qttest profile).
+    function test_p0_sorts_before_p1() {
+        const p1 = AppController.newTaskDraft("todo");
+        p1.title = "arch p1 probe"; p1.priority = "P1";
+        AppController.saveTask(p1);
+
+        const p0 = AppController.newTaskDraft("todo");
+        p0.title = "arch p0 probe"; p0.priority = "P0";
+        AppController.saveTask(p0);
+
+        AppController.setArchived(p1.id, true);
+        AppController.setArchived(p0.id, true);
+
+        const av = make('import TodoCpp; ArchiveView { anchors.fill: parent }');
+        const items = av.buildItems();
+
+        let iP0 = -1, iP1 = -1;
+        for (let i = 0; i < items.length; i++) {
+            if (items[i].id === p0.id) iP0 = i;
+            if (items[i].id === p1.id) iP1 = i;
+        }
+        verify(iP0 >= 0 && iP1 >= 0, "both archived tasks must be present");
+        verify(iP0 < iP1, "P0 must sort before P1 in the archive list");
+
+        AppController.deleteTask(p0.id);
+        AppController.deleteTask(p1.id);
+    }
+}

--- a/tests/qml/tst_Brand.qml
+++ b/tests/qml/tst_Brand.qml
@@ -1,0 +1,170 @@
+// Brand (qml/Brand.qml): a pragma-Singleton token bank (no signals/functions/
+// objectName), so this pins the public design-token contract the rest of the
+// app binds to — Theme.qml maps straight onto Brand, SplashScreen/BrandLogo/
+// SettingsView read it by name. Accessed as `Brand.x` (never instantiated).
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "Brand"
+    when: windowShown
+    visible: true
+    width: 400
+    height: 400
+
+    Item { id: host; anchors.fill: parent }
+
+    // ── Identity ──────────────────────────────────────────────
+    // The wordmark + taglines callers render verbatim (SplashScreen.qml,
+    // SettingsView.qml bind Brand.tagline; the "." in "heap." is load-bearing).
+    function test_identity_strings() {
+        compare(Brand.name, "heap.");
+        compare(Brand.tagline, "Work, in one place.");
+        compare(Brand.taglineLong, "A quiet place for the work you owe.");
+        verify(Brand.name.length > 0);
+        verify(Brand.tagline.length > 0);
+        verify(Brand.taglineLong.length > 0);
+    }
+
+    // ── Typography ────────────────────────────────────────────
+    function test_font_families() {
+        compare(Brand.fontSans, "IBM Plex Sans");
+        compare(Brand.fontMono, "JetBrains Mono");
+        verify(Brand.fontSans.length > 0);
+        verify(Brand.fontMono.length > 0);
+    }
+
+    // Core palette tokens are fully opaque — Theme composites panels/text on top
+    // of these, so any accidental alpha would bleed through everywhere.
+    function test_core_palette_opaque() {
+        const opaque = [
+            Brand.bg, Brand.bg2, Brand.panel, Brand.panel2, Brand.border,
+            Brand.text, Brand.text2, Brand.text3, Brand.text4,
+            Brand.accent, Brand.accent2,
+            Brand.lightBg, Brand.lightPanel, Brand.lightBorder,
+            Brand.lightText, Brand.lightText3, Brand.lightAccent
+        ];
+        for (let i = 0; i < opaque.length; ++i)
+            fuzzyCompare(opaque[i].a, 1.0, 0.001, "palette color #" + i + " must be opaque");
+    }
+
+    // accentSoft is deliberately the accent color at a low alpha (used for
+    // tinted fills). Pin both halves: same hue as accent, ~15% opacity.
+    function test_accent_soft_is_accent_tint() {
+        fuzzyCompare(Brand.accentSoft.a, 0.15, 0.005, "accentSoft must be a ~15% tint");
+        fuzzyCompare(Brand.accentSoft.r, Brand.accent.r, 0.01, "accentSoft red must track accent");
+        fuzzyCompare(Brand.accentSoft.g, Brand.accent.g, 0.01, "accentSoft green must track accent");
+        fuzzyCompare(Brand.accentSoft.b, Brand.accent.b, 0.01, "accentSoft blue must track accent");
+        // A tint, not the solid accent: the alpha genuinely differs.
+        verify(Brand.accentSoft.a < Brand.accent.a);
+    }
+
+    // The text ramp text→text2→text3→text4 must dim monotonically on every
+    // channel (dark-theme text hierarchy — brightest primary, dimmest quaternary).
+    function test_text_ramp_dims_monotonically() {
+        const ramp = [Brand.text, Brand.text2, Brand.text3, Brand.text4];
+        for (let i = 1; i < ramp.length; ++i) {
+            verify(ramp[i].r < ramp[i - 1].r, "text ramp red must decrease at step " + i);
+            verify(ramp[i].g < ramp[i - 1].g, "text ramp green must decrease at step " + i);
+            verify(ramp[i].b < ramp[i - 1].b, "text ramp blue must decrease at step " + i);
+        }
+    }
+
+    // Type scale is strictly descending display→caption, with the exact px the
+    // components hardcode against (e.g. sizeBody 14 / sizeCaption 11).
+    function test_type_scale_descending() {
+        compare(Brand.sizeDisplay, 56);
+        compare(Brand.sizeH1, 32);
+        compare(Brand.sizeH2, 22);
+        compare(Brand.sizeBody, 14);
+        compare(Brand.sizeMono, 13);
+        compare(Brand.sizeCaption, 11);
+        const scale = [Brand.sizeDisplay, Brand.sizeH1, Brand.sizeH2,
+                       Brand.sizeBody, Brand.sizeMono, Brand.sizeCaption];
+        for (let i = 1; i < scale.length; ++i)
+            verify(scale[i] < scale[i - 1], "type scale must strictly descend at step " + i);
+    }
+
+    // Spacing scale is strictly ascending on the 4px grid Theme.pad/gap select
+    // from (spacing2 / spacing3 / spacing4).
+    function test_spacing_scale_ascending() {
+        compare(Brand.spacing1, 4);
+        compare(Brand.spacing2, 8);
+        compare(Brand.spacing3, 12);
+        compare(Brand.spacing4, 16);
+        compare(Brand.spacing5, 24);
+        compare(Brand.spacing6, 32);
+        const s = [Brand.spacing1, Brand.spacing2, Brand.spacing3,
+                   Brand.spacing4, Brand.spacing5, Brand.spacing6];
+        for (let i = 1; i < s.length; ++i)
+            verify(s[i] > s[i - 1], "spacing must strictly ascend at step " + i);
+    }
+
+    // Radius scale ascends sm→md→lg, and radiusPill is the "always fully round"
+    // sentinel (>= any plausible half-height).
+    function test_radius_scale() {
+        compare(Brand.radiusSm, 6);
+        compare(Brand.radiusMd, 8);
+        compare(Brand.radiusLg, 12);
+        compare(Brand.radiusPill, 999);
+        verify(Brand.radiusSm < Brand.radiusMd);
+        verify(Brand.radiusMd < Brand.radiusLg);
+        verify(Brand.radiusLg < Brand.radiusPill);
+    }
+
+    // Status colors are opaque and pairwise distinct — the board/kanban legend
+    // relies on todo/in-progress/review/done/warn being visually separable.
+    function test_status_colors_opaque_and_distinct() {
+        const st = [Brand.statusTodo, Brand.statusInProgress, Brand.statusReview,
+                    Brand.statusDone, Brand.statusWarn];
+        for (let i = 0; i < st.length; ++i)
+            fuzzyCompare(st[i].a, 1.0, 0.001, "status color #" + i + " must be opaque");
+        for (let i = 0; i < st.length; ++i)
+            for (let j = i + 1; j < st.length; ++j)
+                verify(!Qt.colorEqual(st[i], st[j]),
+                       "status colors " + i + " and " + j + " must differ");
+    }
+
+    // Logo/icon asset refs are declared as non-empty qrc: strings (the paths
+    // themselves are a known dead-resource issue — only the contract that these
+    // properties exist and are resource URLs is asserted here).
+    function test_asset_paths_are_declared_qrc_strings() {
+        const paths = [
+            Brand.logoMark, Brand.logoMarkLight, Brand.logoMarkMono,
+            Brand.logoLockup, Brand.logoLockupLight,
+            Brand.logoWordmark, Brand.logoWordmarkLight,
+            Brand.appIcon, Brand.favicon
+        ];
+        for (let i = 0; i < paths.length; ++i) {
+            verify(paths[i].length > 0, "asset path #" + i + " must be non-empty");
+            verify(paths[i].indexOf("qrc:") === 0, "asset path #" + i + " must be a qrc: url");
+        }
+    }
+
+    // Brand identity tokens are quieter than the product accent/text on purpose
+    // (design intent: identity sits behind the product). brandInk is dimmer than
+    // primary text; iconInk pushes one stop dimmer still for the app squircle.
+    function test_identity_tokens_are_quieter_than_product() {
+        // brandInk should be darker/quieter than the primary text.
+        verify(Brand.brandInk.r < Brand.text.r, "brandInk must be quieter than primary text");
+        // iconInk is a further stop down from brandInk for dock/taskbar contrast.
+        verify(Brand.iconInk.r < Brand.brandInk.r, "iconInk must be quieter than brandInk");
+        // The identity accent is muted relative to the product accent.
+        verify(Brand.brandAccent.g < Brand.accent.g, "brandAccent must be muted vs product accent");
+    }
+
+    // Integration (read-only): Theme maps straight onto Brand for the tokens with
+    // no high-contrast branch — bg / panel / textMuted must equal the Brand token
+    // selected by the live Theme.dark flag. Reads Theme without mutating it.
+    function test_theme_pulls_tokens_from_brand() {
+        verify(Qt.colorEqual(Theme.bg, Theme.dark ? Brand.bg : Brand.lightBg),
+               "Theme.bg must resolve to the Brand bg for the active mode");
+        verify(Qt.colorEqual(Theme.panel, Theme.dark ? Brand.panel : Brand.lightPanel),
+               "Theme.panel must resolve to the Brand panel for the active mode");
+        verify(Qt.colorEqual(Theme.textMuted, Theme.dark ? Brand.text3 : Brand.lightText3),
+               "Theme.textMuted must resolve to the Brand muted text for the active mode");
+    }
+}

--- a/tests/qml/tst_BrandLogo.qml
+++ b/tests/qml/tst_BrandLogo.qml
@@ -1,0 +1,92 @@
+// Property/theme-contract tests for qml/BrandLogo.qml (native-QML brand lockup).
+// BrandLogo has no signals, functions, or objectName — it is a pure visual
+// component, so coverage is smoke-load + variant/aspect + theme→color resolution.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "BrandLogo"
+    when: windowShown
+    visible: true
+    width: 400
+    height: 300
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // Smoke: the component instantiates against the live TodoCpp module and
+    // lands on its documented defaults (horizontal "lockup", dark theme).
+    function test_smoke_load() {
+        const bl = make('import TodoCpp; BrandLogo { }');
+        compare(bl.variant, "lockup");
+        compare(bl.theme, "dark");
+    }
+
+    // Native aspect-ratio constants mirror the original SVG geometry and drive
+    // implicitWidth. 380/100 = 3.8, 280/90 ≈ 3.11, mark is square.
+    function test_aspect_ratio_constants() {
+        const bl = make('import TodoCpp; BrandLogo { }');
+        compare(bl.lockupAspect, 3.8);
+        compare(bl.wordmarkAspect, 3.11);
+        compare(bl.markAspect, 1.0);
+    }
+
+    // implicitWidth = implicitHeight * aspect, and the variant selects which
+    // aspect. Default implicitHeight is 28 → 106.4 / 28 / 87.08.
+    function test_implicit_width_by_variant() {
+        const bl = make('import TodoCpp; BrandLogo { }');
+        compare(bl.implicitHeight, 28);
+
+        bl.variant = "lockup";
+        verify(Math.abs(bl.implicitWidth - 28 * 3.8) < 0.01,
+               "lockup implicitWidth should be height*lockupAspect");
+
+        bl.variant = "mark";
+        verify(Math.abs(bl.implicitWidth - 28 * 1.0) < 0.01,
+               "mark implicitWidth should be square (height*markAspect)");
+
+        bl.variant = "wordmark";
+        verify(Math.abs(bl.implicitWidth - 28 * 3.11) < 0.01,
+               "wordmark implicitWidth should be height*wordmarkAspect");
+    }
+
+    // Dark theme (default): quiet slate ink, white crown, near-white text.
+    function test_colors_dark_theme() {
+        const bl = make('import TodoCpp; BrandLogo { theme: "dark" }');
+        verify(Qt.colorEqual(bl._inkColor,   "#c6d0dc"), "dark ink");
+        verify(Qt.colorEqual(bl._crownColor, "#ffffff"), "dark crown");
+        verify(Qt.colorEqual(bl._textColor,  "#e8eef4"), "dark text");
+    }
+
+    // Light theme inverts: darker ink, near-black crown and text.
+    function test_colors_light_theme() {
+        const bl = make('import TodoCpp; BrandLogo { theme: "light" }');
+        verify(Qt.colorEqual(bl._inkColor,   "#404b58"), "light ink");
+        verify(Qt.colorEqual(bl._crownColor, "#0b0e13"), "light crown");
+        verify(Qt.colorEqual(bl._textColor,  "#0b0e13"), "light text");
+    }
+
+    // Mono theme collapses every part of the mark to monoColor.
+    function test_colors_mono_theme() {
+        const bl = make('import TodoCpp; BrandLogo { theme: "mono" }');
+        bl.monoColor = "#ff0000";
+        verify(Qt.colorEqual(bl._inkColor,   "#ff0000"), "mono ink follows monoColor");
+        verify(Qt.colorEqual(bl._crownColor, "#ff0000"), "mono crown follows monoColor");
+        verify(Qt.colorEqual(bl._textColor,  "#ff0000"), "mono text follows monoColor");
+    }
+
+    // monoColor defaults to the Brand singleton's text color.
+    function test_mono_color_default_is_brand_text() {
+        const bl = make('import TodoCpp; BrandLogo { }');
+        verify(Qt.colorEqual(bl.monoColor, Brand.text),
+               "monoColor should default to Brand.text");
+    }
+}

--- a/tests/qml/tst_CommandPalette.qml
+++ b/tests/qml/tst_CommandPalette.qml
@@ -1,0 +1,51 @@
+// CommandPalette: regression for the fuzzy-score proximity penalty pushing a
+// genuine match below zero. _fuzzyScore documents "match -> >= 0, no match ->
+// -1", but `score -= lastPos * 0.05` runs after the match check, so a single
+// char first occurring at index >= 41 scored -0.05 and the caller's
+// `if (score < 0) continue` dropped the entry even though the char is present.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "CommandPalette"
+    when: windowShown
+    visible: true
+    width: 500
+    height: 400
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    function test_smoke_load() {
+        const cp = make('import TodoCpp; CommandPalette { }');
+        verify(cp !== null);
+    }
+
+    // A present char must never score below 0, regardless of how late it matches.
+    function test_fuzzy_late_single_char_not_negative() {
+        const cp = make('import TodoCpp; CommandPalette { }');
+        const late = "a".repeat(41) + "z";           // only 'z' at index 41
+        verify(cp._fuzzyScore("z", late) >= 0, "a present char must score >= 0");
+        // Boundary: index 40 lands exactly on 0 (survives even unpatched).
+        compare(cp._fuzzyScore("z", "a".repeat(40) + "z"), 0.0);
+        // A genuinely absent char must still return the negative no-match sentinel.
+        verify(cp._fuzzyScore("z", "aaa") < 0, "absent char must score < 0");
+    }
+
+    // End-to-end: an entry whose only match for the query is a late single char
+    // must survive _filterAndScore, not be dropped as if it were a no-match.
+    function test_filter_keeps_late_single_char_entry() {
+        const cp = make('import TodoCpp; CommandPalette { }');
+        cp._entries = [{ kind: "task", label: "a".repeat(41) + "z", sub: "" }];
+        const out = cp._filterAndScore("z");
+        compare(out.length, 1, "an entry containing the query char must be kept");
+    }
+}

--- a/tests/qml/tst_CommandPalette.qml
+++ b/tests/qml/tst_CommandPalette.qml
@@ -48,4 +48,20 @@ TestCase {
         const out = cp._filterAndScore("z");
         compare(out.length, 1, "an entry containing the query char must be kept");
     }
+
+    // Body-hit tier: a weak label match that _fuzzyScore clamps to 0 plus a body
+    // hit (entry W) must not rank below a pure body-only hit (entry B). Both floor
+    // to the body tier, so a stable sort keeps input order (W before B).
+    // Pre-fix W stayed at 0 (the `if (score < 0)` rescue didn't fire) and sorted
+    // below B at 5. (_filterAndScore strips scores, so we assert order, not score.)
+    function test_body_hit_not_ranked_below_body_only() {
+        const cp = make('import TodoCpp; CommandPalette { }');
+        cp._entries = [
+            { kind: "task", id: "W", label: "z" + "a".repeat(80) + "z", sub: "", body: "find zz now" },
+            { kind: "task", id: "B", label: "plain label", sub: "", body: "also zz here" }
+        ];
+        const out = cp._filterAndScore("zz");
+        compare(out.length, 2, "both body-containing entries must be kept");
+        compare(out[0].id, "W", "weak-label+body must not rank below a pure body-only hit");
+    }
 }

--- a/tests/qml/tst_DatePickerPopup.qml
+++ b/tests/qml/tst_DatePickerPopup.qml
@@ -1,0 +1,125 @@
+// DatePickerPopup contract tests (smoke + public API).
+//
+// Covers the picked(date) signal contract, openAt() seeding/anchoring, the
+// month-nav _step() year wrap and the _sameDay() day comparator. The component
+// has no objectNames, so there are no click-driven tests — API level only.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "DatePickerPopup"
+    when: windowShown
+    visible: true
+    width: 400
+    height: 400
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // Smoke: the popup instantiates standalone against the live module.
+    function test_smoke_load() {
+        make('import TodoCpp; DatePickerPopup { }');
+    }
+
+    // Signal contract: picked(date value) carries the exact calendar day.
+    function test_picked_signal_contract() {
+        const dp = make('import TodoCpp; DatePickerPopup { }');
+        const target = new Date();
+        target.setDate(target.getDate() + 420);
+        target.setHours(0, 0, 0, 0);
+
+        let got = null;
+        dp.picked.connect(function(value) { got = value; });
+        dp.picked(target);
+
+        verify(got !== null, "picked did not deliver its argument");
+        compare(got.getFullYear(), target.getFullYear());
+        compare(got.getMonth(), target.getMonth());
+        compare(got.getDate(), target.getDate());
+    }
+
+    // openAt(d, anchor): seeds selected + the visible month/year from d,
+    // reparents to the anchor and opens. Closed again so the modal overlay
+    // never leaks into other tests.
+    function test_open_at_seeds_selection() {
+        const dp = make('import TodoCpp; DatePickerPopup { }');
+        const target = new Date();
+        target.setDate(target.getDate() + 421);
+        target.setHours(0, 0, 0, 0);
+
+        dp.openAt(target, host);
+        tryCompare(dp, "opened", true);
+
+        verify(dp._sameDay(dp.selected, target), "selected must match the seeded date");
+        compare(dp._month, target.getMonth());
+        compare(dp._year, target.getFullYear());
+        compare(dp.parent, host);
+
+        dp.close();
+        tryCompare(dp, "opened", false);
+    }
+
+    // openAt(null): falls back to today. Captured before/after the call so a
+    // midnight rollover between the two clock reads cannot flake the test.
+    function test_open_at_null_defaults_to_today() {
+        const dp = make('import TodoCpp; DatePickerPopup { }');
+        const before = new Date();
+        dp.openAt(null, host);
+        const after = new Date();
+
+        verify(dp._sameDay(dp.selected, before) || dp._sameDay(dp.selected, after),
+               "openAt(null) must seed today's date");
+        compare(dp._month, dp.selected.getMonth());
+        compare(dp._year, dp.selected.getFullYear());
+
+        dp.close();
+        tryCompare(dp, "opened", false);
+    }
+
+    // _step(delta): month nav wraps December → January (and back) with the
+    // year carried across the boundary.
+    function test_step_wraps_year_boundaries() {
+        const dp = make('import TodoCpp; DatePickerPopup { }');
+
+        dp._month = 11;  // December
+        dp._year = 2027;
+        dp._step(1);
+        compare(dp._month, 0);
+        compare(dp._year, 2028);
+
+        dp._step(-1);
+        compare(dp._month, 11);
+        compare(dp._year, 2027);
+
+        dp._step(1);
+        dp._step(1);     // Jan → Feb, no wrap
+        compare(dp._month, 1);
+        compare(dp._year, 2028);
+    }
+
+    // _sameDay(a, b): calendar-day equality — ignores time-of-day, rejects
+    // different days and null/undefined operands.
+    function test_same_day_comparison() {
+        const dp = make('import TodoCpp; DatePickerPopup { }');
+        const day = new Date();
+        day.setDate(day.getDate() + 422);
+        day.setHours(9, 15, 0, 0);
+        const sameDayLater = new Date(day);
+        sameDayLater.setHours(23, 45, 0, 0);
+        const nextDay = new Date(day);
+        nextDay.setDate(nextDay.getDate() + 1);
+
+        verify(dp._sameDay(day, sameDayLater), "same day, different times → true");
+        verify(!dp._sameDay(day, nextDay), "different days → false");
+        verify(!dp._sameDay(null, day), "null lhs → falsy");
+        verify(!dp._sameDay(day, null), "null rhs → falsy");
+    }
+}

--- a/tests/qml/tst_DocsEditor.qml
+++ b/tests/qml/tst_DocsEditor.qml
@@ -1,0 +1,142 @@
+// DocsEditor (qml/DocsEditor.qml): smoke-load of the Popup against the live
+// TodoCpp module, its default property surface, the kind→width binding, and the
+// full saved*/deleted* signal contract that DocsView (qml/DocsView.qml:1051)
+// wires its saveDoc/saveSnippet/saveContact/saveSection handlers onto.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "DocsEditor"
+    when: windowShown
+    visible: true
+    width: 500
+    height: 500
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // Smoke: the Popup instantiates (Theme / PillButton / FieldLabel / FormField
+    // / CodeHighlighter all resolve). A removed property or renamed type here
+    // returns null.
+    function test_smoke_load() {
+        const de = make('import TodoCpp; DocsEditor { }');
+        verify(de !== null);
+    }
+
+    // Public property defaults: the editor opens as a "doc" form, not-new,
+    // modal, with empty ids/collections and an object draft.
+    function test_default_properties() {
+        const de = make('import TodoCpp; DocsEditor { }');
+        compare(de.kind, "doc");
+        compare(de.isNew, false);
+        compare(de.sectionId, "");
+        compare(de.originalRef, "");
+        compare(de.idx, -1);
+        compare(de.sections.length, 0);
+        compare(de.contactPalette.length, 0);
+        compare(de.accentPalette.length, 0);
+        compare(de.docCustomFields.length, 0);
+        compare(typeof de.draft, "object");
+        compare(de.modal, true);
+    }
+
+    // width is bound to kind: the wide 700 layout is snippet-only; every other
+    // kind is the 500 form. Exercises the ternary both ways as a live binding.
+    function test_width_tracks_kind() {
+        const de = make('import TodoCpp; DocsEditor { }');
+        compare(de.width, 500);          // default kind === "doc"
+        de.kind = "snippet";
+        compare(de.width, 700);
+        de.kind = "contact";
+        compare(de.width, 500);
+        de.kind = "section";
+        compare(de.width, 500);
+        de.kind = "doc";
+        compare(de.width, 500);
+    }
+
+    // savedDoc carries the draft object (DocsView: onSavedDoc: (draft) => saveDoc(draft)).
+    function test_signal_saved_doc() {
+        const de = make('import TodoCpp; DocsEditor { }');
+        let got = null;
+        de.savedDoc.connect(function(d) { got = d; });
+        de.savedDoc({ ref: "TS 36.331", title: "RRC" });
+        verify(got !== null, "savedDoc must deliver its draft argument");
+        compare(got.title, "RRC");
+        compare(got.ref, "TS 36.331");
+    }
+
+    // deletedDoc is a bare notification (DocsView: () => deleteDoc(sectionId, originalRef)).
+    function test_signal_deleted_doc() {
+        const de = make('import TodoCpp; DocsEditor { }');
+        let n = 0;
+        de.deletedDoc.connect(function() { n++; });
+        de.deletedDoc();
+        compare(n, 1);
+    }
+
+    // savedSnippet carries the draft (DocsView pairs it with editor.idx).
+    function test_signal_saved_snippet() {
+        const de = make('import TodoCpp; DocsEditor { }');
+        let got = null;
+        de.savedSnippet.connect(function(d) { got = d; });
+        de.savedSnippet({ title: "build", lang: "sh", code: "make" });
+        verify(got !== null, "savedSnippet must deliver its draft argument");
+        compare(got.title, "build");
+        compare(got.lang, "sh");
+    }
+
+    function test_signal_deleted_snippet() {
+        const de = make('import TodoCpp; DocsEditor { }');
+        let n = 0;
+        de.deletedSnippet.connect(function() { n++; });
+        de.deletedSnippet();
+        compare(n, 1);
+    }
+
+    // savedContact carries the draft (DocsView: onSavedContact: (draft) => saveContact(draft, idx)).
+    function test_signal_saved_contact() {
+        const de = make('import TodoCpp; DocsEditor { }');
+        let got = null;
+        de.savedContact.connect(function(d) { got = d; });
+        de.savedContact({ name: "Ada", role: "PHY" });
+        verify(got !== null, "savedContact must deliver its draft argument");
+        compare(got.name, "Ada");
+        compare(got.role, "PHY");
+    }
+
+    function test_signal_deleted_contact() {
+        const de = make('import TodoCpp; DocsEditor { }');
+        let n = 0;
+        de.deletedContact.connect(function() { n++; });
+        de.deletedContact();
+        compare(n, 1);
+    }
+
+    // savedSection carries the draft (DocsView: onSavedSection: (draft) => saveSection(draft, sectionId)).
+    function test_signal_saved_section() {
+        const de = make('import TodoCpp; DocsEditor { }');
+        let got = null;
+        de.savedSection.connect(function(d) { got = d; });
+        de.savedSection({ title: "3GPP", accent: "#3ba1ff" });
+        verify(got !== null, "savedSection must deliver its draft argument");
+        compare(got.title, "3GPP");
+        compare(got.accent, "#3ba1ff");
+    }
+
+    function test_signal_deleted_section() {
+        const de = make('import TodoCpp; DocsEditor { }');
+        let n = 0;
+        de.deletedSection.connect(function() { n++; });
+        de.deletedSection();
+        compare(n, 1);
+    }
+}

--- a/tests/qml/tst_EventEditor.qml
+++ b/tests/qml/tst_EventEditor.qml
@@ -1,0 +1,132 @@
+// EventEditor coverage: smoke-load of the modal popup against a live
+// AppController, the callable function contract (parseHour / parseHourRange /
+// _formatHour / _maybeExpandRange), and showForId() pulling a saved event's
+// data back out of the events model. EventEditor declares no signals and no
+// objectNames, so there is no click-driven layer here.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "EventEditor"
+    when: windowShown
+    visible: true
+    width: 500
+    height: 500
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // The popup instantiates against the live singletons; defaults hold and
+    // pickedDate starts out bound to AppController.selectedDate.
+    function test_smoke_load() {
+        const ed = make('import TodoCpp; EventEditor { }');
+        compare(ed.eventId, "");
+        verify(!ed.visible, "editor popup must start closed");
+        compare(Qt.formatDate(ed.pickedDate, "yyyy-MM-dd"),
+                Qt.formatDate(AppController.selectedDate, "yyyy-MM-dd"));
+    }
+
+    // _formatHour is the inverse of the fractional-hour model encoding.
+    function test_format_hour() {
+        const ed = make('import TodoCpp; EventEditor { }');
+        compare(ed._formatHour(9.5), "09:30");
+        compare(ed._formatHour(14), "14:00");
+        compare(ed._formatHour(0), "00:00");
+        compare(ed._formatHour(9.75), "09:45");
+    }
+
+    // parseHour: "HH:MM" resolves to a fractional hour via the chrono parser,
+    // and the plain split(":") fallback gives the same answer, so the compare
+    // holds on either path. Empty / garbage input degrades to 0.
+    function test_parse_hour() {
+        const ed = make('import TodoCpp; EventEditor { }');
+        compare(ed.parseHour("14:30"), 14.5);
+        compare(ed.parseHour("9:00"), 9);
+        compare(ed.parseHour(""), 0);
+        compare(ed.parseHour("garbage"), 0);
+    }
+
+    // parseHourRange: a numeric time range expands to [start, end]; a single
+    // time or empty input yields null (the invalid-end guard). Numeric range
+    // forms are locale-independent in the chrono parser (see
+    // tests/test_chrono_parser.cpp Range* cases).
+    function test_parse_hour_range() {
+        const ed = make('import TodoCpp; EventEditor { }');
+        const r = ed.parseHourRange("14:00-15:00");
+        verify(r !== null, "numeric range must parse");
+        compare(r[0], 14);
+        compare(r[1], 15);
+        verify(ed.parseHourRange("") === null, "empty input is not a range");
+        verify(ed.parseHourRange("14:00") === null, "single time is not a range");
+    }
+
+    // _maybeExpandRange: typing a range into the start field splits it across
+    // start/end; a plain single time leaves both fields untouched.
+    function test_maybe_expand_range() {
+        const ed = make('import TodoCpp; EventEditor { }');
+        const f = createTemporaryQmlObject(
+            'import QtQuick; QtObject { property string text: "14:00-15:00" }', host);
+        const o = createTemporaryQmlObject(
+            'import QtQuick; QtObject { property string text: "" }', host);
+        verify(f !== null && o !== null);
+
+        ed._maybeExpandRange(f, o);
+        compare(f.text, "14:00");
+        compare(o.text, "15:00");
+
+        f.text = "10:30";
+        o.text = "keep";
+        ed._maybeExpandRange(f, o);
+        compare(f.text, "10:30", "single time must not be rewritten");
+        compare(o.text, "keep", "other field must not be clobbered");
+    }
+
+    // showForId: a saved event round-trips through the events model back into
+    // the editor — eventId and pickedDate reflect the stored row and the popup
+    // opens. The shared test profile persists between runs, so the probe day
+    // is emptied of leftover events first and the event is deleted afterwards.
+    function test_show_for_id_populates_from_model() {
+        const day = new Date();
+        day.setDate(day.getDate() + 410);
+        day.setHours(0, 0, 0, 0);
+
+        const evs = AppController.events;
+        for (let i = evs.rowCount() - 1; i >= 0; i--) {
+            const idx = evs.index(i, 0);
+            const d = evs.data(idx, Qt.UserRole + 7);   // DateRole
+            if (d && d.getFullYear
+                && d.getFullYear() === day.getFullYear()
+                && d.getMonth() === day.getMonth()
+                && d.getDate() === day.getDate())
+                AppController.deleteEvent(String(evs.data(idx, Qt.UserRole + 1)));
+        }
+
+        const ev = AppController.newEventDraft(10, day);
+        ev.title = "event-editor probe";
+        ev.type = "oneone";
+        ev.end = 11;
+        ev.attendees = "@qa";
+        ev.date = day;
+        ev.context = "editor-probe-ctx";
+        AppController.saveEvent(ev);
+
+        const ed = make('import TodoCpp; EventEditor { }');
+        ed.showForId(ev.id);
+
+        verify(ed.visible, "showForId must open the popup");
+        compare(ed.eventId, ev.id);
+        compare(Qt.formatDate(ed.pickedDate, "yyyy-MM-dd"),
+                Qt.formatDate(day, "yyyy-MM-dd"));
+
+        ed.close();
+        AppController.deleteEvent(ev.id);   // leave the shared profile clean
+    }
+}

--- a/tests/qml/tst_HelpContent.qml
+++ b/tests/qml/tst_HelpContent.qml
@@ -1,0 +1,88 @@
+// Contract + smoke tests for qml/HelpContent.qml (the Settings -> Help page).
+// HelpContent is a stateless presentational Item: a TOC whose rows emit
+// anchorRequested(objectName), and one objectName'd HelpCard section per anchor.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "HelpContent"
+    when: windowShown
+    visible: true
+    width: 500
+    height: 500
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // Smoke: the whole tree instantiates — the inline HelpCard/H2/H3/Body/Hint/Kbd
+    // components, the PillButton, and every Theme/I18n/AppController singleton
+    // binding resolve. A removed property or renamed type returns null here.
+    function test_smoke_load() {
+        const hc = make('import TodoCpp; HelpContent {}');
+        verify(hc !== null);
+    }
+
+    // Signal contract: anchorRequested carries the anchor objectName as a string,
+    // which is exactly what SettingsView (onAnchorRequested -> _scrollToAnchor(name))
+    // consumes. Emitted directly since the TOC rows expose no objectName to click.
+    function test_anchor_requested_signal_carries_objectname() {
+        const hc = make('import TodoCpp; HelpContent {}');
+        let got = null;
+        let count = 0;
+        hc.anchorRequested.connect(function(name) { got = name; count++; });
+        hc.anchorRequested("help-tweaks");
+        compare(count, 1);
+        compare(got, "help-tweaks");
+    }
+
+    // tocModel shape: a fixed list of {anchor, label} non-empty string pairs.
+    function test_toc_model_shape() {
+        const hc = make('import TodoCpp; HelpContent {}');
+        const toc = hc.tocModel;
+        verify(toc !== undefined && toc !== null, "tocModel missing");
+        compare(toc.length, 15);
+        for (let i = 0; i < toc.length; ++i) {
+            verify(typeof toc[i].anchor === "string" && toc[i].anchor.length > 0,
+                   "toc[" + i + "].anchor must be a non-empty string");
+            verify(typeof toc[i].label === "string" && toc[i].label.length > 0,
+                   "toc[" + i + "].label must be a non-empty string");
+        }
+    }
+
+    // TOC anchors must be unique: a duplicate would make two rows scroll to the
+    // same place (and duplicate objectNames make _findChildByName ambiguous).
+    function test_toc_anchors_unique() {
+        const hc = make('import TodoCpp; HelpContent {}');
+        const toc = hc.tocModel;
+        const seen = ({});
+        for (let i = 0; i < toc.length; ++i) {
+            const a = toc[i].anchor;
+            verify(seen[a] === undefined, "duplicate TOC anchor: " + a);
+            seen[a] = true;
+        }
+    }
+
+    // The load-bearing cross-component contract: every TOC anchor must resolve to
+    // a HelpCard whose objectName equals it. SettingsView._scrollToAnchor does
+    // _findChildByName(bodyCol, anchor) and *silently no-ops* on a miss
+    // (SettingsView.qml:611-612), so a missing section is an invisible dead link.
+    // findChild here mirrors that recursive objectName search exactly.
+    function test_every_toc_anchor_resolves_to_a_section() {
+        const hc = make('import TodoCpp; HelpContent {}');
+        const toc = hc.tocModel;
+        for (let i = 0; i < toc.length; ++i) {
+            const anchor = toc[i].anchor;
+            const section = findChild(hc, anchor);
+            verify(section !== null,
+                   "TOC anchor '" + anchor + "' has no HelpCard with a matching objectName");
+        }
+    }
+}

--- a/tests/qml/tst_HotkeysPanel.qml
+++ b/tests/qml/tst_HotkeysPanel.qml
@@ -1,0 +1,86 @@
+// Tests for qml/HotkeysPanel.qml — the rebindable-hotkey catalog Popup.
+// Load-smoke + _labelFor() function contract + isCapturing/_activeCaptures
+// property contract + onClosed reset behaviour. The panel declares no custom
+// signals and no objectName, so there is no signal- or click-layer to cover.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "HotkeysPanel"
+    when: windowShown
+    visible: true
+    width: 500
+    height: 500
+
+    Item { id: host; anchors.fill: parent }
+
+    function make() {
+        const o = createTemporaryQmlObject('import TodoCpp; HotkeysPanel { }', host);
+        verify(o !== null, "HotkeysPanel failed to instantiate");
+        return o;
+    }
+
+    // smoke: the Popup (with its inline BindingRow/KeyCaptureChip components and
+    // the AppController.shortcuts-bound ListView) resolves and instantiates.
+    function test_smoke_load() {
+        const panel = make();
+        verify(panel !== null);
+    }
+
+    // _labelFor() guards a falsy id and returns "" without touching the
+    // controller (source: `if (!actionId) return "";`).
+    function test_label_for_empty_returns_empty() {
+        const panel = make();
+        compare(panel._labelFor(""), "");
+    }
+
+    // _labelFor(id) forwards to AppController.shortcutLabel(id) for a real
+    // catalog entry; both must agree and be non-empty.
+    function test_label_for_known_matches_controller() {
+        const panel = make();
+        const expected = AppController.shortcutLabel("palette.open");
+        verify(expected.length > 0, "seeded catalog must label palette.open");
+        compare(panel._labelFor("palette.open"), expected);
+    }
+
+    // An id absent from the catalog yields "" (shortcutLabel returns "" for a
+    // missing index, and _labelFor passes it straight through).
+    function test_label_for_unknown_returns_empty() {
+        const panel = make();
+        compare(panel._labelFor("__no_such_action__"), "");
+    }
+
+    // isCapturing is the derived predicate _activeCaptures > 0. Drive the
+    // backing counter (a plain instance property on a throwaway object → no
+    // global state) and check the readonly predicate tracks it.
+    function test_is_capturing_tracks_active_captures() {
+        const panel = make();
+        compare(panel._activeCaptures, 0, "fresh panel starts with no captures");
+        verify(!panel.isCapturing);
+
+        panel._activeCaptures = 2;
+        verify(panel.isCapturing, "isCapturing must be true while captures are active");
+
+        panel._activeCaptures = 0;
+        verify(!panel.isCapturing);
+    }
+
+    // Closing the panel resets the capture counter (source: onClosed:
+    // _activeCaptures = 0) so a chip left mid-capture cannot leave global
+    // Shortcuts disabled after the panel goes away.
+    function test_closed_resets_active_captures() {
+        const panel = make();
+        panel.parent = host;              // give the Popup a window to open into
+        panel.open();
+        tryVerify(function() { return panel.visible; }, 2000, "panel did not open");
+
+        panel._activeCaptures = 3;
+        panel.close();
+        // onClosed fires when the close settles; wait for the counter to reset.
+        tryCompare(panel, "_activeCaptures", 0);
+        verify(!panel.isCapturing);
+    }
+}

--- a/tests/qml/tst_MentionAutocomplete.qml
+++ b/tests/qml/tst_MentionAutocomplete.qml
@@ -1,0 +1,316 @@
+// MentionAutocomplete (qml/MentionAutocomplete.qml) contract tests.
+//
+// Drives the trigger-range parser, the people/ticket suggestion filters and
+// the in-place accept() against a live AppController (people + tasks). The
+// component has no objectNames and its delegate declares `required property`,
+// so there are no click-driven tests — API level only.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "MentionAutocomplete"
+    when: windowShown
+    visible: true
+    width: 500
+    height: 500
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    function makeAc() {
+        return make('import TodoCpp; MentionAutocomplete { }');
+    }
+
+    function makeField() {
+        return make('import QtQuick.Controls; TextField { width: 220 }');
+    }
+
+    function findById(list, id) {
+        for (let i = 0; i < list.length; ++i)
+            if (list[i].id === id) return list[i];
+        return null;
+    }
+
+    // ── smoke + defaults ──────────────────────────────────────────────
+
+    function test_smoke_load() {
+        const ac = makeAc();
+        verify(ac !== null, "MentionAutocomplete failed to instantiate");
+        compare(ac.maxRows, 8);
+        compare(ac.enablePeople, true);
+        compare(ac.enableTickets, true);
+        compare(ac._suggestions.length, 0);
+        compare(ac._trigger, "");
+        compare(ac.isOpen, false);   // no suggestions → closed
+    }
+
+    // ── _currentTriggerRange(): the caret-walk parser ────────────────
+
+    // "@" mid-text after a space → people trigger, correct span + prefix.
+    function test_trigger_range_person_midtext() {
+        const ac = makeAc();
+        const f = makeField();
+        f.text = "hi @jo";       // @ at index 3, prefix "jo"
+        f.cursorPosition = 6;
+        ac.target = f;
+
+        const r = ac._currentTriggerRange();
+        verify(r !== null, "@jo must be recognised as a trigger");
+        compare(r.trigger, "@");
+        compare(r.start, 3);     // index of the '@'
+        compare(r.end, 6);       // caret
+        compare(r.prefix, "jo");
+    }
+
+    // Trigger at the very start of the document (no lead char to inspect).
+    function test_trigger_range_at_start_of_text() {
+        const ac = makeAc();
+        const f = makeField();
+        f.text = "@bo";
+        f.cursorPosition = 3;
+        ac.target = f;
+
+        const r = ac._currentTriggerRange();
+        verify(r !== null, "@bo at start must be recognised");
+        compare(r.trigger, "@");
+        compare(r.start, 0);
+        compare(r.end, 3);
+        compare(r.prefix, "bo");
+    }
+
+    // "#" ticket trigger after whitespace.
+    function test_trigger_range_ticket() {
+        const ac = makeAc();
+        const f = makeField();
+        f.text = "see #he";      // # at index 4, prefix "he"
+        f.cursorPosition = 7;
+        ac.target = f;
+
+        const r = ac._currentTriggerRange();
+        verify(r !== null, "#he must be recognised as a ticket trigger");
+        compare(r.trigger, "#");
+        compare(r.start, 4);
+        compare(r.end, 7);
+        compare(r.prefix, "he");
+    }
+
+    // A '@' glued to a preceding handle char (an e-mail) must NOT trigger —
+    // the lead char before '@' is 'a', not whitespace/punctuation.
+    function test_trigger_range_rejects_email_lead() {
+        const ac = makeAc();
+        const f = makeField();
+        f.text = "mail a@b";     // '@' at 6, lead char 'a' at 5
+        f.cursorPosition = 8;
+        ac.target = f;
+
+        verify(ac._currentTriggerRange() === null,
+               "a@b (e-mail) must not open the mention dropdown");
+    }
+
+    // enablePeople / enableTickets gate the corresponding trigger to null.
+    function test_trigger_range_respects_enable_flags() {
+        const ac = makeAc();
+        const f = makeField();
+        ac.target = f;
+
+        ac.enablePeople = false;
+        f.text = "@jo";
+        f.cursorPosition = 3;
+        verify(ac._currentTriggerRange() === null,
+               "@ trigger must be suppressed when enablePeople is false");
+
+        ac.enablePeople = true;
+        ac.enableTickets = false;
+        f.text = "#he";
+        f.cursorPosition = 3;
+        verify(ac._currentTriggerRange() === null,
+               "# trigger must be suppressed when enableTickets is false");
+    }
+
+    // No trigger char / no target → null range and refresh() clears cleanly.
+    function test_trigger_range_and_refresh_null_cases() {
+        const ac = makeAc();
+
+        // No target at all.
+        verify(ac._currentTriggerRange() === null, "null target → null range");
+        ac.refresh();
+        compare(ac._suggestions.length, 0, "refresh with no target clears suggestions");
+
+        // Target with plain text, no @/# before the caret.
+        const f = makeField();
+        f.text = "plain text";
+        f.cursorPosition = 5;
+        ac.target = f;
+        verify(ac._currentTriggerRange() === null, "plain text → null range");
+        ac.refresh();
+        compare(ac._suggestions.length, 0, "refresh with no trigger clears suggestions");
+    }
+
+    // ── _peopleSuggestions() / _ticketSuggestions(): filter + role mapping ──
+
+    // A person is matched by id-prefix and name-substring, and the returned
+    // {id,name} reads the right roles (id=UserRole+1, name=UserRole+2). A
+    // role swap would surface here.
+    function test_people_suggestions_match_and_roles() {
+        const pid = "acatokp.one";
+        const pname = "AcatokpNamedPerson";
+        AppController.deletePerson(pid);   // clear any leftover from a prior run
+        AppController.savePerson({ _isNew: true, id: pid, name: pname, state: "todo" });
+
+        const ac = makeAc();
+
+        // id-prefix match (query is pre-lowercased by the contract).
+        let out = ac._peopleSuggestions("acatokp");
+        let hit = findById(out, pid);
+        verify(hit !== null, "person not found by id-prefix query");
+        compare(hit.name, pname, "name role (UserRole+2) mismapped");
+
+        // name-substring match on a token unique to the name.
+        out = ac._peopleSuggestions("named");
+        verify(findById(out, pid) !== null, "person not found by name-substring query");
+
+        // A non-matching query excludes the person.
+        out = ac._peopleSuggestions("zzznomatchzzz");
+        verify(findById(out, pid) === null, "non-matching query must not return the person");
+
+        AppController.deletePerson(pid);
+    }
+
+    // A ticket is matched by title-substring, and the entry's `name` field
+    // carries the TITLE (tasks role UserRole+2 = TitleRole).
+    function test_ticket_suggestions_match_and_roles() {
+        const draft = AppController.newTaskDraft("todo");
+        draft.title = "EtprobeUniqueTicket";
+        AppController.saveTask(draft);
+        const tid = draft.id;
+        verify(tid && tid.length > 0, "saved task must expose an id");
+
+        const ac = makeAc();
+
+        let out = ac._ticketSuggestions("etprobe");
+        let hit = findById(out, tid);
+        verify(hit !== null, "ticket not found by title-substring query");
+        compare(hit.name, "EtprobeUniqueTicket", "ticket entry.name must carry the title");
+
+        out = ac._ticketSuggestions("zzznomatchzzz");
+        verify(findById(out, tid) === null, "non-matching query must not return the ticket");
+
+        AppController.deleteTask(tid);
+    }
+
+    // ── refresh(): wires the parser to the suggestion source ─────────
+
+    // Typing "@<prefix>" against a real person populates _suggestions, sets
+    // the live trigger and resets the selection to the top. Reads plain
+    // properties only, so it does not depend on the popup actually opening.
+    function test_refresh_populates_people_trigger() {
+        const pid = "brefreshp.one";
+        AppController.deletePerson(pid);
+        AppController.savePerson({ _isNew: true, id: pid, name: "BrefreshpPerson", state: "todo" });
+
+        const ac = makeAc();
+        const f = makeField();
+        f.text = "@brefreshp";
+        f.cursorPosition = f.text.length;
+        ac.target = f;
+
+        ac.refresh();
+        compare(ac._trigger, "@", "refresh must record the active trigger");
+        compare(ac._selectedIdx, 0, "refresh must reset the selection to the top");
+        verify(ac._suggestions.length >= 1, "refresh must populate suggestions");
+        verify(findById(ac._suggestions, pid) !== null, "the typed person must be suggested");
+
+        ac.dismiss();
+        AppController.deletePerson(pid);
+    }
+
+    // ── open-state behaviours (moveSelection / accept require isOpen) ──
+
+    // moveSelection clamps _selectedIdx to [0, len-1] while the dropdown is
+    // open. Two matching people guarantee at least two rows to move between.
+    function test_move_selection_clamps_when_open() {
+        const a = "cmovep.aaa", b = "cmovep.bbb";
+        AppController.deletePerson(a);
+        AppController.deletePerson(b);
+        AppController.savePerson({ _isNew: true, id: a, name: "CmovepAaa", state: "todo" });
+        AppController.savePerson({ _isNew: true, id: b, name: "CmovepBbb", state: "todo" });
+
+        const ac = makeAc();
+        const f = makeField();
+        f.text = "@cmovep";
+        f.cursorPosition = f.text.length;
+        ac.target = f;
+        ac.refresh();
+
+        // The visible binding follows _suggestions; the popup opens in the
+        // shown test window (proven by the DatePickerPopup/PersonEditor suites).
+        tryVerify(function() { return ac.isOpen; }, 3000, "dropdown did not open");
+        const n = ac._suggestions.length;
+        verify(n >= 2, "expected at least two matching people");
+
+        ac.moveSelection(+1);
+        compare(ac._selectedIdx, 1, "down must advance the selection");
+        ac.moveSelection(+50);
+        compare(ac._selectedIdx, n - 1, "down must clamp at the last row");
+        ac.moveSelection(-50);
+        compare(ac._selectedIdx, 0, "up must clamp at the first row");
+
+        ac.dismiss();
+        AppController.deletePerson(a);
+        AppController.deletePerson(b);
+    }
+
+    // accept() rewrites the trigger span in place with the canonical "@<id> "
+    // and lands the caret after the insert (HEAP-65: edit via remove()+insert(),
+    // never a whole-text reassignment).
+    function test_accept_inserts_canonical_id_in_place() {
+        const pid = "daccept.person";
+        AppController.deletePerson(pid);
+        AppController.savePerson({ _isNew: true, id: pid, name: "DacceptPerson", state: "todo" });
+
+        const ac = makeAc();
+        const f = makeField();
+        f.text = "hi @daccept end";   // '@' at 3, prefix "daccept" ends at 11
+        f.cursorPosition = 11;
+        ac.target = f;
+        ac.refresh();
+
+        tryVerify(function() { return ac.isOpen; }, 3000, "dropdown did not open");
+        verify(findById(ac._suggestions, pid) !== null, "the typed person must be the sole match");
+        compare(ac._selectedIdx, 0);
+
+        const ok = ac.accept();
+        verify(ok, "accept must report success when a suggestion is committed");
+        compare(f.text, "hi @daccept.person  end",
+                "accept must splice the canonical id in place, keeping the tail");
+        compare(f.cursorPosition, 19,
+                "caret must land after the inserted mention, not at 0");
+        compare(ac._suggestions.length, 0, "accept must clear the live suggestion list");
+        compare(ac._trigger, "", "accept must clear the live trigger");
+
+        AppController.deletePerson(pid);
+    }
+
+    // When closed, accept() is a no-op returning false, moveSelection does not
+    // touch the selection, and dismiss() resets the transient state.
+    function test_accept_and_move_noop_when_closed() {
+        const ac = makeAc();
+        compare(ac.isOpen, false);
+
+        compare(ac.accept(), false, "accept must return false while closed");
+        ac.moveSelection(+1);
+        compare(ac._selectedIdx, 0, "moveSelection must be inert while closed");
+
+        ac.dismiss();
+        compare(ac._suggestions.length, 0);
+        compare(ac._trigger, "");
+    }
+}

--- a/tests/qml/tst_MiniWeek.qml
+++ b/tests/qml/tst_MiniWeek.qml
@@ -1,0 +1,170 @@
+// MiniWeek (sidebar week strip): load-smoke against the live AppController plus
+// the date math its rendering rests on — isoFor/isSameDay/startOfWeek/dayList —
+// and the event-dot wiring (eventCountFor + the _eventsRev bump on model change).
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "MiniWeek"
+    when: windowShown
+    visible: true
+    width: 400
+    height: 400
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // The QML-test profile persists between runs and is shared by all tst_
+    // files, so every method wipes the probe day it uses before and after.
+    function _wipeEventsOn(day) {
+        const evs = AppController.events;
+        for (let i = evs.rowCount() - 1; i >= 0; i--) {
+            const idx = evs.index(i, 0);
+            const d = evs.data(idx, Qt.UserRole + 7);   // EventModel::DateRole
+            if (d && d.getFullYear
+                && d.getFullYear() === day.getFullYear()
+                && d.getMonth() === day.getMonth()
+                && d.getDate() === day.getDate())
+                AppController.deleteEvent(String(evs.data(idx, Qt.UserRole + 1)));  // IdRole
+        }
+    }
+
+    // Smoke: instantiates against the live singletons; a renamed property or a
+    // missing type would make createTemporaryQmlObject return null.
+    function test_smoke_load() {
+        const mw = make('import TodoCpp; MiniWeek { width: 320 }');
+        compare(mw._days.length, 7, "the strip always renders a full week");
+        compare(mw.dowLabelsByJsDow.length, 7, "one label per JS day-of-week");
+    }
+
+    // isoFor: yyyy-MM-dd with zero padding. Qt.formatDate is the independent
+    // reference implementation, so this is not circular.
+    function test_isofor_formats_iso_date() {
+        const mw = make('import TodoCpp; MiniWeek { width: 320 }');
+        const d = new Date();
+        d.setDate(d.getDate() + 465);
+        d.setHours(0, 0, 0, 0);
+        compare(mw.isoFor(d), Qt.formatDate(d, "yyyy-MM-dd"));
+    }
+
+    // isSameDay: date-only comparison — time of day must not matter, and
+    // null/undefined must be rejected instead of throwing.
+    function test_is_same_day() {
+        const mw = make('import TodoCpp; MiniWeek { width: 320 }');
+        const a = new Date();
+        a.setDate(a.getDate() + 463);
+        a.setHours(9, 15, 0, 0);
+        const b = new Date(a);
+        b.setHours(23, 59, 0, 0);
+        verify(mw.isSameDay(a, b), "same calendar day, different clock time");
+        const c = new Date(a);
+        c.setDate(c.getDate() + 1);
+        verify(!mw.isSameDay(a, c), "next day must not match");
+        verify(!mw.isSameDay(null, a), "null lhs is not a match");
+        verify(!mw.isSameDay(a, undefined), "undefined rhs is not a match");
+    }
+
+    // startOfWeek: lands on the configured first day of week (Theme.weekStart
+    // is read-only, so the contract is checked against its current value),
+    // never overshoots the input, and is idempotent.
+    function test_start_of_week_contract() {
+        const mw = make('import TodoCpp; MiniWeek { width: 320 }');
+        const d = new Date();
+        d.setDate(d.getDate() + 467);
+        d.setHours(0, 0, 0, 0);
+        const s = mw.startOfWeek(d);
+        const expectedDow = Theme.weekStart === "sun" ? 0 : 1;
+        compare(s.getDay(), expectedDow, "week starts on the configured day");
+        const diffDays = Math.round((d.getTime() - s.getTime()) / 86400000);
+        verify(diffDays >= 0 && diffDays < 7, "start of week is 0..6 days before the input");
+        verify(mw.isSameDay(mw.startOfWeek(s), s), "startOfWeek is idempotent");
+    }
+
+    // refDate binds to AppController.selectedDate and _days re-evaluates from
+    // it: 7 consecutive days from startOfWeek, containing the selected day.
+    function test_daylist_follows_selected_date() {
+        const prev = AppController.selectedDate;
+        const day = new Date();
+        day.setDate(day.getDate() + 460);
+        day.setHours(0, 0, 0, 0);
+        AppController.selectedDate = day;
+
+        const mw = make('import TodoCpp; MiniWeek { width: 320 }');
+        verify(mw.isSameDay(mw.refDate, day), "refDate follows AppController.selectedDate");
+        compare(mw._days.length, 7);
+        verify(mw.isSameDay(mw._days[0], mw.startOfWeek(day)), "strip begins at startOfWeek(refDate)");
+        for (let i = 1; i < 7; i++) {
+            const p = mw._days[i - 1];
+            const next = new Date(p.getFullYear(), p.getMonth(), p.getDate() + 1);
+            verify(mw.isSameDay(mw._days[i], next), "days are consecutive at index " + i);
+        }
+        let hit = false;
+        for (let i = 0; i < 7; i++) if (mw.isSameDay(mw._days[i], day)) hit = true;
+        verify(hit, "selected day is inside the rendered week");
+
+        // Live re-evaluation: moving the selection a week ahead shifts the strip.
+        const day2 = new Date(day.getFullYear(), day.getMonth(), day.getDate() + 7);
+        AppController.selectedDate = day2;
+        verify(mw.isSameDay(mw.refDate, day2), "refDate tracks a later selection");
+        verify(mw.isSameDay(mw._days[0], mw.startOfWeek(day2)), "_days re-evaluates with the selection");
+
+        AppController.selectedDate = prev;  // restore global state for other tests
+    }
+
+    // eventCountFor scans the live events model by DateRole — the count feeds
+    // the per-day dot indicator.
+    function test_event_count_for() {
+        const mw = make('import TodoCpp; MiniWeek { width: 320 }');
+        const day = new Date();
+        day.setDate(day.getDate() + 461);
+        day.setHours(0, 0, 0, 0);
+
+        _wipeEventsOn(day);
+        compare(mw.eventCountFor(day), 0, "probe day starts empty");
+
+        const ev = AppController.newEventDraft(AppController.workdayStart, day);
+        ev.title = "miniweek count probe";
+        ev.date = day;
+        AppController.saveEvent(ev);
+        compare(mw.eventCountFor(day), 1);
+
+        const ev2 = AppController.newEventDraft(AppController.workdayStart + 2, day);
+        ev2.title = "miniweek count probe 2";
+        ev2.date = day;
+        AppController.saveEvent(ev2);
+        compare(mw.eventCountFor(day), 2);
+
+        _wipeEventsOn(day);
+        compare(mw.eventCountFor(day), 0, "probe day left clean");
+    }
+
+    // The Connections block bumps _eventsRev on rowsInserted/rowsRemoved —
+    // that revision is what forces the dot indicators to re-query the model.
+    // EventModel::upsert/removeById emit synchronously, so no waits needed.
+    function test_events_rev_bumps_on_model_change() {
+        const mw = make('import TodoCpp; MiniWeek { width: 320 }');
+        const day = new Date();
+        day.setDate(day.getDate() + 462);
+        day.setHours(0, 0, 0, 0);
+        _wipeEventsOn(day);
+
+        const rev0 = mw._eventsRev;
+        const ev = AppController.newEventDraft(AppController.workdayStart, day);
+        ev.title = "miniweek rev probe";
+        ev.date = day;
+        AppController.saveEvent(ev);
+        verify(mw._eventsRev > rev0, "rowsInserted must bump _eventsRev");
+
+        const rev1 = mw._eventsRev;
+        _wipeEventsOn(day);
+        verify(mw._eventsRev > rev1, "rowsRemoved must bump _eventsRev");
+    }
+}

--- a/tests/qml/tst_MonthView.qml
+++ b/tests/qml/tst_MonthView.qml
@@ -248,4 +248,47 @@ TestCase {
         AppController.deleteEvent(ev.id);
         AppController.selectedDate = prev;
     }
+
+    // Regression (priority-sort falsy-zero): within a day cell, tasks are sorted
+    // by priority with P0 the top tier. A `priRank[p] || 9` comparator demoted
+    // P0 (rank 0 is falsy) to the unknown-priority rank, sorting the most
+    // critical task LAST. Assert P0 precedes P1 in the same deadline cell.
+    function test_p0_task_sorts_before_p1_in_cell() {
+        const prev = AppController.selectedDate;
+        const day = new Date();
+        day.setDate(day.getDate() + 456);
+        day.setHours(12, 0, 0, 0);
+
+        const p1 = AppController.newTaskDraft("todo");
+        p1.title = "mv p1 probe"; p1.priority = "P1";
+        p1.scheduledAt = day; p1.dueAt = day; p1.hasTime = false;
+        AppController.saveTask(p1);
+
+        const p0 = AppController.newTaskDraft("todo");
+        p0.title = "mv p0 probe"; p0.priority = "P0";
+        p0.scheduledAt = day; p0.dueAt = day; p0.hasTime = false;
+        AppController.saveTask(p0);
+
+        AppController.selectedDate = day;
+        const mv = make('import TodoCpp; MonthView { anchors.fill: parent }');
+
+        let cell = null;
+        for (let k = 0; k < mv.cells.length; k++)
+            if (mv.isSameDay(mv.cells[k].date, day)) { cell = mv.cells[k]; break; }
+        verify(cell !== null, "grid must contain the deadline day cell");
+
+        // Robust to leftover tasks on the day: compare the two seeded ids by
+        // their position, not absolute index 0.
+        let iP0 = -1, iP1 = -1;
+        for (let i = 0; i < cell.tasks.length; i++) {
+            if (cell.tasks[i].id === p0.id) iP0 = i;
+            if (cell.tasks[i].id === p1.id) iP1 = i;
+        }
+        verify(iP0 >= 0 && iP1 >= 0, "both seeded tasks must be in the cell");
+        verify(iP0 < iP1, "P0 must sort before P1 (highest priority first)");
+
+        AppController.deleteTask(p0.id);
+        AppController.deleteTask(p1.id);
+        AppController.selectedDate = prev;
+    }
 }

--- a/tests/qml/tst_MonthView.qml
+++ b/tests/qml/tst_MonthView.qml
@@ -1,0 +1,251 @@
+// MonthView: month / custom-range calendar (companion to WeekView).
+//
+// Covers: load-smoke against the live AppController, the taskClicked /
+// eventClicked signal contracts, the pure helpers (isSameDay, priColor,
+// passesFilter), grid geometry + step() in both "month" and "weeks" modes,
+// and buildCells() picking up real task deadlines and events from the models.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "MonthView"
+    when: windowShown
+    visible: true
+    width: 600
+    height: 500
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // Smoke: the component instantiates against the live singleton and the
+    // default month grid is fully built (6 weeks x 7 days).
+    function test_monthview_load() {
+        const mv = make('import TodoCpp; MonthView { anchors.fill: parent }');
+        compare(mv.mode, "month");
+        compare(mv.rows, 6);
+        compare(mv.cells.length, 42);
+    }
+
+    // Signal contract: taskClicked carries the task id.
+    function test_taskclicked_signal_contract() {
+        const mv = make('import TodoCpp; MonthView { anchors.fill: parent }');
+        let got = "";
+        mv.taskClicked.connect(function(id) { got = id; });
+        mv.taskClicked("HEAP-mv-task");
+        compare(got, "HEAP-mv-task");
+    }
+
+    // Signal contract: eventClicked carries the event id.
+    function test_eventclicked_signal_contract() {
+        const mv = make('import TodoCpp; MonthView { anchors.fill: parent }');
+        let got = "";
+        mv.eventClicked.connect(function(id) { got = id; });
+        mv.eventClicked("ev-mv-probe");
+        compare(got, "ev-mv-probe");
+    }
+
+    // isSameDay compares calendar days, ignoring the clock, and rejects junk.
+    function test_helpers_is_same_day() {
+        const mv = make('import TodoCpp; MonthView { anchors.fill: parent }');
+        const a = new Date(2031, 4, 20, 9, 15);
+        const b = new Date(2031, 4, 20, 23, 59);
+        const c = new Date(2031, 4, 21, 0, 0);
+        verify(mv.isSameDay(a, b), "same calendar day must match regardless of time");
+        verify(!mv.isSameDay(a, c), "different days must not match");
+        verify(!mv.isSameDay(null, b), "null is never the same day");
+        verify(!mv.isSameDay(a, "not-a-date"), "non-dates are rejected");
+    }
+
+    // priColor maps priority ids onto the Theme palette (P3 is the fallback).
+    function test_helpers_pri_color() {
+        const mv = make('import TodoCpp; MonthView { anchors.fill: parent }');
+        compare(mv.priColor("P0"), Theme.p0);
+        compare(mv.priColor("P1"), Theme.p1);
+        compare(mv.priColor("P2"), Theme.p2);
+        compare(mv.priColor("P3"), Theme.p3);
+        compare(mv.priColor("unknown"), Theme.p3);
+    }
+
+    // passesFilter: done tasks are always hidden; searchText matches
+    // case-insensitively across title/id/desc; the priority filter only kicks
+    // in once at least one priority is enabled. Instance-local state only.
+    function test_passes_filter_search_and_priority() {
+        const mv = make('import TodoCpp; MonthView { anchors.fill: parent }');
+        const t = { id: "t-1", title: "Alpha task", desc: "", priority: "P2", status: "todo" };
+
+        verify(mv.passesFilter(t), "plain todo task must pass the default filter");
+        verify(!mv.passesFilter({ id: "t-2", title: "x", desc: "", priority: "P1", status: "done" }),
+               "done tasks never pass");
+
+        mv.searchText = "ALPHA";
+        verify(mv.passesFilter(t), "search must match the title case-insensitively");
+        mv.searchText = "zzz-no-match";
+        verify(!mv.passesFilter(t), "non-matching search must filter the task out");
+        mv.searchText = "";
+
+        mv.prioritiesFilter = { "P1": true };
+        verify(!mv.passesFilter(t), "P2 task must fail with only P1 enabled");
+        mv.prioritiesFilter = { "P2": true };
+        verify(mv.passesFilter(t), "P2 task must pass with P2 enabled");
+    }
+
+    // Month mode: 6x7 grid, title is the anchor month, and step() moves the
+    // selected date one month (clamped to day 28) in either direction.
+    function test_month_mode_grid_and_step() {
+        const prev = AppController.selectedDate;
+        const day = new Date();
+        day.setDate(day.getDate() + 452);
+        day.setHours(0, 0, 0, 0);
+        AppController.selectedDate = day;
+
+        const mv = make('import TodoCpp; MonthView { anchors.fill: parent }');
+        compare(mv.rows, 6);
+        compare(mv.cells.length, 42);
+        compare(mv.rangeTitle(), Qt.formatDate(day, "MMMM yyyy"));
+
+        mv.step(1);
+        const fwd = new Date(day.getFullYear(), day.getMonth() + 1, Math.min(day.getDate(), 28));
+        verify(mv.isSameDay(AppController.selectedDate, fwd),
+               "step(1) must advance the selected date one month (day clamped to 28)");
+
+        mv.step(-1);
+        const back = new Date(fwd.getFullYear(), fwd.getMonth() - 1, Math.min(fwd.getDate(), 28));
+        verify(mv.isSameDay(AppController.selectedDate, back),
+               "step(-1) must go back one month");
+
+        AppController.selectedDate = prev;
+    }
+
+    // Weeks mode: N x 7 grid anchored at the week of selectedDate, and step()
+    // jumps by the whole visible span (rows * 7 days).
+    function test_weeks_mode_grid_and_step() {
+        const prev = AppController.selectedDate;
+        const day = new Date();
+        day.setDate(day.getDate() + 455);
+        day.setHours(0, 0, 0, 0);
+        AppController.selectedDate = day;
+
+        const mv = make('import TodoCpp; MonthView { anchors.fill: parent }');
+        mv.mode = "weeks";
+        mv.weeksCount = 2;
+        compare(mv.rows, 2);
+        compare(mv.cells.length, 14);
+        verify(mv.isSameDay(mv.cells[0].date, mv.startOfWeek(day)),
+               "weeks grid must start at the week containing the anchor");
+
+        mv.step(1);
+        const fwd = new Date(day.getFullYear(), day.getMonth(), day.getDate() + 14);
+        verify(mv.isSameDay(AppController.selectedDate, fwd),
+               "step(1) in weeks mode must jump rows*7 days forward");
+
+        AppController.selectedDate = prev;
+    }
+
+    // rows clamps weeksCount into 1..8 without touching the property itself.
+    function test_weeks_count_clamped() {
+        const mv = make('import TodoCpp; MonthView { anchors.fill: parent }');
+        mv.mode = "weeks";
+        mv.weeksCount = 0;
+        compare(mv.rows, 1);
+        compare(mv.cells.length, 7);
+        mv.weeksCount = 99;
+        compare(mv.rows, 8);
+        compare(mv.cells.length, 56);
+        mv.weeksCount = 3;
+        compare(mv.rows, 3);
+        compare(mv.cells.length, 21);
+    }
+
+    // buildCells places a real task (via DeadlineRole, the QDate of dueAt) into
+    // the cell of its deadline day, and the search filter removes it again.
+    function test_cells_include_task_deadline() {
+        const prev = AppController.selectedDate;
+        const day = new Date();
+        day.setDate(day.getDate() + 453);
+        day.setHours(12, 0, 0, 0);
+
+        const draft = AppController.newTaskDraft("todo");
+        draft.title = "monthview cell probe";
+        draft.scheduledAt = day;
+        draft.dueAt = day;
+        draft.hasTime = false;
+        AppController.saveTask(draft);
+
+        AppController.selectedDate = day;
+        const mv = make('import TodoCpp; MonthView { anchors.fill: parent }');
+
+        let cell = null;
+        for (let k = 0; k < mv.cells.length; k++)
+            if (mv.isSameDay(mv.cells[k].date, day)) { cell = mv.cells[k]; break; }
+        verify(cell !== null, "the grid must contain a cell for the deadline day");
+
+        let found = false;
+        for (let i = 0; i < cell.tasks.length; i++)
+            if (cell.tasks[i].id === draft.id) found = true;
+        verify(found, "the task must land in its deadline day's cell");
+
+        // Non-matching search filters it back out (direct call: no binding dep).
+        mv.searchText = "zzz-no-such-task";
+        const cells2 = mv.buildCells();
+        let stillThere = false;
+        for (let k = 0; k < cells2.length; k++) {
+            if (!mv.isSameDay(cells2[k].date, day)) continue;
+            for (let i = 0; i < cells2[k].tasks.length; i++)
+                if (cells2[k].tasks[i].id === draft.id) stillThere = true;
+        }
+        verify(!stillThere, "a non-matching search must remove the task from the grid");
+
+        AppController.deleteTask(draft.id);
+        AppController.selectedDate = prev;
+    }
+
+    // buildCells places a real calendar event (DateRole) into its day's cell.
+    // The probe day is emptied first: the test-mode profile persists between
+    // runs, so leftovers from earlier runs would otherwise pile up.
+    function test_cells_include_event() {
+        const prev = AppController.selectedDate;
+        const day = new Date();
+        day.setDate(day.getDate() + 454);
+        day.setHours(0, 0, 0, 0);
+
+        const evs = AppController.events;
+        for (let i = evs.rowCount() - 1; i >= 0; i--) {
+            const idx = evs.index(i, 0);
+            const d = evs.data(idx, Qt.UserRole + 7);   // date role
+            if (d && d.getFullYear
+                && d.getFullYear() === day.getFullYear()
+                && d.getMonth() === day.getMonth()
+                && d.getDate() === day.getDate())
+                AppController.deleteEvent(String(evs.data(idx, Qt.UserRole + 1)));
+        }
+
+        const ev = AppController.newEventDraft(10, day);
+        ev.title = "monthview event probe";
+        ev.date = day;
+        AppController.saveEvent(ev);
+
+        AppController.selectedDate = day;
+        const mv = make('import TodoCpp; MonthView { anchors.fill: parent }');
+
+        let cell = null;
+        for (let k = 0; k < mv.cells.length; k++)
+            if (mv.isSameDay(mv.cells[k].date, day)) { cell = mv.cells[k]; break; }
+        verify(cell !== null, "the grid must contain a cell for the event day");
+
+        let found = false;
+        for (let i = 0; i < cell.events.length; i++)
+            if (cell.events[i].id === ev.id) found = true;
+        verify(found, "the event must land in its day's cell");
+
+        AppController.deleteEvent(ev.id);
+        AppController.selectedDate = prev;
+    }
+}

--- a/tests/qml/tst_PersonEditor.qml
+++ b/tests/qml/tst_PersonEditor.qml
@@ -1,0 +1,112 @@
+// PersonEditor contract tests (smoke + public API).
+//
+// Covers standalone instantiation, the showFor() seeding paths (new draft,
+// existing draft, id auto-derive re-arm, null fallback) and the Escape close
+// policy. The component has no objectNames and declares no signals, so there
+// are no click-driven or signal-contract tests — API level only.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "PersonEditor"
+    when: windowShown
+    visible: true
+    width: 500
+    height: 500
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // Smoke: the popup instantiates standalone against the live module, with
+    // the documented defaults and the fixed state/palette catalogues.
+    function test_smoke_load() {
+        const pe = make('import TodoCpp; PersonEditor { }');
+        compare(pe.isNew, false);
+        compare(pe._idAutoDerived, true);
+        compare(pe.states.length, 3);
+        compare(pe.states[0], "todo");
+        compare(pe.states[1], "pinged");
+        compare(pe.states[2], "replied");
+        compare(pe.palette.length, 8);
+        compare(pe.palette[0], "#d97a6c");
+    }
+
+    // showFor(new draft): flags isNew, keeps the id auto-derived from the name
+    // and opens the popup. Closed again so the modal overlay never leaks into
+    // other tests.
+    function test_showfor_new_draft_opens() {
+        const pe = make('import TodoCpp; PersonEditor { }');
+        pe.showFor({ _isNew: true, name: "Draft Person" });
+        tryCompare(pe, "opened", true);
+
+        compare(pe.isNew, true);
+        compare(pe._idAutoDerived, true);
+        compare(pe.draft.name, "Draft Person");
+
+        pe.close();
+        tryCompare(pe, "opened", false);
+    }
+
+    // showFor(existing draft with id): edit mode — the user's chosen handle is
+    // kept, so id auto-derivation must be off.
+    function test_showfor_existing_draft() {
+        const pe = make('import TodoCpp; PersonEditor { }');
+        pe.showFor({ id: "p.probe", name: "Probe", role: "QA",
+                     state: "replied", color: "#7da8d9" });
+        tryCompare(pe, "opened", true);
+
+        compare(pe.isNew, false);
+        compare(pe._idAutoDerived, false);
+        compare(pe.draft.id, "p.probe");
+        compare(pe.draft.state, "replied");
+
+        pe.close();
+        tryCompare(pe, "opened", false);
+    }
+
+    // showFor(existing draft without id): a blank id re-arms auto-derivation
+    // even in edit mode (the `isNew || idField empty` branch).
+    function test_showfor_blank_id_rearms_auto_derive() {
+        const pe = make('import TodoCpp; PersonEditor { }');
+        pe.showFor({ name: "No Id Yet" });
+        tryCompare(pe, "opened", true);
+
+        compare(pe.isNew, false);
+        compare(pe._idAutoDerived, true);
+
+        pe.close();
+        tryCompare(pe, "opened", false);
+    }
+
+    // showFor(null): falls back to an empty draft and still opens.
+    function test_showfor_null_defaults() {
+        const pe = make('import TodoCpp; PersonEditor { }');
+        pe.showFor(null);
+        tryCompare(pe, "opened", true);
+
+        compare(pe.isNew, false);
+        compare(Object.keys(pe.draft).length, 0);
+
+        pe.close();
+        tryCompare(pe, "opened", false);
+    }
+
+    // Escape closes the popup — pins the CloseOnEscape half of closePolicy.
+    // The popup declares focus: true, so the key lands inside it once open.
+    function test_escape_closes() {
+        const pe = make('import TodoCpp; PersonEditor { }');
+        pe.showFor({ _isNew: true });
+        tryCompare(pe, "opened", true);
+
+        keyClick(Qt.Key_Escape);
+        tryCompare(pe, "opened", false);
+    }
+}

--- a/tests/qml/tst_PillButton.qml
+++ b/tests/qml/tst_PillButton.qml
@@ -1,0 +1,140 @@
+// PillButton (qml/PillButton.qml): smoke-load, default flags/paddings, the
+// neutral / primary / danger styling contract against the live Theme singleton,
+// text passthrough, and click → clicked() incl. the enabled guard.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "PillButton"
+    when: windowShown
+    visible: true
+    width: 400
+    height: 400
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // Park the synthetic cursor away from the (top-left) button under test so
+    // the hovered branch of the style bindings is off deterministically.
+    function parkCursor() {
+        mouseMove(host, host.width - 2, host.height - 2);
+    }
+
+    // Smoke: instantiates against the live TodoCpp module (Theme resolves).
+    function test_smoke_load() {
+        const b = make('import TodoCpp; PillButton { }');
+        verify(b !== null);
+    }
+
+    // Both style flags default to off; pill paddings are fixed.
+    function test_default_flags_and_padding() {
+        const b = make('import TodoCpp; PillButton { text: "ok" }');
+        compare(b.primary, false);
+        compare(b.danger, false);
+        compare(b.padding, 8);
+        compare(b.leftPadding, 12);
+        compare(b.rightPadding, 12);
+    }
+
+    // contentItem mirrors the button's text, initially and on change.
+    function test_text_passthrough() {
+        const b = make('import TodoCpp; PillButton { text: "Save" }');
+        compare(b.contentItem.text, "Save");
+        b.text = "Create";
+        compare(b.contentItem.text, "Create");
+    }
+
+    // Neutral (default) variant: panel2 fill, Theme.border line, Theme.text
+    // label at Medium weight.
+    function test_neutral_style() {
+        const b = make('import TodoCpp; PillButton { text: "n"; width: 120; height: 32 }');
+        parkCursor();
+        tryCompare(b, "hovered", false);
+        verify(Qt.colorEqual(b.background.color, Theme.panel2), "neutral fill must be panel2");
+        verify(Qt.colorEqual(b.background.border.color, Theme.border), "neutral border must be Theme.border");
+        compare(b.background.border.width, 1);
+        compare(b.background.radius, 6);
+        verify(Qt.colorEqual(b.contentItem.color, Theme.text), "neutral label must be Theme.text");
+        compare(b.contentItem.font.weight, Font.Medium);
+        compare(b.contentItem.font.pixelSize, 12);
+    }
+
+    // Primary variant: accent fill, no border, fixed dark label at DemiBold —
+    // what every "Save"/"Create" caller (EventEditor, DocsEditor, …) relies on.
+    function test_primary_style() {
+        const b = make('import TodoCpp; PillButton { text: "p"; primary: true }');
+        verify(Qt.colorEqual(b.background.color, Theme.accent), "primary fill must be Theme.accent");
+        verify(Qt.colorEqual(b.background.border.color, "#00000000"), "primary border must be transparent");
+        verify(Qt.colorEqual(b.contentItem.color, "#06121a"), "primary label is the fixed dark ink");
+        compare(b.contentItem.font.weight, Font.DemiBold);
+    }
+
+    // Danger variant: p0-tinted fill/border with a p0 label — the "Delete"
+    // buttons (DocsEditor, EventEditor, PersonEditor, SelectionBar) contract.
+    function test_danger_style() {
+        const b = make('import TodoCpp; PillButton { text: "d"; danger: true }');
+        verify(Qt.colorEqual(b.background.color, Theme.withAlpha(Theme.p0, 0.12)), "danger fill must be p0 @ 0.12");
+        verify(Qt.colorEqual(b.background.border.color, Theme.withAlpha(Theme.p0, 0.4)), "danger border must be p0 @ 0.4");
+        verify(Qt.colorEqual(b.contentItem.color, Theme.p0), "danger label must be Theme.p0");
+        compare(b.contentItem.font.weight, Font.Medium);
+    }
+
+    // Precedence pin: primary wins over danger in every ternary chain
+    // (background, border, label) when both flags are set.
+    function test_primary_precedes_danger() {
+        const b = make('import TodoCpp; PillButton { text: "pd"; primary: true; danger: true }');
+        verify(Qt.colorEqual(b.background.color, Theme.accent), "primary must win the fill");
+        verify(Qt.colorEqual(b.background.border.color, "#00000000"), "primary must win the border");
+        verify(Qt.colorEqual(b.contentItem.color, "#06121a"), "primary must win the label");
+    }
+
+    // Flags are live bindings, not one-shot styling: flipping them at runtime
+    // restyles the pill both ways.
+    function test_runtime_flag_flip() {
+        const b = make('import TodoCpp; PillButton { text: "flip"; width: 120; height: 32 }');
+        parkCursor();
+        b.primary = true;
+        verify(Qt.colorEqual(b.background.color, Theme.accent), "flip to primary must restyle");
+        b.primary = false;
+        b.danger = true;
+        verify(Qt.colorEqual(b.contentItem.color, Theme.p0), "flip to danger must restyle");
+        b.danger = false;
+        tryCompare(b, "hovered", false);
+        verify(Qt.colorEqual(b.background.color, Theme.panel2), "flip back must restore the neutral fill");
+    }
+
+    // Hover restyle (panel3 fill + strong border) is intentionally not tested:
+    // the offscreen QPA platform used by the suite does not synthesise a hover
+    // enter, so `hovered` never flips true and the branch is unreachable here.
+    // The neutral (non-hover) styling is already pinned by test_neutral_style.
+
+    // A real mouse click reaches clicked() exactly once — the only wiring every
+    // caller uses (onClicked: …).
+    function test_click_emits_clicked() {
+        const b = make('import TodoCpp; PillButton { text: "go"; width: 120; height: 32 }');
+        let n = 0;
+        b.clicked.connect(function() { n++; });
+        mouseClick(b);
+        compare(n, 1);
+        parkCursor();
+    }
+
+    // enabled:false must swallow the click — QuickCapturePopup gates its
+    // Create pill on `enabled: root._title.length > 0`.
+    function test_disabled_swallows_click() {
+        const b = make('import TodoCpp; PillButton { text: "no"; width: 120; height: 32; enabled: false }');
+        let n = 0;
+        b.clicked.connect(function() { n++; });
+        mouseClick(b);
+        compare(n, 0);
+        parkCursor();
+    }
+}

--- a/tests/qml/tst_ProfileEditor.qml
+++ b/tests/qml/tst_ProfileEditor.qml
@@ -1,0 +1,141 @@
+// ProfileEditor popup: smoke-load, the showCreate/showRename/showDuplicate
+// mode contract, and the AppController profile wiring its Save button relies
+// on (createProfile activates the new profile; duplicateProfile activates the
+// copy so setProfileColor(activeProfileId) recolors the right one).
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "ProfileEditor"
+    when: windowShown
+    visible: true
+    width: 500
+    height: 500
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // The qttest profile persists between runs and is shared by all tst files,
+    // so drop any probe profiles a previous (possibly failed) run left behind.
+    function cleanupProbes() {
+        const profs = AppController.profiles;
+        for (let i = 0; i < profs.length; i++) {
+            if (String(profs[i].name).indexOf("pe-probe") === 0
+                    && AppController.profiles.length > 1)
+                AppController.deleteProfile(String(profs[i].id));
+        }
+    }
+
+    // Smoke: the popup instantiates standalone and exposes its defaults.
+    function test_smoke_load() {
+        const pe = make('import TodoCpp; ProfileEditor { }');
+        compare(pe.mode, "create");
+        compare(pe.profileId, "");
+        compare(pe.presetName, "");
+        compare(pe.presetColor, "");
+        verify(!pe.visible, "popup must start closed");
+        // Save picks colors out of this array — pin its shape.
+        compare(pe.palette.length, 8);
+        compare(String(pe.palette[0]).toLowerCase(), "#5cc2dd");
+    }
+
+    // showCreate() resets stale rename state back to create mode and opens.
+    function test_show_create_resets_mode() {
+        const pe = make('import TodoCpp; ProfileEditor { }');
+        pe.mode = "rename";
+        pe.profileId = "prof-stale";
+        pe.showCreate();
+        compare(pe.mode, "create");
+        compare(pe.profileId, "");
+        tryCompare(pe, "opened", true);
+        pe.close();
+        tryCompare(pe, "opened", false);
+    }
+
+    // showRename(id, name, color) arms rename mode for the given profile.
+    function test_show_rename_presets() {
+        const pe = make('import TodoCpp; ProfileEditor { }');
+        pe.showRename("prof-abc", "My profile", pe.palette[3]);
+        compare(pe.mode, "rename");
+        compare(pe.profileId, "prof-abc");
+        tryCompare(pe, "opened", true);
+        pe.close();
+        tryCompare(pe, "opened", false);
+    }
+
+    // showDuplicate(id, sourceName, sourceColor) arms duplicate mode.
+    function test_show_duplicate_presets() {
+        const pe = make('import TodoCpp; ProfileEditor { }');
+        pe.showDuplicate("prof-src", "Alpha", "");
+        compare(pe.mode, "duplicate");
+        compare(pe.profileId, "prof-src");
+        tryCompare(pe, "opened", true);
+        pe.close();
+        tryCompare(pe, "opened", false);
+    }
+
+    // The create/rename branch of saveBtn.activate(): createProfile must
+    // return the new id and activate it (the dialog closes into the new
+    // profile), and renameProfile/setProfileColor must land on that profile.
+    function test_save_wiring_create_rename_recolor() {
+        cleanupProbes();
+        const prevActive = AppController.activeProfileId;
+        const before = AppController.profiles.length;
+
+        const id = AppController.createProfile("pe-probe-create", "#5cc2dd");
+        verify(id !== "", "createProfile must return the new profile id");
+        compare(AppController.profiles.length, before + 1);
+        compare(AppController.activeProfileId, id,
+                "createProfile must activate the new profile");
+
+        AppController.renameProfile(id, "pe-probe-renamed");
+        AppController.setProfileColor(id, "#6cc4b8");
+        const m = AppController.profileById(id);
+        compare(String(m.name), "pe-probe-renamed");
+        compare(String(m.color).toLowerCase(), "#6cc4b8");
+
+        // Restore shared state: drop the probe, reactivate the old profile.
+        AppController.deleteProfile(id);
+        compare(AppController.profiles.length, before);
+        AppController.activeProfileId = prevActive;
+        compare(AppController.activeProfileId, prevActive);
+    }
+
+    // The duplicate branch of saveBtn.activate() recolors via
+    // AppController.activeProfileId right after duplicateProfile — this only
+    // works if duplicateProfile activates the copy. Pin that assumption.
+    function test_save_wiring_duplicate_activates_copy() {
+        cleanupProbes();
+        const prevActive = AppController.activeProfileId;
+        const before = AppController.profiles.length;
+
+        const srcId = AppController.createProfile("pe-probe-src", "#7cc492");
+        verify(srcId !== "");
+        const dupId = AppController.duplicateProfile(srcId, "pe-probe-dup");
+        verify(dupId !== "", "duplicateProfile must return the copy's id");
+        verify(dupId !== srcId, "the copy must get a fresh id");
+        compare(AppController.activeProfileId, dupId,
+                "duplicateProfile must activate the copy");
+
+        // Recolor through activeProfileId exactly like the editor does:
+        // the copy changes, the source keeps its color.
+        AppController.setProfileColor(AppController.activeProfileId, "#e6984c");
+        compare(String(AppController.profileById(dupId).color).toLowerCase(), "#e6984c");
+        compare(String(AppController.profileById(srcId).color).toLowerCase(), "#7cc492");
+
+        // Restore shared state.
+        AppController.deleteProfile(dupId);
+        AppController.deleteProfile(srcId);
+        compare(AppController.profiles.length, before);
+        AppController.activeProfileId = prevActive;
+        compare(AppController.activeProfileId, prevActive);
+    }
+}

--- a/tests/qml/tst_QuickCaptureNotesPopup.qml
+++ b/tests/qml/tst_QuickCaptureNotesPopup.qml
@@ -1,0 +1,69 @@
+// Load-smoke, config-contract and function-contract tests for the Notes
+// quick-capture popup (qml/QuickCaptureNotesPopup.qml). The component exposes
+// no objectName on any child, so input-driven paths are intentionally omitted.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "QuickCaptureNotesPopup"
+    when: windowShown
+    visible: true
+    width: 500
+    height: 500
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // Smoke: the whole tree instantiates — MentionAutocomplete, PillButton,
+    // Theme.* / I18n.t(...) bindings and the discard-confirm child popup all
+    // resolve. A renamed property or missing type would return null here.
+    function test_smoke_load() {
+        const qc = make('import TodoCpp; QuickCaptureNotesPopup { }');
+        verify(qc !== null, "QuickCaptureNotesPopup failed to instantiate");
+    }
+
+    // Config contract: the popup must stay modal and must NOT auto-close — it
+    // owns all key handling so the Esc→discard-confirm flow can intercept Esc
+    // (source comment, qml/QuickCaptureNotesPopup.qml:19-21).
+    function test_popup_config_contract() {
+        const qc = make('import TodoCpp; QuickCaptureNotesPopup { }');
+        compare(qc.modal, true, "notes popup must be modal");
+        compare(qc.closePolicy, Popup.NoAutoClose,
+                "must not auto-close on Escape/outside-click");
+        compare(qc.padding, 0, "padding is 0 (margins are per-child)");
+        compare(qc.width, 600, "fixed 600px width");
+    }
+
+    // _submit() on an empty editor is a silent no-op: it hits the
+    // body.trim().length === 0 guard and closes without appending a note
+    // (qml/QuickCaptureNotesPopup.qml:30-40). Confirms editor/root ids resolve
+    // and no spurious entry lands in AppController.notesState.
+    function test_submit_empty_is_noop() {
+        const qc = make('import TodoCpp; QuickCaptureNotesPopup { }');
+        const before = AppController.notesState;
+        qc._submit();                       // editor.text defaults to ""
+        compare(AppController.notesState, before,
+                "empty submit must not append a note entry");
+        verify(!qc.opened, "empty submit must leave the popup closed");
+    }
+
+    // _maybeDiscard() on an empty editor closes silently instead of opening the
+    // discard-confirm popup (qml/QuickCaptureNotesPopup.qml:42-48). No note is
+    // written and the call must not throw.
+    function test_maybe_discard_empty_is_noop() {
+        const qc = make('import TodoCpp; QuickCaptureNotesPopup { }');
+        const before = AppController.notesState;
+        qc._maybeDiscard();                 // editor.text defaults to ""
+        compare(AppController.notesState, before,
+                "discard on empty editor must not touch notesState");
+        verify(!qc.opened, "empty discard must leave the popup closed");
+    }
+}

--- a/tests/qml/tst_SplashScreen.qml
+++ b/tests/qml/tst_SplashScreen.qml
@@ -1,0 +1,101 @@
+// SplashScreen: load-smoke against the live singletons, default public knobs,
+// the finished() signal contract, and the auto-animation path Main.qml relies
+// on (finished fires when the bar completes; never fires with autoAnimate off).
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "SplashScreen"
+    when: windowShown
+    visible: true
+    width: 400
+    height: 400
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // Smoke: instantiates against the live Brand/BrandLogo/AppController
+    // singletons; a renamed property or missing type would return null.
+    function test_smoke_load() {
+        const s = make('import TodoCpp; SplashScreen { }');
+        verify(s !== null, "failed to instantiate SplashScreen");
+    }
+
+    // Default public knobs. autoAnimate is forced off so the demo animation
+    // does not advance progress while we read the defaults.
+    function test_default_knobs() {
+        const s = make('import TodoCpp; SplashScreen { autoAnimate: false }');
+        compare(s.progress, 0.0, "progress starts at 0");
+        compare(s.status, "initializing allocator…");
+        compare(s.channel, "stable · channel");
+        compare(s.autoDuration, 1200);
+        // buildInfo is bound to the live AppController version string.
+        compare(s.buildInfo, "v" + AppController.appVersion);
+    }
+
+    // progress is the primary public knob ("bind to your loader's progress"):
+    // writable, and holds what the loader pushes when autoAnimate is off.
+    function test_progress_is_externally_drivable() {
+        const s = make('import TodoCpp; SplashScreen { autoAnimate: false }');
+        s.progress = 0.37;
+        compare(s.progress, 0.37);
+        s.progress = 1.0;
+        compare(s.progress, 1.0);
+    }
+
+    // Signal contract: finished() takes no arguments and is emittable.
+    function test_finished_signal_contract() {
+        const s = make('import TodoCpp; SplashScreen { autoAnimate: false }');
+        let fired = 0;
+        s.finished.connect(function() { fired++; });
+        s.finished();
+        compare(fired, 1);
+    }
+
+    // Auto-animate path (Main.qml: onFinished: splashFade.start()): the demo
+    // NumberAnimation must drive progress to 1 and emit finished() exactly once.
+    function test_auto_animate_emits_finished() {
+        const s = make('import TodoCpp; SplashScreen { autoDuration: 80 }');
+        let fired = 0;
+        s.finished.connect(function() { fired++; });
+        // Animation-driven, so poll instead of a blind wait.
+        tryVerify(function() { return fired === 1; }, 2000,
+                  "finished() must fire when the auto animation completes");
+        compare(s.progress, 1, "the bar ends full when the animation finishes");
+        compare(fired, 1, "finished() fires exactly once per animation run");
+    }
+
+    // running: root.autoAnimate is a live binding — flipping the knob on at
+    // runtime must start the animation and reach finished().
+    function test_auto_animate_toggled_on_at_runtime() {
+        const s = make('import TodoCpp; SplashScreen { autoAnimate: false; autoDuration: 80 }');
+        let fired = 0;
+        s.finished.connect(function() { fired++; });
+        s.autoAnimate = true;
+        tryVerify(function() { return fired === 1; }, 2000,
+                  "enabling autoAnimate at runtime must run the bar to completion");
+        compare(s.progress, 1);
+    }
+
+    // Reduced-motion contract (Main.qml sets autoAnimate: !Theme.reducedMotion
+    // and dismisses via its own Timer): with autoAnimate off the splash must
+    // never fire finished() or move the bar on its own.
+    function test_no_spontaneous_finish_when_auto_animate_off() {
+        const s = make('import TodoCpp; SplashScreen { autoAnimate: false; autoDuration: 50 }');
+        let fired = 0;
+        s.finished.connect(function() { fired++; });
+        // Deliberate minimal wait: gives a wrongly-running 50ms animation ample
+        // time to complete, so a regression would be caught here.
+        wait(200);
+        compare(fired, 0, "finished() must not fire while autoAnimate is false");
+        compare(s.progress, 0.0, "progress must not advance while autoAnimate is false");
+    }
+}

--- a/tests/qml/tst_TaskEditor.qml
+++ b/tests/qml/tst_TaskEditor.qml
@@ -1,0 +1,85 @@
+// TaskEditor: regressions for two edit-path bugs.
+//  (1) Delete keyed off the live editable idField instead of the stable
+//      open-time id, so editing the id then hitting Delete was a silent no-op
+//      (deleteTask misses, popup closes as if it worked).
+//  (2) The recurrence dropdown lacked every:sat / every:sun, so a weekend
+//      recurrence (which the chrono parser emits) mapped to "None" on open and
+//      was overwritten to "" on save — silent data loss on edit.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "TaskEditor"
+    when: windowShown
+    visible: true
+    width: 520
+    height: 640
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    function taskExists(id) {
+        const m = AppController.tasks;
+        for (let i = 0; i < m.rowCount(); i++)
+            if (String(m.data(m.index(i, 0), Qt.UserRole + 1)) === id) return true;
+        return false;
+    }
+
+    // Delete must target root._originalId (the id captured when the editor
+    // opened), not idField.text which the user can edit. Reproduces the silent
+    // no-op: edit the id field, delete, and the ORIGINAL row must still be gone.
+    function test_delete_uses_original_id_not_edited_field() {
+        const draft = AppController.newTaskDraft("todo");
+        draft.title = "te delete probe";
+        AppController.saveTask(draft);
+        const origId = draft.id;
+        verify(taskExists(origId), "seed task must exist before delete");
+
+        const te = make('import TodoCpp; TaskEditor { }');
+        te.showFor(AppController.taskById(origId));   // opens as an existing task
+
+        const idField = findChild(te, "te-id");
+        verify(idField !== null, "te-id not found");
+        idField.text = "ZZZ-999";                     // user edits the id, no Save
+
+        const del = findChild(te, "te-delete");
+        verify(del !== null, "te-delete not found");
+        // Emit the button's clicked() — runs the exact onClicked handler a real
+        // click would, deterministically (avoids offscreen Popup hit-testing).
+        del.clicked();
+
+        verify(!taskExists(origId),
+               "Delete must remove the opened task by its original id");
+
+        // Cleanup in case the fix regressed and the row survived.
+        if (taskExists(origId)) AppController.deleteTask(origId);
+    }
+
+    // A task opened with a weekend recurrence must round-trip: the value Save
+    // would write (recurBox._vals[currentIndex]) equals the opened recurrence,
+    // not "" (which the missing sat/sun options collapsed it to).
+    function test_recurrence_weekend_roundtrips() {
+        const te = make('import TodoCpp; TaskEditor { }');
+        const rec = findChild(te, "te-recurrence");
+        verify(rec !== null, "te-recurrence not found");
+        verify(rec._vals.indexOf("every:sat") >= 0, "every:sat must be an option");
+        verify(rec._vals.indexOf("every:sun") >= 0, "every:sun must be an option");
+
+        te.showFor({ id: "", title: "sat probe", recurrence: "every:sat", _isNew: true });
+        compare(rec._vals[rec.currentIndex], "every:sat",
+                "Saturday recurrence must survive open->save round-trip");
+
+        te.showFor({ id: "", title: "sun probe", recurrence: "every:sun", _isNew: true });
+        compare(rec._vals[rec.currentIndex], "every:sun",
+                "Sunday recurrence must survive open->save round-trip");
+        te.close();
+    }
+}

--- a/tests/qml/tst_Theme.qml
+++ b/tests/qml/tst_Theme.qml
@@ -1,0 +1,204 @@
+// Unit tests for the Theme singleton (qml/Theme.qml).
+// Theme is `pragma Singleton` with no signals and no objectName, so we exercise
+// its palette bindings, convenience reads, and pure functions directly, driving
+// settings-dependent branches through the writable AppController.appSettingsJson
+// (captured and restored inside each method so tests stay independent).
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "Theme"
+    when: windowShown
+    visible: true
+    width: 200
+    height: 200
+
+    Item { id: host; anchors.fill: parent }
+
+    // ── smoke: the singleton resolves and core tokens have sane types ──
+    function test_singleton_resolves() {
+        verify(Theme !== null, "Theme singleton must resolve");
+        compare(typeof Theme.animMs, "number");
+        verify(Theme.rowH > 0, "rowH must be positive");
+        verify(Theme.pad > 0, "pad must be positive");
+        verify(Theme.radius > 0, "radius must be positive");
+        verify(Theme.hourH > 0, "hourH must be positive");
+        verify(Theme.fontUi.length > 0, "fontUi must be non-empty");
+        verify(Theme.fontMono.length > 0, "fontMono must be non-empty");
+        compare(typeof Theme.dark, "boolean");
+        compare(typeof Theme.compact, "boolean");
+        compare(typeof Theme.reducedMotion, "boolean");
+        compare(typeof Theme.highContrast, "boolean");
+    }
+
+    // ── withAlpha: keeps r/g/b, replaces alpha ──
+    function test_withalpha_preserves_rgb_sets_alpha() {
+        const c = Qt.rgba(0.2, 0.4, 0.6, 1.0);
+        const half = Theme.withAlpha(c, 0.5);
+        fuzzyCompare(half.r, 0.2, 0.01);
+        fuzzyCompare(half.g, 0.4, 0.01);
+        fuzzyCompare(half.b, 0.6, 0.01);
+        fuzzyCompare(half.a, 0.5, 0.01);
+        // alpha bounds are passed through untouched
+        fuzzyCompare(Theme.withAlpha(c, 0.0).a, 0.0, 0.01);
+        fuzzyCompare(Theme.withAlpha(c, 1.0).a, 1.0, 0.01);
+        // original color is not mutated by the call
+        fuzzyCompare(c.a, 1.0, 0.01);
+    }
+
+    // ── scaledMs: identity when motion is on, 0 when reduced ──
+    function test_scaledms_matches_motion_state() {
+        compare(Theme.scaledMs(0), 0);
+        // animMs is defined as reducedMotion ? 0 : 160 — scaledMs(160) must agree.
+        compare(Theme.scaledMs(160), Theme.animMs);
+        if (Theme.reducedMotion) {
+            compare(Theme.scaledMs(200), 0);
+            compare(Theme.animMs, 0);
+        } else {
+            compare(Theme.scaledMs(200), 200);
+            compare(Theme.animMs, 160);
+        }
+    }
+
+    // ── statusColor: each known id maps to its swatch, unknown → textMuted ──
+    function test_statuscolor_mapping() {
+        compare(String(Theme.statusColor("backlog")), String(Theme.stBacklog));
+        compare(String(Theme.statusColor("todo")),    String(Theme.stTodo));
+        compare(String(Theme.statusColor("prog")),    String(Theme.stProg));
+        compare(String(Theme.statusColor("half")),    String(Theme.stHalf));
+        compare(String(Theme.statusColor("blocked")), String(Theme.stBlocked));
+        compare(String(Theme.statusColor("review")),  String(Theme.stReview));
+        compare(String(Theme.statusColor("done")),    String(Theme.stDone));
+        // unknown / empty fall back to textMuted
+        compare(String(Theme.statusColor("nope")), String(Theme.textMuted));
+        compare(String(Theme.statusColor("")),     String(Theme.textMuted));
+    }
+
+    // ── priorityColor: P0..P3 → ramp, unknown → textMuted (callers pass
+    //    uppercase "P0".."P3", e.g. FilterBar model + TaskCard task.priority) ──
+    function test_prioritycolor_mapping() {
+        compare(String(Theme.priorityColor("P0")), String(Theme.p0));
+        compare(String(Theme.priorityColor("P1")), String(Theme.p1));
+        compare(String(Theme.priorityColor("P2")), String(Theme.p2));
+        compare(String(Theme.priorityColor("P3")), String(Theme.p3));
+        compare(String(Theme.priorityColor("P4")), String(Theme.textMuted));
+        compare(String(Theme.priorityColor("")),   String(Theme.textMuted));
+    }
+
+    // ── eventColor: known types → swatch, unknown → accent (default) ──
+    function test_eventcolor_mapping() {
+        compare(String(Theme.eventColor("standup")), String(Theme.mStandup));
+        compare(String(Theme.eventColor("oneone")),  String(Theme.mOneone));
+        compare(String(Theme.eventColor("sync")),    String(Theme.mSync));
+        compare(String(Theme.eventColor("focus")),   String(Theme.mFocus));
+        // default branch returns the live accent, not textMuted
+        compare(String(Theme.eventColor("mystery")), String(Theme.accent));
+        compare(String(Theme.eventColor("")),        String(Theme.accent));
+    }
+
+    // ── fmtHour, 24h format ── (settings forced + restored before asserting)
+    function test_fmthour_24h() {
+        const saved = AppController.appSettingsJson;
+        AppController.appSettingsJson = JSON.stringify({ calendar: { timeFormat: "24h" } });
+        // read while the setting is active; restore before any assert can throw
+        const v0   = Theme.fmtHour(0);
+        const v9   = Theme.fmtHour(9);
+        const v13  = Theme.fmtHour(13);
+        const v23  = Theme.fmtHour(23);
+        const half = Theme.fmtHour(9.5);
+        const q    = Theme.fmtHour(0.25);
+        const fmt  = Theme.timeFormat;
+        AppController.appSettingsJson = saved;
+
+        compare(fmt, "24h");
+        compare(v0,  "00:00");
+        compare(v9,  "09:00");
+        compare(v13, "13:00");
+        compare(v23, "23:00");
+        compare(half, "09:30");
+        compare(q,   "00:15");
+    }
+
+    // ── fmtHour, 12h format: am/pm + 12-hour clock boundaries ──
+    function test_fmthour_12h() {
+        const saved = AppController.appSettingsJson;
+        AppController.appSettingsJson = JSON.stringify({ calendar: { timeFormat: "12h" } });
+        const midnight = Theme.fmtHour(0);
+        const noon     = Theme.fmtHour(12);
+        const onePm    = Theme.fmtHour(13);
+        const elevenPm = Theme.fmtHour(23);
+        const elevenAm = Theme.fmtHour(11);
+        const oneAm    = Theme.fmtHour(1);
+        const halfPast = Theme.fmtHour(9.5);
+        const fmt      = Theme.timeFormat;
+        AppController.appSettingsJson = saved;
+
+        compare(fmt, "12h");
+        compare(midnight, "12:00am");  // 0h → 12am
+        compare(noon,     "12:00pm");  // 12h → 12pm
+        compare(onePm,    "1:00pm");
+        compare(elevenPm, "11:00pm");
+        compare(elevenAm, "11:00am");
+        compare(oneAm,    "1:00am");
+        compare(halfPast, "9:30am");
+    }
+
+    // ── convenience reads fall back to defaults when settings are empty ──
+    function test_calendar_defaults_when_settings_empty() {
+        const saved = AppController.appSettingsJson;
+        AppController.appSettingsJson = "";   // → _settings === {}
+        const weekStart    = Theme.weekStart;
+        const timeFormat   = Theme.timeFormat;
+        const snapMinutes  = Theme.snapMinutes;
+        const showWeekends = Theme.showWeekends;
+        const reduced      = Theme.reducedMotion;
+        const contrast     = Theme.highContrast;
+        const animMs       = Theme.animMs;
+        AppController.appSettingsJson = saved;
+
+        compare(weekStart, "mon");
+        compare(timeFormat, "24h");
+        compare(snapMinutes, 15);
+        compare(showWeekends, true);
+        compare(reduced, false);
+        compare(contrast, false);
+        compare(animMs, 160);
+    }
+
+    // ── explicit overrides win — notably showWeekends:false must survive
+    //    (guards the `=== undefined ? true : !!x` logic against a `|| true` trap) ──
+    function test_calendar_overrides_apply() {
+        const saved = AppController.appSettingsJson;
+        AppController.appSettingsJson = JSON.stringify({
+            calendar: { weekStart: "sun", snapMinutes: 30, showWeekends: false }
+        });
+        const weekStart    = Theme.weekStart;
+        const snapMinutes  = Theme.snapMinutes;
+        const showWeekends = Theme.showWeekends;
+        AppController.appSettingsJson = saved;
+
+        compare(weekStart, "sun");
+        compare(snapMinutes, 30);
+        compare(showWeekends, false);
+    }
+
+    // ── malformed settings JSON must not throw — Theme swallows the parse
+    //    error and reverts every convenience read to its default ──
+    function test_malformed_settings_falls_back() {
+        const saved = AppController.appSettingsJson;
+        AppController.appSettingsJson = "{ not valid json";
+        const weekStart    = Theme.weekStart;
+        const timeFormat   = Theme.timeFormat;
+        const snapMinutes  = Theme.snapMinutes;
+        const showWeekends = Theme.showWeekends;
+        AppController.appSettingsJson = saved;
+
+        compare(weekStart, "mon");
+        compare(timeFormat, "24h");
+        compare(snapMinutes, 15);
+        compare(showWeekends, true);
+    }
+}

--- a/tests/qml/tst_ThinScrollBar.qml
+++ b/tests/qml/tst_ThinScrollBar.qml
@@ -1,0 +1,130 @@
+// ThinScrollBar (translucent 6px thumb, fades when idle): load-smoke, the
+// styling contract (AsNeeded policy, minimumSize, bare background), the
+// fade-opacity binding, and real attached-to-Flickable tracking.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "ThinScrollBar"
+    when: windowShown
+    visible: true
+    width: 400
+    height: 400
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // Smoke: a broken Theme reference or a renamed property would make
+    // createTemporaryQmlObject return null. Also pins the two knobs every
+    // caller relies on: AsNeeded (auto-hide) and the minimum thumb size.
+    function test_smoke_load() {
+        const sb = make('import TodoCpp; ThinScrollBar { }');
+        compare(sb.policy, ScrollBar.AsNeeded, "callers rely on the auto-hide policy");
+        fuzzyCompare(sb.minimumSize, 0.06, 0.001);
+    }
+
+    // The design-prototype thumb: 6px rounded rectangle, idle color is
+    // Theme.text at 0.18 alpha, and the track is a bare Item (translucent
+    // treatment — no background chrome).
+    function test_thumb_visuals_and_bare_background() {
+        const sb = make('import TodoCpp; ThinScrollBar { height: 120 }');
+        // Park the cursor away from the bar so hovered/pressed are
+        // deterministically false (a stray hover would pick the 0.30 color).
+        mouseMove(tc, 350, 350);
+        verify(!sb.pressed, "standalone bar must not start pressed");
+        verify(!sb.hovered, "cursor parked away — bar must not be hovered");
+
+        compare(sb.contentItem.implicitWidth, 6);
+        compare(sb.contentItem.implicitHeight, 6);
+        compare(sb.contentItem.radius, 3);
+
+        const c = sb.contentItem.color;
+        fuzzyCompare(c.a, 0.18, 0.01);
+        fuzzyCompare(c.r, Theme.text.r, 0.01);
+        fuzzyCompare(c.g, Theme.text.g, 0.01);
+        fuzzyCompare(c.b, Theme.text.b, 0.01);
+
+        verify(sb.background !== null, "background must exist (empty Item)");
+        compare(sb.background.implicitWidth, 0);
+        compare(sb.background.implicitHeight, 0);
+    }
+
+    // Fade contract ("fades when idle"): thumb opacity is 0 when idle, 1 when
+    // the bar is active or policy is AlwaysOn. The opacity change runs through
+    // a Behavior/NumberAnimation, so every step uses tryCompare — no bare
+    // wait() on animation timing (duration also collapses to 0 under the
+    // reduced-motion setting).
+    function test_fade_when_idle_contract() {
+        const sb = make('import TodoCpp; ThinScrollBar { height: 120 }');
+        mouseMove(tc, 350, 350);  // ensure hovered is false
+        sb.active = false;
+        tryCompare(sb.contentItem, "opacity", 0.0);
+
+        sb.policy = ScrollBar.AlwaysOn;
+        tryCompare(sb.contentItem, "opacity", 1.0);
+
+        sb.policy = ScrollBar.AsNeeded;
+        tryCompare(sb.contentItem, "opacity", 0.0);
+
+        sb.active = true;
+        tryCompare(sb.contentItem, "opacity", 1.0);
+    }
+
+    // Real usage (DocsView/NotesView/KanbanBoard/SettingsView all attach it as
+    // ScrollBar.vertical on a scrollable): size mirrors the viewport/content
+    // ratio, position tracks contentY, and increase() drives the flickable.
+    function test_attached_flickable_tracking() {
+        const flick = make('import QtQuick; import QtQuick.Controls; import TodoCpp; '
+            + 'Flickable { property alias bar: tsb; width: 200; height: 200; '
+            + 'contentWidth: 200; contentHeight: 2000; '
+            + 'ScrollBar.vertical: ThinScrollBar { id: tsb } }');
+        const bar = flick.bar;
+        verify(bar !== null, "attached ThinScrollBar not reachable via alias");
+
+        // 200/2000 viewport ratio; layout is asynchronous → tryVerify.
+        tryVerify(function() { return Math.abs(bar.size - 0.1) < 0.02; }, 5000,
+                  "size must mirror the viewport/content ratio");
+        tryVerify(function() { return bar.visible; }, 5000,
+                  "overflowing content must show the AsNeeded bar");
+
+        flick.contentY = 900;  // 45% of the 2000px content
+        tryVerify(function() { return Math.abs(bar.position - 0.45) < 0.02; }, 5000,
+                  "position must track contentY");
+
+        // stepSize is unset → increase() steps by 0.1 → contentY 900 + 200.
+        bar.increase();
+        tryVerify(function() { return Math.abs(flick.contentY - 1100) < 30; }, 5000,
+                  "increase() must scroll the attached flickable");
+    }
+
+    // AsNeeded semantics the component opts into. Qt's Basic ScrollBar keeps
+    // `visible` true for every policy but AlwaysOff (visible: policy !==
+    // AlwaysOff) — the auto-hide is expressed through `size`, which the attach
+    // clamps to [0,1]: size == 1 means the content fits (nothing to scroll and
+    // the thumb stays faded), size < 1 means it overflows and the thumb shows.
+    function test_asneeded_size_reflects_overflow() {
+        const flick = make('import QtQuick; import QtQuick.Controls; import TodoCpp; '
+            + 'Flickable { property alias bar: tsb; width: 200; height: 200; '
+            + 'contentWidth: 200; contentHeight: 100; '
+            + 'ScrollBar.vertical: ThinScrollBar { id: tsb } }');
+        const bar = flick.bar;
+        verify(bar !== null, "attached ThinScrollBar not reachable via alias");
+
+        // Content fits (100 < 200) → size clamps to 1.0, nothing to scroll.
+        tryVerify(function() { return bar.size >= 1.0 - 0.001; }, 5000,
+                  "content fitting the viewport must clamp size to 1.0");
+
+        // Overflow → size drops below 1.0 and the thumb becomes scrollable.
+        flick.contentHeight = 2000;
+        tryVerify(function() { return bar.size < 1.0; }, 5000,
+                  "overflowing content must drop size below 1.0");
+    }
+}

--- a/tests/qml/tst_TimelineView.qml
+++ b/tests/qml/tst_TimelineView.qml
@@ -1,0 +1,66 @@
+// TimelineView: regression for the same-deadline priority tiebreak falsy-zero
+// bug. Among tasks sharing a deadline within a bucket, P0 must order before P1;
+// `priRank[p] || 9` demoted P0's rank 0 to the unknown fallback, sorting the
+// most critical task last within the bucket.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "TimelineView"
+    when: windowShown
+    visible: true
+    width: 700
+    height: 500
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    function test_smoke_load() {
+        const tv = make('import TodoCpp; TimelineView { anchors.fill: parent }');
+        verify(tv !== null);
+    }
+
+    // Both tasks carry the same deadline → same bucket → the priority tiebreak
+    // decides their order. Compare the two seeded ids by position (robust to any
+    // other tasks that land in the same bucket).
+    function test_p0_tiebreaks_before_p1_same_deadline() {
+        const day = new Date();
+        day.setDate(day.getDate() + 602);
+        day.setHours(0, 0, 0, 0);
+
+        const p1 = AppController.newTaskDraft("todo");
+        p1.title = "tl p1 probe"; p1.priority = "P1";
+        p1.dueAt = day; p1.scheduledAt = day; p1.hasTime = false;
+        AppController.saveTask(p1);
+
+        const p0 = AppController.newTaskDraft("todo");
+        p0.title = "tl p0 probe"; p0.priority = "P0";
+        p0.dueAt = day; p0.scheduledAt = day; p0.hasTime = false;
+        AppController.saveTask(p0);
+
+        const tv = make('import TodoCpp; TimelineView { anchors.fill: parent }');
+        const groups = tv.buildGroups();
+
+        let iP0 = -1, iP1 = -1;
+        for (const k in groups) {
+            const arr = groups[k];
+            for (let i = 0; i < arr.length; i++) {
+                if (arr[i].id === p0.id) iP0 = i;
+                if (arr[i].id === p1.id) iP1 = i;
+            }
+        }
+        verify(iP0 >= 0 && iP1 >= 0, "both tasks must be bucketed");
+        verify(iP0 < iP1, "P0 must tiebreak before P1 at the same deadline");
+
+        AppController.deleteTask(p0.id);
+        AppController.deleteTask(p1.id);
+    }
+}

--- a/tests/qml/tst_TweaksPanel.qml
+++ b/tests/qml/tst_TweaksPanel.qml
@@ -1,0 +1,128 @@
+// Tests for qml/TweaksPanel.qml — the compact Tweaks popup.
+// Surface: readonly accentSwatches, and the settings-shadow functions
+// (_reload / _setAppearance / _appearanceValue) that round-trip through the
+// live AppController.appSettingsJson. No objectName / root signal exists, so
+// there are no click- or signal-contract layers here.
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "TweaksPanel"
+    when: windowShown
+    visible: true
+    width: 500
+    height: 500
+
+    Item { id: host; anchors.fill: parent }
+
+    // AppController.appSettingsJson is global + persisted. Snapshot before every
+    // test and restore after, so a failing compare can never leak state into the
+    // next test (or a later run of the shared qttest profile).
+    property string _savedSettings: ""
+    function init()    { _savedSettings = AppController.appSettingsJson; }
+    function cleanup() { AppController.appSettingsJson = _savedSettings; }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    // smoke-load: the popup instantiates against the live singletons (Theme,
+    // AppController, I18n) — a renamed property or missing type would null here.
+    function test_smoke_load() {
+        const p = make('import TodoCpp; TweaksPanel { }');
+        verify(p !== null);
+    }
+
+    // accentSwatches is the fixed chip palette mirrored from the Settings accent
+    // picker: exactly 7 hex colors, stable order.
+    function test_accent_swatches() {
+        const p = make('import TodoCpp; TweaksPanel { }');
+        compare(p.accentSwatches.length, 7);
+        compare(String(p.accentSwatches[0]).toLowerCase(), "#5cc2dd");
+        compare(String(p.accentSwatches[6]).toLowerCase(), "#9aa3b4");
+    }
+
+    // _appearanceValue(key, fallback): reads settings.appearance[key], falling
+    // back when absent — and, crucially, an explicit `false` must survive the
+    // `!== undefined` guard rather than collapsing to the fallback.
+    function test_appearance_value_contract() {
+        const p = make('import TodoCpp; TweaksPanel { }');
+
+        // Empty shadow → fallback.
+        p.settings = ({});
+        compare(p._appearanceValue("accent", "#fallback"), "#fallback");
+
+        // Stored value wins over fallback.
+        p.settings = ({ appearance: { accent: "#abcdef" } });
+        compare(p._appearanceValue("accent", "#fallback"), "#abcdef");
+
+        // Missing key inside a present appearance object → fallback.
+        compare(p._appearanceValue("highContrast", true), true);
+
+        // Explicit false is a real value, not "undefined".
+        p.settings = ({ appearance: { reducedMotion: false } });
+        compare(p._appearanceValue("reducedMotion", true), false);
+    }
+
+    // _reload() re-parses AppController.appSettingsJson into the shadow.
+    function test_reload_parses_json() {
+        const p = make('import TodoCpp; TweaksPanel { }');
+        AppController.appSettingsJson = '{"appearance":{"accent":"#0a0b0c"}}';
+        p._reload();
+        compare(String(p._appearanceValue("accent", "x")), "#0a0b0c");
+    }
+
+    // _reload() swallows malformed JSON and resets to an empty shadow.
+    function test_reload_invalid_json_clears() {
+        const p = make('import TodoCpp; TweaksPanel { }');
+        AppController.appSettingsJson = "not json {";
+        p._reload();
+        // Empty shadow ⇒ every read returns its fallback.
+        compare(p._appearanceValue("accent", "#fb"), "#fb");
+    }
+
+    // _reload() on an empty string clears the shadow (the early-return branch).
+    function test_reload_empty_clears() {
+        const p = make('import TodoCpp; TweaksPanel { }');
+        AppController.appSettingsJson = "";
+        p._reload();
+        compare(p._appearanceValue("accent", "#fb"), "#fb");
+    }
+
+    // _setAppearance(key, val) writes through to AppController.appSettingsJson
+    // AND leaves the shadow readable via _appearanceValue.
+    function test_set_appearance_writes_through() {
+        const p = make('import TodoCpp; TweaksPanel { }');
+        p._setAppearance("accent", "#123456");
+
+        const parsed = JSON.parse(AppController.appSettingsJson);
+        verify(parsed.appearance !== undefined, "appearance object must be written");
+        compare(parsed.appearance.accent, "#123456");
+        compare(String(p._appearanceValue("accent", "x")), "#123456");
+    }
+
+    // _setAppearance merges: setting one appearance key must not drop the others,
+    // and must preserve unrelated top-level settings sections.
+    function test_set_appearance_preserves_existing_keys() {
+        const p = make('import TodoCpp; TweaksPanel { }');
+
+        // Seed a shadow with a sibling appearance key + an unrelated section.
+        AppController.appSettingsJson =
+            '{"appearance":{"accent":"#111111","reducedMotion":true},"calendar":{"weekStart":"mon"}}';
+        p._reload();
+
+        p._setAppearance("highContrast", true);
+
+        const parsed = JSON.parse(AppController.appSettingsJson);
+        compare(parsed.appearance.accent, "#111111", "sibling appearance key dropped");
+        compare(parsed.appearance.reducedMotion, true, "sibling appearance key dropped");
+        compare(parsed.appearance.highContrast, true, "new key not written");
+        verify(parsed.calendar !== undefined, "unrelated settings section dropped");
+        compare(parsed.calendar.weekStart, "mon", "unrelated settings section dropped");
+    }
+}

--- a/tests/qml/tst_WeekView.qml
+++ b/tests/qml/tst_WeekView.qml
@@ -81,4 +81,26 @@ TestCase {
         verify(wv.isWeekendDate(new Date(2026, 0, 4)),  "Sunday is a weekend");
         verify(!wv.isWeekendDate(null), "null is not a weekend");
     }
+
+    // Delegate wiring: under a Sunday-first week the first header column IS
+    // Sunday and must be shaded as weekend. The old positional `index >= 5`
+    // returns false for column 0, so this fails if the delegate binding is
+    // reverted from isWeekendDate(date) back to the index test.
+    function test_weekend_delegate_binding_under_sunday_first() {
+        const savedSettings = AppController.appSettingsJson;
+        const savedDate = AppController.selectedDate;
+
+        AppController.appSettingsJson = JSON.stringify({ calendar: { weekStart: "sun" } });
+        compare(Theme.weekStart, "sun", "precondition: settings must drive weekStart");
+        AppController.selectedDate = new Date(2026, 0, 7);  // week starts Sun Jan 4
+
+        const wv2 = make('import TodoCpp; WeekView { anchors.fill: parent }');
+        const col0 = findChild(wv2, "wvHeadCol");   // first Repeater delegate = index 0
+        verify(col0 !== null, "header column delegate not found");
+        compare(col0.modelData.date.getDay(), 0, "first column must be Sunday under weekStart=sun");
+        verify(col0.isWeekend, "the Sunday column must be shaded as weekend (not index >= 5)");
+
+        AppController.appSettingsJson = savedSettings;
+        AppController.selectedDate = savedDate;
+    }
 }

--- a/tests/qml/tst_WeekView.qml
+++ b/tests/qml/tst_WeekView.qml
@@ -1,0 +1,72 @@
+// WeekView: regression for the priority-sort falsy-zero bug. Within a day's
+// task chips P0 (top tier) must sort before P1; `priRank[p] || 9` demoted P0's
+// rank 0 to the unknown-priority fallback, sorting the most critical task last
+// (and, on days with >4 tasks, out of the visible slice(0,4) entirely).
+import QtQuick
+import QtQuick.Controls
+import QtTest
+import TodoCpp
+
+TestCase {
+    id: tc
+    name: "WeekView"
+    when: windowShown
+    visible: true
+    width: 700
+    height: 500
+
+    Item { id: host; anchors.fill: parent }
+
+    function make(qml) {
+        const o = createTemporaryQmlObject(qml, host);
+        verify(o !== null);
+        return o;
+    }
+
+    function test_smoke_load() {
+        const wv = make('import TodoCpp; WeekView { anchors.fill: parent }');
+        verify(wv !== null);
+    }
+
+    // Two tasks share one deadline day; the P0 must precede the P1 in that day's
+    // sorted task list. Robust to leftover tasks (persistent qttest profile):
+    // compares the two seeded ids by position, not absolute index.
+    function test_p0_task_sorts_before_p1_in_day() {
+        const prev = AppController.selectedDate;
+        const day = new Date();
+        day.setDate(day.getDate() + 592);
+        day.setHours(0, 0, 0, 0);
+
+        const p1 = AppController.newTaskDraft("todo");
+        p1.title = "wv p1 probe"; p1.priority = "P1";
+        p1.dueAt = day; p1.scheduledAt = day; p1.hasTime = false;
+        AppController.saveTask(p1);
+
+        const p0 = AppController.newTaskDraft("todo");
+        p0.title = "wv p0 probe"; p0.priority = "P0";
+        p0.dueAt = day; p0.scheduledAt = day; p0.hasTime = false;
+        AppController.saveTask(p0);
+
+        AppController.selectedDate = day;
+        const wv = make('import TodoCpp; WeekView { anchors.fill: parent }');
+
+        // Pure builder called directly — no binding-timing dependency.
+        const days = wv.buildDays();
+        let dayTasks = null;
+        for (let k = 0; k < days.length; k++)
+            if (wv.isSameDay(days[k].date, day)) { dayTasks = days[k].tasks; break; }
+        verify(dayTasks !== null, "the visible week must contain the deadline day");
+
+        let iP0 = -1, iP1 = -1;
+        for (let i = 0; i < dayTasks.length; i++) {
+            if (dayTasks[i].id === p0.id) iP0 = i;
+            if (dayTasks[i].id === p1.id) iP1 = i;
+        }
+        verify(iP0 >= 0 && iP1 >= 0, "both seeded tasks must land in the day");
+        verify(iP0 < iP1, "P0 must sort before P1 (highest priority first)");
+
+        AppController.deleteTask(p0.id);
+        AppController.deleteTask(p1.id);
+        AppController.selectedDate = prev;
+    }
+}

--- a/tests/qml/tst_WeekView.qml
+++ b/tests/qml/tst_WeekView.qml
@@ -69,4 +69,16 @@ TestCase {
         AppController.deleteTask(p1.id);
         AppController.selectedDate = prev;
     }
+
+    // Weekend shading tracks the real day-of-week, not the column position. The
+    // old `index >= 5` tinted Friday and missed Sunday under weekStart="sun";
+    // isWeekendDate keys off the date. Jan 2026: 1st=Thu, so 2nd=Fri, 3rd=Sat,
+    // 4th=Sun.
+    function test_weekend_tracks_real_day_not_column() {
+        const wv = make('import TodoCpp; WeekView { anchors.fill: parent }');
+        verify(!wv.isWeekendDate(new Date(2026, 0, 2)), "Friday is not a weekend");
+        verify(wv.isWeekendDate(new Date(2026, 0, 3)),  "Saturday is a weekend");
+        verify(wv.isWeekendDate(new Date(2026, 0, 4)),  "Sunday is a weekend");
+        verify(!wv.isWeekendDate(null), "null is not a weekend");
+    }
 }


### PR DESCRIPTION
## Summary

Adds QuickTest coverage for the 18 previously-untested QML components, then
uses that coverage plus an adversarial bug hunt to fix 10 confirmed source
bugs. Suite is **245 passing / 0 failing** (was 45 at branch start).

### Part 1 — component test suites (18 components)
smoke-load, signal contracts, and public-function/AppController contracts for:
DatePickerPopup, EventEditor, PersonEditor, ProfileEditor, MonthView, MiniWeek,
PillButton, SplashScreen, ThinScrollBar, DocsEditor, MentionAutocomplete,
QuickCaptureNotesPopup, TweaksPanel, HotkeysPanel, HelpContent, Theme, Brand,
BrandLogo. Click-driven level is dropped where a component declares no
`objectName` (tests never edit sources to fake a green).

### Part 2 — bug fixes (10 confirmed, each adversarially verified)
| Fix | Severity |
|---|---|
| P0 tasks sorted **last** — `priRank[p] \|\| 9` (`0 \|\| 9 === 9`) in WeekView / TimelineView / ArchiveView / MonthView; on busy days a P0 fell out of the visible `slice(0,4)` entirely | high |
| Event move-drag carried a constant **+6px** vertical bias (grab captured in MouseArea-local coords vs eventsLayer-absolute) — a plain click rescheduled the event instead of opening it; DayCalendar + WeekView | high |
| TaskEditor Delete keyed off the editable id field, not the stable open-time id → silent no-op if the id was edited; recurrence dropdown lacked `every:sat`/`every:sun` → weekend recurrences dropped on edit | medium |
| Kanban column rename auto-committed a stale Escape-cancelled value on next blur | medium |
| Settings meeting-lead slider collapsed a stored `0` to `5` (`\|\| 5`) | medium |
| Command palette / notes fuzzy search dropped a present late single-char match (negative score) | low |
| Weekend column shading used column index, mis-shading Friday under `weekStart="sun"` | low |

Testable fixes ship with red→green regression tests via each view's public
builder (`buildDays`/`buildGroups`/`buildItems`/`buildCells`) or pure functions;
coordinate/focus-driven fixes are covered by reasoning against the correct
sibling code (resize handles use absolute coords).

### Known, not fixed (needs a schema change)
TaskEditor ORs `hasTime` across the deadline and scheduled fields into the
model's single flag, so a timed scheduled + date-only deadline round-trips the
deadline back as `…00:00`. A proper fix splits `hasTime` per-datetime and
touches both serializers + the state-schema field-count guard — out of scope
for this pass.

QML-only change; no C/C++ touched.
